### PR TITLE
Add TRITONPARSE_KERNEL_ALLOWLIST

### DIFF
--- a/tritonparse/structured_logging.py
+++ b/tritonparse/structured_logging.py
@@ -176,14 +176,28 @@ def maybe_enable_debug_logging():
     """
     This logging is for logging module itself, not for logging the triton compilation.
     """
-    if TRITONPARSE_DEBUG and not log.hasHandlers():
-        log_handler = logging.StreamHandler()
-        log_handler.setLevel(logging.DEBUG)
-        log_handler.setFormatter(
-            logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-        )
+    if TRITONPARSE_DEBUG:
+        # Always set debug level if TRITONPARSE_DEBUG is set
         log.setLevel(logging.DEBUG)
-        log.addHandler(log_handler)
+        
+        # Prevent propagation to root logger to avoid duplicate messages
+        log.propagate = False
+        
+        # Check if we already have a debug handler
+        has_debug_handler = any(
+            isinstance(handler, logging.StreamHandler) 
+            and handler.level <= logging.DEBUG
+            for handler in log.handlers
+        )
+        
+        if not has_debug_handler:
+            log_handler = logging.StreamHandler()
+            log_handler.setLevel(logging.DEBUG)
+            formatter = logging.Formatter("%(asctime)s[%(levelname)s] %(message)s")
+            formatter.default_time_format = '%Y%m%d %H:%M:%S'
+            formatter.default_msec_format = None
+            log_handler.setFormatter(formatter)
+            log.addHandler(log_handler)
 
 
 def get_stack_trace(skip=1):


### PR DESCRIPTION
Summary:
- Introduced a kernel allowlist feature `TRITONPARSE_KERNEL_ALLOWLIST` to filter which kernels should be traced based on patterns defined in an environment variable.
- Added functions to parse the allowlist, extract kernel names, and determine if a kernel should be traced.
- Updated the initialization process to configure the kernel allowlist and log its status.

This enhancement improves the control over tracing, allowing users to focus on specific kernels of interest.

Test Plan:
```bash
% TORCHINDUCTOR_FX_GRAPH_CACHE=0 TRITONPARSE_DEBUG=1 TRITONPARSE_KERNEL_ALLOWLIST="add_kernel,*fused*" python tests/test_add.py
20250624 12:44:54[DEBUG] Kernel allowlist patterns: ['add_kernel', '*fused*']
20250624 12:44:54[INFO] Kernel allowlist enabled with patterns: ['add_kernel', '*fused*']
20250624 12:44:56[DEBUG] Kernel 'add_kernel' matches pattern 'add_kernel', will trace
20250624 12:44:56[DEBUG] Tracing kernel add_kernel
20250624 12:44:56[DEBUG] TritonTraceHandler: logging to /scratch/yhao/pta/tritonparse/logs/dedicated_log_triton_trace_yhao24_.ndjson
Triton kernel executed successfully
20250624 12:44:58[DEBUG] Kernel 'triton_poi_fused_add_0' matches pattern '*fused*', will trace
20250624 12:44:58[DEBUG] Tracing kernel triton_poi_fused_add_0
Torch compiled function executed successfully
tritonparse log file list: /tmp/tmp78fhgxd2/log_file_list.json
```
