### PR TITLE
Move `times` to metadata

### DIFF
--- a/tritonparse/structured_logging.py
+++ b/tritonparse/structured_logging.py
@@ -756,7 +756,7 @@ def maybe_trace_triton(
 
     # Add timing information if available
     if times:
-        trace_data["times"] = times
+        trace_data["metadata"]["times"] = times
     # Log the collected information through the tracing system
     trace_structured_triton(
         event_type,


### PR DESCRIPTION
Move the compilation times to metadata to make sure it is correctly read by the website.

Fixes https://github.com/meta-pytorch/tritonparse/issues/65

```json
        "times": {
            "ir_initialization": 2969442,
            "lowering_stages": [
                ["ttir", 6685],
                ["ttgir", 23173],
                ["llir", 497905],
                ["ptx", 154709],
                ["cubin", 41588]
            ],
            "store_results": 471
        }
```
Previously, the above information exists in logs but not show on the website. The TritonParse website can automatically show all information in `metadata`, but no other properties. 

<img width="2200" height="250" alt="image" src="https://github.com/user-attachments/assets/b7d88fb5-2b39-415c-816a-18e88bf5335b" />
