### PR TITLE
Fix scroll

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tritonparse-website",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tritonparse-website",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
         "@types/react-syntax-highlighter": "^15.5.7",


### PR DESCRIPTION
Update version in package-lock.json and refactor CodeComparisonView and CodeViewer components

Summary:
- Bumped version from 0.0.3 to 0.0.4 in package-lock.json.
- Refactored CodeComparisonView to improve line highlighting logic and ensure clarity in setting highlighted lines.
- Introduced a custom hook for scroll management in CodeViewer to enhance user experience with scroll position persistence and highlight handling.

previously, when you click one line in left panel, the other two panels will highlight corresponding lines but it won't auto scroll  to the corresponding area. So, users need to manually scroll them to check code. now this PR fix it by adding a scroll management while all panels will scroll to the first highlight line. 