### PR TITLE
Introduce .bin.ndjson format

### DIFF
--- a/tritonparse/decompress_bin_ndjson.py
+++ b/tritonparse/decompress_bin_ndjson.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+Script to decompress .bin.ndjson files back to regular .ndjson format.
+
+The .bin.ndjson format stores each JSON record as a separate gzip member,
+concatenated in sequence within a single binary file. This script uses
+gzip.open() which automatically handles member concatenation to read
+the compressed file and write out the original NDJSON format.
+"""
+
+import argparse
+import gzip
+import os
+import sys
+from pathlib import Path
+
+
+def decompress_bin_ndjson(input_file: str, output_file: str = None) -> None:
+    """
+    Decompress a .bin.ndjson file to regular .ndjson format.
+    
+    Args:
+        input_file: Path to the .bin.ndjson file
+        output_file: Path for the output .ndjson file (optional)
+    """
+    input_path = Path(input_file)
+    
+    # Validate input file
+    if not input_path.exists():
+        print(f"Error: Input file '{input_file}' does not exist", file=sys.stderr)
+        return
+    
+    if not input_path.suffix.endswith('.bin.ndjson'):
+        print(f"Warning: Input file '{input_file}' doesn't have .bin.ndjson extension")
+    
+    # Determine output file path
+    if output_file is None:
+        if input_path.name.endswith('.bin.ndjson'):
+            # Replace .bin.ndjson with .ndjson
+            output_file = str(input_path.with_suffix('').with_suffix('.ndjson'))
+        else:
+            # Add .decompressed.ndjson suffix
+            output_file = str(input_path.with_suffix('.decompressed.ndjson'))
+    
+    output_path = Path(output_file)
+    
+    try:
+        line_count = 0
+        with gzip.open(input_path, 'rt', encoding='utf-8') as compressed_file:
+            with open(output_path, 'w', encoding='utf-8') as output:
+                for line in compressed_file:
+                    # gzip.open automatically handles member concatenation
+                    # Each line is already a complete JSON record with newline
+                    output.write(line)
+                    line_count += 1
+        
+        # Get file sizes for comparison
+        input_size = input_path.stat().st_size
+        output_size = output_path.stat().st_size
+        compression_ratio = (1 - input_size / output_size) * 100 if output_size > 0 else 0
+        
+        print(f"Successfully decompressed '{input_file}' to '{output_file}'")
+        print(f"  Input size:  {input_size:,} bytes")
+        print(f"  Output size: {output_size:,} bytes")
+        print(f"  Compression ratio: {compression_ratio:.1f}%")
+        print(f"  Records processed: {line_count:,}")
+        
+    except gzip.BadGzipFile as e:
+        print(f"Error: Invalid gzip format in '{input_file}': {e}", file=sys.stderr)
+    except UnicodeDecodeError as e:
+        print(f"Error: Unicode decode error in '{input_file}': {e}", file=sys.stderr)
+    except Exception as e:
+        print(f"Error: Failed to decompress '{input_file}': {e}", file=sys.stderr)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Decompress .bin.ndjson files to regular .ndjson format",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s trace.bin.ndjson
+  %(prog)s trace.bin.ndjson -o output.ndjson
+  %(prog)s /logs/dedicated_log_triton_trace_user_.bin.ndjson
+        """
+    )
+    
+    parser.add_argument(
+        'input_file',
+        help='Input .bin.ndjson file to decompress'
+    )
+    
+    parser.add_argument(
+        '-o', '--output',
+        help='Output .ndjson file path (default: replace .bin.ndjson with .ndjson)'
+    )
+    
+    parser.add_argument(
+        '-v', '--verbose',
+        action='store_true',
+        help='Enable verbose output'
+    )
+    
+    args = parser.parse_args()
+    
+    if args.verbose:
+        print(f"Decompressing: {args.input_file}")
+        if args.output:
+            print(f"Output file: {args.output}")
+    
+    decompress_bin_ndjson(args.input_file, args.output)
+
+
+if __name__ == "__main__":
+    main() 

--- a/tritonparse/extract_source_mappings.py
+++ b/tritonparse/extract_source_mappings.py
@@ -14,6 +14,7 @@ and extracts bidirectional mappings between:
 """
 
 import argparse
+import gzip
 import json
 import logging
 import os
@@ -555,15 +556,33 @@ def parse_single_file(
     # Set default output directory if not provided
     output_dir = output_dir or os.path.dirname(file_path)
 
-    with open(file_path, "r") as f:
+    # Check if input file is compressed based on file extension
+    is_compressed_input = file_path.endswith('.bin.ndjson')
+    
+    # Open file in appropriate mode - use gzip.open for compressed files
+    if is_compressed_input:
+        # Use gzip.open which automatically handles member concatenation
+        file_handle = gzip.open(file_path, 'rt', encoding='utf-8')
+    else:
+        file_handle = open(file_path, "r")
+    
+    with file_handle as f:
         file_name = os.path.basename(file_path)
-        file_name_without_extension = os.path.splitext(file_name)[0]
+        # Handle .bin.ndjson extension properly
+        if is_compressed_input:
+            file_name_without_extension = file_name[:-11]  # Remove .bin.ndjson
+        else:
+            file_name_without_extension = os.path.splitext(file_name)[0]
+            
+        # Process lines uniformly for both compressed and uncompressed files
         for i, line in enumerate(f):
             logger.debug(f"Processing line {i + 1} in {file_path}")
-            # Skip empty lines
-            if not line.strip():
+            
+            json_str = line.strip()
+            if not json_str:
                 continue
-            parsed_line = parse_single_trace_content(line)
+
+            parsed_line = parse_single_trace_content(json_str)
             if not parsed_line:
                 logger.warning(f"Failed to parse line {i + 1} in {file_path}")
                 continue


### PR DESCRIPTION
Summary:
- Added a new format: **.bin.ndjson**
- Added support for reading compressed input files in extract_source_mappings.py using gzip.
- Updated file handling logic to differentiate between compressed (**.bin.ndjson**) and uncompressed files.
- Enhanced structured_logging.py to enable gzip compression for trace logs, allowing for efficient storage and retrieval.
- Modified TritonTraceHandler to handle gzip compression for individual log records, ensuring compatibility with standard gzip readers.

New **.bin.ndjson** format summary:
- Writing: Each JSON record is individually gzip-compressed into a separate gzip member, then sequentially appended to the same binary file, leveraging the gzip specification's support for member concatenation.
- Reading: Standard gzip.open() automatically handles member concatenation, allowing line-by-line reading just like a regular text file, without requiring special parsing logic.

For compression, gzip is fast, reasonably effective, and natively supported in Python. For example, a 950MB raw log file can be compressed to 117MB with gzip and 110MB with lzma. However, gzip is more than 10 times faster than lzma.
Test Plan:

```bash
TRITON_TRACE_GZIP=1 python test_add.py
```
By default, a new trace file generated `./logs/dedicated_log_triton_trace_yhao24_.bin.ndjson`. The trace file size is reduced from 24K to 5.3K. In another larger scale experiment, the trace file is reduced from 950M to 117MB.
```bash
% ll
total 32K
-rw-r--r--. 1 5.3K Jun 23 20:01 dedicated_log_triton_trace_yhao24_.bin.ndjson
-rw-r--r--. 1 24K Jun 23 20:01 dedicated_log_triton_trace_yhao24_.ndjson
```