### PR TITLE
Improve Stack Display in Launch Analysis

### DIFF
--- a/website/src/pages/KernelOverview.tsx
+++ b/website/src/pages/KernelOverview.tsx
@@ -343,7 +343,8 @@ const KernelOverview: React.FC<KernelOverviewProps> = ({
                     ([key]) =>
                       key !== "compilation_metadata" &&
                       key !== "extracted_args" &&
-                      key !== "event_type"
+                      key !== "event_type" &&
+                      key !== "stack"
                   )
                 );
 
@@ -373,6 +374,35 @@ const KernelOverview: React.FC<KernelOverviewProps> = ({
                 }
                 return null;
               })()}
+
+              {/* Unchanged Stack Trace */}
+              {kernel.launchDiff.sames && kernel.launchDiff.sames.stack && (
+                <div className="mb-4">
+                  <h4 className="text-md font-semibold mb-2 text-gray-800">
+                    Unchanged Stack Trace
+                  </h4>
+                  <div className="bg-white p-3 rounded-md border border-gray-200 overflow-auto resize-y h-80 min-h-24">
+                    {Array.isArray(kernel.launchDiff.sames.stack) ? (
+                      kernel.launchDiff.sames.stack.map((entry: any, index: number) => (
+                        <div key={index} className="mb-1 font-mono text-sm">
+                          <span className="text-blue-600">
+                            {getSourceFilePath(entry)}
+                          </span>
+                          :<span className="text-red-600">{entry.line}</span> -
+                          <span className="text-green-600">{entry.name}</span> -
+                          <span className="text-gray-700">{entry.loc}</span>
+                        </div>
+                      ))
+                    ) : (
+                      <pre className="font-mono text-sm text-gray-700 whitespace-pre-wrap break-all">
+                        {typeof kernel.launchDiff.sames.stack === 'string' 
+                          ? kernel.launchDiff.sames.stack 
+                          : JSON.stringify(kernel.launchDiff.sames.stack, null, 2)}
+                      </pre>
+                    )}
+                  </div>
+                </div>
+              )}
 
               {/* Differing Fields */}
               <div className="mb-4">


### PR DESCRIPTION

## Problem
The `stack` field in the "Other Unchanged Fields" table was causing layout issues - it was too long to display properly in a table cell, making the entire table unreadable and stretched horizontally.

## Solution
Separated the `stack` field from the table and created a dedicated display section for it.

## Changes
- **Filtered out** the `stack` field from "Other Unchanged Fields" table
- **Added** a new "Unchanged Stack Trace" section between "Other Unchanged Fields" and "Differing Fields"
- **Implemented** proper formatting for stack traces:
  - Array format: displays each entry line-by-line with syntax highlighting (file path, line number, function name)
  - String/other formats: displays in a formatted pre block
- **Used** a scrollable container (height: 280px, resizable) to prevent excessive vertical space usage
- **Maintained** consistent styling with the existing "Compilation Stack Trace" section

## Result
Stack information is now displayed in a clean, readable format without breaking the table layout.

<img width="2588" height="1242" alt="image" src="https://github.com/user-attachments/assets/8ce3d979-4910-4151-8d07-d26f3cc27e6c" />
