### PR TITLE
Update CHANGELOG and README for version 0.1.1 enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - 2024-07-31
+## [0.1.1] - 2025-07-22
+
+### Added
+
+- **Launch Difference Analysis**: A new `launch_diff` event is automatically generated for each kernel, providing a concise summary of how launch parameters vary across different calls. This helps to quickly identify changes in kernel arguments, grid dimensions, and other metadata.
+- **Kernel-Centric Event Grouping**: The parser now intelligently groups compilation and launch events by kernel, making it easier to analyze the entire lifecycle of a specific kernel.
+- **Launch Event Tracing Control**: Added an `enable_trace_launch` parameter to `tritonparse.structured_logging.init` to give users explicit control over whether to trace kernel launch events.
+- **Enhanced Logging and Testing**: Improved the structured logging initialization and expanded test coverage to verify the correctness of `launch` and `compilation` event counts.
+
+## [0.1.0] - 2025-07-21
 
 This is the initial public release of TritonParse.
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,15 @@
 
 **A comprehensive visualization and analysis tool for Triton IR files** — helping developers analyze, debug, and understand Triton kernel compilation processes.
 
-🌐 **[Try it online →](https://pytorch-labs.github.io/tritonparse/?json_url=https%3A%2F%2Fpytorch-labs.github.io%2Ftritonparse%2Ff0_fc0_a0_cai-.ndjson)**
+🌐 **[Try it online →](https://pytorch-labs.github.io/tritonparse/?json_url=https%3A%2F%2Fpytorch-labs.github.io%2Fdedicated_log_triton_trace_findhao__mapped.ndjson.gz)**
 
 ## ✨ Key Features
 
+- **🚀 Launch Difference Analysis** - Automatically detect and visualize variations in kernel launch parameters, helping you pinpoint performance bottlenecks and debug launch configurations.
 - **🔍 Interactive Visualization** - Explore Triton kernels with detailed metadata and stack traces
 - **📊 Multi-format IR Support** - View TTGIR, TTIR, LLIR, PTX, and AMDGCN in one place
 - **🔄 Side-by-side Comparison** - Compare IR stages with synchronized highlighting
-- **📝 Structured Logging** - Capture detailed compilation events with source mapping
+- **📝 Structured Logging** - Capture detailed compilation and launch events with source mapping
 - **🌐 Ready-to-use Interface** - No installation required, works in your browser
 - **🔒 Privacy-first** - All processing happens locally in your browser, no data uploaded
 
@@ -23,8 +24,8 @@
 ```python
 import tritonparse.structured_logging
 
-# Initialize logging
-tritonparse.structured_logging.init("./logs/")
+# Initialize logging with launch tracing enabled
+tritonparse.structured_logging.init("./logs/", enable_trace_launch=True)
 
 # Your Triton/PyTorch code here
 # ... your kernels ...
@@ -55,7 +56,8 @@ INFO:tritonparse:Copying parsed logs from /tmp/tmp1gan7zky to /scratch/findhao/t
 
 ### 2. Visualize Results
 
-**Visit [https://pytorch-labs.github.io/tritonparse/](https://pytorch-labs.github.io/tritonparse/?json_url=https%3A%2F%2Fpytorch-labs.github.io%2Ftritonparse%2Ff0_fc0_a0_cai-.ndjson)** and open your local trace files (.ndjson.gz format).
+**Visit [https://pytorch-labs.github.io/tritonparse/](https://pytorch-labs.github.io/tritonparse/?json_url=https%3A%2F%2Fpytorch-labs.github.
+io%2Ftritonparse%dedicated_log_triton_trace_findhao__mapped.ndjson.gz)** and open your local trace files (.ndjson.gz format).
 
 > **🔒 Privacy Note**: Your trace files are processed entirely in your browser - nothing is uploaded to any server! 
 

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -154,7 +154,7 @@ function App() {
    * Loads the default data file from public directory
    */
   const loadDefaultData = async () => {
-    const logFile = "./f0_fc0_a0_cai-.ndjson";
+    const logFile = "./dedicated_log_triton_trace_findhao__mapped.ndjson.gz";
     await loadData(logFile);
   };
 


### PR DESCRIPTION
### Changes:
- Updated CHANGELOG.md to reflect the new version 0.1.1, detailing added features such as `launch_diff` event generation, kernel-centric event grouping, and enhanced logging capabilities.
- Revised README.md to include updated links and descriptions for new features, particularly the `launch_diff` analysis and structured logging improvements.
- Adjusted example code in README to demonstrate the new `enable_trace_launch` parameter in the logging initialization.

These updates improve documentation clarity and highlight recent enhancements to the TritonParse tool.