### PR TITLE
[BE]Remove APT package caching from GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,17 +68,6 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-pip-3.11-
 
-            - name: Cache APT packages
-              uses: actions/cache@v3
-              with:
-                  path: |
-                      /var/cache/apt/archives
-                      /var/lib/apt/lists
-                  key: ${{ runner.os }}-apt-${{ hashFiles('.ci/setup.sh') }}-${{ steps.weekly-cache.outputs.week }}
-                  restore-keys: |
-                      ${{ runner.os }}-apt-${{ hashFiles('.ci/setup.sh') }}-
-                      ${{ runner.os }}-apt-
-
             - name: Get Triton latest commit
               id: triton-commit
               run: |


### PR DESCRIPTION
Summary:
Eliminated the caching step for APT packages in the CI workflow to streamline the process. This change simplifies the workflow by focusing on essential steps, improving maintainability and reducing potential cache-related issues.

No other modifications were made to the workflow.