### PR TITLE
Refactor logging configuration and clean up test cases

### DIFF
--- a/tritonparse/structured_logging.py
+++ b/tritonparse/structured_logging.py
@@ -1009,6 +1009,9 @@ def clear_logging_config():
     This function resets the logging handlers, global state variables,
     and Triton knobs to their default states, effectively disabling
     the custom tracing.
+
+    WARNING: This function is not supposed to be called unless you are sure
+    you want to clear the logging config.
     """
     global TRITON_TRACE_HANDLER, triton_trace_folder, _KERNEL_ALLOWLIST_PATTERNS
     global _trace_launch_enabled


### PR DESCRIPTION
Summary:
- Removed unused log parsing functions from `test_tritonparse.py` to streamline the test code.
- Added calls to `triton.knobs.compilation.listener` and `tritonparse.structured_logging.clear_logging_config()` to ensure proper cleanup and reset of logging configurations after tests.
- Improved test reliability by ensuring that logging settings do not persist between test runs.

These changes enhance the maintainability of the test suite and ensure that logging configurations are correctly managed during testing.