### PR TITLE
[BE] Add Complex Kernel Test

### DIFF
--- a/tests/test_complex_kernels.py
+++ b/tests/test_complex_kernels.py
@@ -1,0 +1,256 @@
+"""
+A more complex test case involving two distinct Triton kernels, one of which uses autotuning.
+This test is designed to validate the launch_diff functionality with multiple, varied launches.
+
+Test Plan:
+```
+TORCHINDUCTOR_FX_GRAPH_CACHE=0 TRITONPARSE_DEBUG=1 python tests/test_complex_kernels.py
+```
+"""
+
+import os
+
+import torch
+import triton
+import triton.language as tl
+
+import tritonparse.structured_logging
+import tritonparse.utils
+
+# Initialize logging
+log_path = "./logs_complex"
+tritonparse.structured_logging.init(log_path, enable_trace_launch=True)
+
+os.environ["TORCHINDUCTOR_FX_GRAPH_CACHE"] = "0"
+
+
+# Kernel 1: Autotuned Matmul (simplified configs for small scale)
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 16,
+                "BLOCK_SIZE_N": 16,
+                "BLOCK_SIZE_K": 16,
+                "GROUP_SIZE_M": 1,
+            },
+            num_stages=1,
+            num_warps=1,
+        ),
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 32,
+                "BLOCK_SIZE_N": 16,
+                "BLOCK_SIZE_K": 16,
+                "GROUP_SIZE_M": 1,
+            },
+            num_stages=1,
+            num_warps=1,
+        ),
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 16,
+                "BLOCK_SIZE_N": 32,
+                "BLOCK_SIZE_K": 16,
+                "GROUP_SIZE_M": 1,
+            },
+            num_stages=1,
+            num_warps=1,
+        ),
+    ],
+    key=["M", "N", "K"],
+)
+@triton.jit
+def matmul_kernel(
+    a,
+    b,
+    c,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    ACTIVATION: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + (pid % group_size)
+    pid_n = (pid % num_pid_in_group) // group_size
+
+    offs_am = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = a + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
+    b_ptrs = b + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a_block = tl.load(
+            a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0
+        )
+        b_block = tl.load(
+            b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0
+        )
+        accumulator += tl.dot(a_block, b_block)
+        a_ptrs += BLOCK_SIZE_K * stride_ak
+        b_ptrs += BLOCK_SIZE_K * stride_bk
+    c_block = accumulator.to(tl.float16)
+
+    offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = c + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+    tl.store(c_ptrs, c_block, mask=c_mask)
+
+
+def matmul(a, b):
+    assert a.shape[1] == b.shape[0], "Incompatible dimensions"
+    M, K = a.shape
+    K, N = b.shape
+    c = torch.empty((M, N), device=a.device, dtype=a.dtype)
+
+    def grid(META):
+        return (
+            triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
+        )
+
+    matmul_kernel[grid](
+        a,
+        b,
+        c,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        c.stride(0),
+        c.stride(1),
+        ACTIVATION=None,
+    )
+    return c
+
+
+# Kernel 2: Fused element-wise operation
+@triton.jit
+def fused_op_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    output_ptr,
+    n_elements,
+    scale_factor: float,
+    ACTIVATION: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    a = tl.load(a_ptr + offsets, mask=mask)
+    b = tl.load(b_ptr + offsets, mask=mask)
+    c = tl.load(c_ptr + offsets, mask=mask)
+
+    result = a * b * scale_factor + c
+    if ACTIVATION == "relu":
+        result = tl.where(result > 0, result, 0.0)
+
+    tl.store(output_ptr + offsets, result, mask=mask)
+
+
+def fused_op(a, b, c, scale_factor: float, activation: str):
+    n_elements = a.numel()
+    output = torch.empty_like(a)
+    BLOCK_SIZE = 8  # Reduced from 1024 for small scale testing
+    grid = (triton.cdiv(n_elements, BLOCK_SIZE),)
+    fused_op_kernel[grid](
+        a,
+        b,
+        c,
+        output,
+        n_elements,
+        scale_factor,
+        ACTIVATION=activation,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+    return output
+
+
+def test_complex_kernels():
+    """Main test function to run both kernels with varied parameters."""
+    torch.manual_seed(0)
+
+    # --- Matmul Launches (3 times with different configs) ---
+    print("--- Testing Matmul Kernel (3 launches) ---")
+    # Launch 1
+    a1 = torch.randn((16, 16), device="cuda", dtype=torch.float16)
+    b1 = torch.randn((16, 16), device="cuda", dtype=torch.float16)
+    c1 = matmul(a1, b1)
+    c1.sum()  # Synchronize
+    print("Matmul Launch 1 (16x16 @ 16x16) done.")
+
+    # Launch 2
+    a2 = torch.randn((32, 16), device="cuda", dtype=torch.float16)
+    b2 = torch.randn((16, 32), device="cuda", dtype=torch.float16)
+    c2 = matmul(a2, b2)
+    c2.sum()  # Synchronize
+    print("Matmul Launch 2 (32x16 @ 16x32) done.")
+
+    # Launch 3
+    a3 = torch.randn((16, 32), device="cuda", dtype=torch.float16)
+    b3 = torch.randn((32, 16), device="cuda", dtype=torch.float16)
+    c3 = matmul(a3, b3)
+    c3.sum()  # Synchronize
+    print("Matmul Launch 3 (16x32 @ 32x16) done.")
+
+    # --- Fused Op Launches (4 times with different parameters) ---
+    print("\n--- Testing Fused Op Kernel (4 launches) ---")
+    x = torch.randn((8,), device="cuda", dtype=torch.float32)
+    y = torch.randn((8,), device="cuda", dtype=torch.float32)
+    z = torch.randn((8,), device="cuda", dtype=torch.float32)
+
+    # Launch 1
+    print("Fused Op Launch 1: scale=1.0, activation=None")
+    out1 = fused_op(x, y, z, scale_factor=1.0, activation="none")
+    out1.sum()  # Synchronize
+
+    # Launch 2
+    print("Fused Op Launch 2: scale=2.5, activation=None")
+    out2 = fused_op(x, y, z, scale_factor=2.5, activation="none")
+    out2.sum()  # Synchronize
+
+    # Launch 3
+    print("Fused Op Launch 3: scale=1.0, activation='relu'")
+    out3 = fused_op(x, y, z, scale_factor=1.0, activation="relu")
+    out3.sum()  # Synchronize
+
+    # Launch 4 (different size)
+    print("Fused Op Launch 4: scale=1.0, activation='relu', different size")
+    x_large = torch.randn((6,), device="cuda", dtype=torch.float32)
+    y_large = torch.randn((6,), device="cuda", dtype=torch.float32)
+    z_large = torch.randn((6,), device="cuda", dtype=torch.float32)
+    out4 = fused_op(x_large, y_large, z_large, scale_factor=1.0, activation="relu")
+    out4.sum()  # Synchronize
+    print("All kernels executed.")
+
+
+if __name__ == "__main__":
+    test_complex_kernels()
+    # Use unified_parse to process the generated logs
+    tritonparse.utils.unified_parse(
+        source=log_path, out="./parsed_output_complex", overwrite=True
+    )

--- a/tritonparse/structured_logging.py
+++ b/tritonparse/structured_logging.py
@@ -156,6 +156,9 @@ def convert(obj):
 
     # 2. simple containers ----------------------------------------------------
     if isinstance(obj, (list, tuple)):
+        # Handle namedtuple specially to preserve field names
+        if hasattr(obj, "_asdict"):
+            return convert(obj._asdict())
         return [convert(x) for x in obj]
 
     if isinstance(obj, (set, frozenset)):
@@ -810,7 +813,7 @@ def extract_arg_info(arg_dict):
 def add_launch_metadata(grid, metadata, arg_dict):
     # Extract detailed argument information
     extracted_args = extract_arg_info(arg_dict)
-    return {"launch_metadata_tritonparse": (grid, metadata, extracted_args)}
+    return {"launch_metadata_tritonparse": (grid, metadata._asdict(), extracted_args)}
 
 
 class JITHookImpl(JITHook):
@@ -928,7 +931,7 @@ class LaunchHookImpl(LaunchHook):
         )
         if launch_metadata_tritonparse is not None:
             trace_data["grid"] = launch_metadata_tritonparse[0]
-            trace_data["metadata"] = launch_metadata_tritonparse[1]
+            trace_data["compilation_metadata"] = launch_metadata_tritonparse[1]
             trace_data["extracted_args"] = launch_metadata_tritonparse[
                 2
             ]  # Now contains detailed arg info

--- a/website/src/components/ArgumentViewer.tsx
+++ b/website/src/components/ArgumentViewer.tsx
@@ -48,6 +48,7 @@ const ArgumentRow: React.FC<{
                     <div className="w-48 flex-shrink-0 font-semibold text-gray-800 break-all">{argName}</div>
                     <div className="flex-1 text-gray-500 italic text-sm flex items-center">
                         Complex argument with internal differences
+                        {/* Dropdown arrow icon */}
                         <svg className={`w-4 h-4 ml-2 transform transition-transform ${isCollapsed ? '' : 'rotate-90'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7"></path></svg>
                     </div>
                 </div>

--- a/website/src/components/ArgumentViewer.tsx
+++ b/website/src/components/ArgumentViewer.tsx
@@ -1,0 +1,133 @@
+import React, { useState } from 'react';
+
+// Renders the value distribution (e.g., "16 (2 times, in launches: 1-2)")
+const DistributionCell: React.FC<{ data: any }> = ({ data }) => {
+    if (!data) return null;
+    if (data.diff_type === 'summary') {
+        return <span className="text-gray-500 italic">{data.summary_text}</span>;
+    }
+    if (data.diff_type === 'distribution' && data.values) {
+        return (
+            <ul className="list-none m-0 p-0 space-y-1">
+                {data.values.map((item: any, index: number) => {
+                    const launchRanges = item.launches
+                        .map((r: any) => (r.start === r.end ? `${r.start + 1}` : `${r.start + 1}-${r.end + 1}`))
+                        .join(', ');
+                    return (
+                        <li key={index}>
+                            <span className="font-mono bg-gray-100 px-1 rounded">{JSON.stringify(item.value)}</span>
+                            <span className="text-gray-500 text-xs ml-2">({item.count} times, in launches: {launchRanges})</span>
+                        </li>
+                    );
+                })}
+            </ul>
+        );
+    }
+    return <span className="font-mono">{JSON.stringify(data)}</span>;
+};
+
+// Renders a single row in the ArgumentViewer table
+const ArgumentRow: React.FC<{
+  argName: string;
+  argData: any;
+  isDiffViewer?: boolean;
+}> = ({ argName, argData, isDiffViewer = false }) => {
+  // Case 1: This is a complex argument with internal differences
+  if (isDiffViewer && argData.diff_type === "argument_diff") {
+    const [isCollapsed, setIsCollapsed] = useState(false);
+    const { sames, diffs } = argData;
+    const hasSames = Object.keys(sames).length > 0;
+    const hasDiffs = Object.keys(diffs).length > 0;
+
+        return (
+            <div className="bg-gray-50 border-b border-gray-200 last:border-b-0">
+                <div 
+                    className="flex items-center space-x-4 p-2 cursor-pointer" 
+                    onClick={() => setIsCollapsed(!isCollapsed)}
+                >
+                    <div className="w-48 flex-shrink-0 font-semibold text-gray-800 break-all">{argName}</div>
+                    <div className="flex-1 text-gray-500 italic text-sm flex items-center">
+                        Complex argument with internal differences
+                        <svg className={`w-4 h-4 ml-2 transform transition-transform ${isCollapsed ? '' : 'rotate-90'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7"></path></svg>
+                    </div>
+                </div>
+                {!isCollapsed && (
+                    <div className="pb-2 px-4 space-y-3">
+                        {hasSames && (
+                            <div>
+                                <h6 className="text-sm font-semibold text-gray-600 mb-1">Unchanged Properties</h6>
+                                <div className="space-y-1 pl-4">
+                                    {Object.entries(sames).map(([key, value]) => (
+                                        <div key={key} className="flex items-start text-sm">
+                                            <span className="w-28 font-mono text-gray-500 flex-shrink-0">{key}:</span>
+                                            <span className="font-mono">{JSON.stringify(value)}</span>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
+                        {hasDiffs && (
+                            <div>
+                                <h6 className="text-sm font-semibold text-gray-600 mb-1">Differing Properties</h6>
+                                <div className="space-y-2 pl-4">
+                                    {Object.entries(diffs).map(([key, value]) => (
+                                        <div key={key} className="flex items-start text-sm">
+                                            <span className="w-28 font-mono text-gray-500 flex-shrink-0">{key}:</span>
+                                            <div className="flex-1"><DistributionCell data={value} /></div>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
+                    </div>
+                )}
+            </div>
+        );
+    }
+
+    // Case 2: This is a simple argument (in the "Sames" table)
+    return (
+        <div className="flex items-start space-x-4 p-2 border-b border-gray-200 last:border-b-0">
+            <div className="w-48 flex-shrink-0 font-semibold text-gray-800 break-all">{argName}</div>
+            <div className="w-48 flex-shrink-0 text-gray-600">{argData.type}</div>
+            <div className="flex-1 font-mono text-sm">
+                {typeof argData.value !== 'object' || argData.value === null ? 
+                    <span>{String(argData.value)}</span> : 
+                    <pre className="text-xs whitespace-pre-wrap break-all">{JSON.stringify(argData, null, 2)}</pre>
+                }
+            </div>
+        </div>
+    );
+};
+
+// Main container component
+const ArgumentViewer: React.FC<{ args: Record<string, any>; isDiffViewer?: boolean; }> = ({ args, isDiffViewer = false }) => {
+    if (!args || Object.keys(args).length === 0) {
+        return <div className="text-sm text-gray-500 p-2">No arguments to display.</div>;
+    }
+
+    // A "complex view" is needed if we are showing diffs and at least one of them is a complex argument_diff
+    const isComplexView = isDiffViewer && Object.values(args).some(arg => arg.diff_type === 'argument_diff');
+
+    return (
+        <div className="border border-gray-200 rounded-md bg-white">
+            {/* Render header only for the simple, non-complex table view */}
+            {!isComplexView && (
+                <div className="flex items-center space-x-4 p-2 bg-gray-100 font-bold text-gray-800 border-b border-gray-200">
+                    <div className="w-48 flex-shrink-0">Argument Name</div>
+                    <div className="w-48 flex-shrink-0">Type</div>
+                    <div className="flex-1">Value</div>
+                </div>
+            )}
+            
+            {/* Rows */}
+            <div>
+                {Object.entries(args).map(([argName, argData]) => (
+                    <ArgumentRow key={argName} argName={argName} argData={argData} isDiffViewer={isDiffViewer} />
+                ))}
+            </div>
+        </div>
+    );
+};
+
+export default ArgumentViewer;

--- a/website/src/components/DiffViewer.tsx
+++ b/website/src/components/DiffViewer.tsx
@@ -22,7 +22,7 @@ const DiffViewer: React.FC<DiffViewerProps> = ({ diffs }) => {
     )
   );
 
-  const renderSimpleDiff = (key: string, data: any) => {
+  const renderSimpleDiff = (_key: string, data: any) => {
     if (data.diff_type === "summary") {
       return <p className="font-mono text-sm text-gray-800">{data.summary_text}</p>;
     }

--- a/website/src/components/DiffViewer.tsx
+++ b/website/src/components/DiffViewer.tsx
@@ -1,0 +1,96 @@
+import ArgumentViewer from "./ArgumentViewer";
+import React from "react";
+import StackDiffViewer from "./StackDiffViewer";
+
+interface DiffViewerProps {
+  diffs: any;
+}
+
+const DiffViewer: React.FC<DiffViewerProps> = ({ diffs }) => {
+  if (!diffs || Object.keys(diffs).length === 0) {
+    return (
+      <p className="text-sm text-gray-500">No differing fields detected.</p>
+    );
+  }
+
+  // Separate different kinds of diffs
+  const extractedArgs = diffs.extracted_args;
+  const stackDiff = diffs.stack;
+  const otherDiffs = Object.fromEntries(
+    Object.entries(diffs).filter(
+      ([key]) => key !== "extracted_args" && key !== "stack"
+    )
+  );
+
+  const renderSimpleDiff = (key: string, data: any) => {
+    if (data.diff_type === "summary") {
+      return <p className="font-mono text-sm text-gray-800">{data.summary_text}</p>;
+    }
+    if (data.diff_type === "distribution") {
+      return (
+        <ul className="list-disc list-inside pl-2 text-sm">
+          {data.values.map((item: any, index: number) => {
+            const launchRanges = item.launches
+              .map((r: any) =>
+                r.start === r.end
+                  ? `${r.start + 1}`
+                  : `${r.start + 1}-${r.end + 1}`
+              )
+              .join(", ");
+            return (
+              <li key={index} className="font-mono text-gray-800 break-all">
+                <span className="font-mono bg-gray-100 px-1 rounded">
+                  {JSON.stringify(item.value)}
+                </span>
+                <span className="text-gray-500 text-xs ml-2">
+                  ({item.count} times, in launches: {launchRanges})
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      );
+    }
+    // Fallback for unexpected structures
+    return <pre>{JSON.stringify(data, null, 2)}</pre>;
+  };
+
+  return (
+    <div className="space-y-4">
+      {extractedArgs && Object.keys(extractedArgs).length > 0 && (
+        <div>
+          <h5 className="text-md font-semibold mb-2 text-gray-700">
+            Extracted Arguments
+          </h5>
+          <ArgumentViewer args={extractedArgs} isDiffViewer={true} />
+        </div>
+      )}
+
+      {Object.keys(otherDiffs).length > 0 && (
+        <div>
+          <h5 className="text-md font-semibold mb-2 text-gray-700">
+            Other Differing Fields
+          </h5>
+          <div className="space-y-3">
+            {Object.entries(otherDiffs).map(([key, value]) => (
+              <div
+                key={key}
+                className="w-full p-2 bg-white rounded border border-gray-200"
+              >
+                <span className="text-sm font-medium text-gray-600 block mb-1 break-all">
+                  {key}
+                </span>
+                <div className="pl-4">{renderSimpleDiff(key, value)}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      
+      {stackDiff && <StackDiffViewer stackDiff={stackDiff} />}
+
+    </div>
+  );
+};
+
+export default DiffViewer; 

--- a/website/src/components/StackDiffViewer.tsx
+++ b/website/src/components/StackDiffViewer.tsx
@@ -42,6 +42,7 @@ const StackDiffViewer: React.FC<{ stackDiff: any }> = ({ stackDiff }) => {
         onClick={() => setIsCollapsed(!isCollapsed)}
       >
         Stack Traces
+        {/* Dropdown arrow icon */}
         <svg
           className={`w-4 h-4 ml-2 transform transition-transform ${isCollapsed ? '' : 'rotate-90'}`}
           fill="none"

--- a/website/src/components/StackDiffViewer.tsx
+++ b/website/src/components/StackDiffViewer.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
+
+// A single frame of a stack trace
+const StackTraceFrame: React.FC<{ frame: any }> = ({ frame }) => (
+  <div className="font-mono text-xs break-all">
+    <span className="text-gray-500">{frame.filename}</span>:
+    <span className="font-semibold text-blue-600">{frame.line}</span> in{" "}
+    <span className="font-semibold text-green-700">{frame.name}</span>
+    {frame.line_code && (
+       <div className="pl-6 mt-1 bg-gray-100 rounded">
+        <SyntaxHighlighter 
+            language="python" 
+            style={oneLight} 
+            customStyle={{ 
+                margin: 0, 
+                padding: '0.25em 0.5em', 
+                fontSize: '0.75rem',
+                background: 'transparent'
+             }}
+        >
+            {frame.line_code}
+        </SyntaxHighlighter>
+    </div>
+    )}
+  </div>
+);
+
+
+const StackDiffViewer: React.FC<{ stackDiff: any }> = ({ stackDiff }) => {
+  const [isCollapsed, setIsCollapsed] = useState(true);
+
+  if (!stackDiff || stackDiff.diff_type !== 'distribution') {
+    return null;
+  }
+
+  return (
+    <div>
+      <h5 
+        className="text-md font-semibold mb-2 text-gray-700 cursor-pointer flex items-center"
+        onClick={() => setIsCollapsed(!isCollapsed)}
+      >
+        Stack Traces
+        <svg
+          className={`w-4 h-4 ml-2 transform transition-transform ${isCollapsed ? '' : 'rotate-90'}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7"></path>
+        </svg>
+      </h5>
+      {!isCollapsed && (
+         <div className="space-y-2">
+          {stackDiff.values.map((item: any, index: number) => {
+            const launchRanges = item.launches
+              .map((r: any) => (r.start === r.end ? `${r.start + 1}` : `${r.start + 1}-${r.end + 1}`))
+              .join(", ");
+            
+            return (
+              <div key={index} className="bg-white p-2 rounded border border-gray-200">
+                <p className="text-xs font-semibold text-gray-600 mb-1">
+                  Variant seen {item.count} times (in launches: {launchRanges})
+                </p>
+                <div className="space-y-1 bg-gray-50 p-1 rounded">
+                   {Array.isArray(item.value) ? item.value.map((frame: any, frameIndex: number) => (
+                    <StackTraceFrame key={frameIndex} frame={frame} />
+                  )) : <p>Invalid stack format</p>}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default StackDiffViewer; 


### PR DESCRIPTION
This pull request introduces a new, comprehensive test case (`tests/test_complex_kernels.py`) to validate the trace parsing logic, especially for the recently added `launch_diff` feature.

### Motivation

The existing tests were insufficient to fully validate the parser's ability to handle more realistic scenarios involving multiple, distinct kernels and varied launch parameters within a single run. This test was created to provide a robust, end-to-end validation for the kernel grouping and launch diffing functionalities.

### What the Test Does

1.  **Defines Two Kernels**:
    *   `matmul_kernel`: An autotuned matrix multiplication kernel designed to test the parser's handling of autotuner-generated configurations.
    *   `fused_op_kernel`: A simpler element-wise kernel used to test basic launch parameter variations.

2.  **Multiple, Varied Launches**:
    *   The `matmul` kernel is launched three times with different input tensor shapes.
    *   The `fused_op` kernel is launched four times with different scalar arguments (`scale_factor`) and compile-time constants (`activation`).

3.  **End-to-End Parsing**:
    *   After executing all kernel launches and generating a trace log, the test script calls `tritonparse.utils.unified_parse`.
    *   This ensures that the entire trace, containing multiple compilations (due to autotuning) and multiple launch events, can be processed successfully into the structured, diff-summarized format.

### How it Improves Testing

*   Provides a realistic test case that mimics a complex model with multiple custom kernels.
*   Specifically validates that launch events are correctly grouped with their corresponding compilation events, even when interleaved.
*   Acts as a strong regression test for the `launch_diff` generation, ensuring that parameter variations are correctly identified and summarized. 