### PR TITLE
[QOL] add lower bounds on prerequisites

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,9 @@ build-backend = "setuptools.build_meta"
 name = "tritonparse"
 version = "0.1.1"
 dependencies = [
-    "triton",
+    "triton>3.3.1",
 ]
+python-requires = ">=3.10"
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
This PR makes the prerequisites [here](https://github.com/pytorch-labs/tritonparse#:~:text=Prerequisites%3A%20Python%20%E2%89%A5%203.10%2C%20Triton%20%3E%203.3.1%20(install%20from%20source)%2C%20GPU%20required%20(NVIDIA/AMD)) explicit in the `pyproject.toml`.

The main reason is that TritonParse may fail silently if the wrong version of Triton is used (for instance, due to further installation of other packages); these changes avoid such a situation :+1: 