### PR TITLE
Fix File Diff URL Redirect

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tritonparse-website",
-  "version": "0.2.0",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tritonparse-website",
-      "version": "0.2.0",
+      "version": "0.2.3",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
         "@types/react-syntax-highlighter": "^15.5.7",

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tritonparse-website",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -70,6 +70,9 @@ function App() {
       const newUrl = new URL(window.location.href);
       newUrl.searchParams.set("json_url", jsonUrl);
       window.history.replaceState({}, "", newUrl.toString());
+    } else if (view === "file_diff") {
+      // Allow direct navigation to File Diff even without json_url
+      setActiveTab("file_diff");
     }
 
     // Check if fb directory exists and load internal utils if available
@@ -132,6 +135,8 @@ function App() {
         // Then, determine which view to show
         if (view === "ir_code_comparison") {
           setActiveTab("comparison");
+        } else if (view === "file_diff") {
+          setActiveTab("file_diff");
         }
 
         setDataLoaded(true);
@@ -201,6 +206,8 @@ function App() {
         // Then, determine which view to show
         if (initialView === "ir_code_comparison") {
           setActiveTab("comparison");
+        } else if (initialView === "file_diff") {
+          setActiveTab("file_diff");
         }
         setDataLoaded(true);
         setLoadedUrl(url);
@@ -212,6 +219,8 @@ function App() {
         // Add view and kernel_hash parameters if applicable
         if (initialView === "ir_code_comparison") {
           newUrl.searchParams.set("view", "ir_code_comparison");
+        } else if (initialView === "file_diff") {
+          newUrl.searchParams.set("view", "file_diff");
         }
 
         if (kernelHash) {


### PR DESCRIPTION

## What Changed
- Enhanced File Diff navigation to support direct URL access via `view=file_diff` parameter
- Fixed active tab highlighting when navigating directly to File Diff view
- Updated website version from 0.2.0 to 0.2.3

## Files Modified
- `website/src/App.tsx` - Added URL routing logic for File Diff view
- `website/package.json` & `website/package-lock.json` - Version bump

**Impact**: Users can now directly access and bookmark File Diff view URLs with proper tab state.
