### PR TITLE
Call `jit_post_compile_hook` within Inductor Triton Kernel compile path

### DIFF
--- a/tritonparse/structured_logging.py
+++ b/tritonparse/structured_logging.py
@@ -875,12 +875,14 @@ class JITHookImpl(JITHook):
                 return True
 
         # Get the current launch_metadata function if it exists
-        current_launch_metadata = getattr(fn.jit_function, "launch_metadata", None)
+        function = getattr(fn, "jit_function", fn)
+
+        current_launch_metadata = getattr(function, "launch_metadata", None)
         if current_launch_metadata is not None:
             log.warning(
                 f"fn {fn} launch_metadata is not None: {current_launch_metadata}. It will be overridden by tritonparse."
             )
-        fn.jit_function.launch_metadata = add_launch_metadata
+        function.launch_metadata = add_launch_metadata
         return True
 
 


### PR DESCRIPTION
Summary: Since Inductor skips JIT compilation for Triton kernels, we need to manually invoke `knobs.runtime.jit_post_compile_hook` if one exists. Here, we do this to enable Tritonparse to extract launch metadata from Inductor launched kernels. We can control whether or not Inductor will run the hook with a new `TORCHINDUCTOR_RUN_JIT_POST_COMPILE_HOOK=1 ` config variable.

Reviewed By: davidberard98

Differential Revision: D80624932


