### PR TITLE
Add custom Vite plugin to strip 'module' attribute from script tags

### DIFF
--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -9,7 +9,17 @@ const packageJson = JSON.parse(
 
 export default defineConfig({
   plugins: [
-    react()
+    react(),
+    {
+      name: 'strip-module-attr',
+      enforce: 'post',
+      transformIndexHtml(html) {
+        return html.replace(
+          /<script\s+type=["']module["']\s+([^>]*?)src=/g,
+          '<script defer $1src='
+        )
+      }
+    }
   ],
 
   base: './',


### PR DESCRIPTION
Summary:
- Introduced a new Vite plugin named 'strip-module-attr' that transforms script tags by replacing the 'type="module"' attribute with 'defer' to fix unidentified module type internally