### PR TITLE
[Feature]Add `--kernel-import override-ttir` Mode to Reproducer

### DIFF
--- a/tritonparse/reproducer/cli.py
+++ b/tritonparse/reproducer/cli.py
@@ -40,6 +40,7 @@ def _add_reproducer_args(parser: argparse.ArgumentParser) -> None:
             "Kernel import strategy:\n"
             "  default: Import kernel from original file (current behavior)\n"
             "  copy: Embed kernel source code directly in reproducer\n"
+            "  override-ttir: Use TTIR from compilation event (bypass Python frontend)\n"
             "Defaults to 'default'."
         ),
     )

--- a/tritonparse/reproducer/orchestrator.py
+++ b/tritonparse/reproducer/orchestrator.py
@@ -46,6 +46,15 @@ def reproduce(
         out_dir, context_bundle.kernel_info.function_name
     )
     save_prettified_json(context_bundle.raw_launch_event, temp_json_path)
+
+    # Save compilation event JSON if using OVERRIDE_TTIR mode
+    comp_json_path = None
+    if kernel_import == KernelImportMode.OVERRIDE_TTIR:
+        comp_json_path = (
+            temp_json_path.parent / f"{temp_json_path.stem}_compilation.json"
+        )
+        save_prettified_json(context_bundle.raw_comp_event, comp_json_path)
+
     logger.debug("Loading reproducer template.")
     template_code = load_template_code(template)
 
@@ -58,6 +67,7 @@ def reproduce(
         context_bundle,
         temp_json_path=temp_json_path,
         kernel_import=kernel_import,
+        comp_json_filename=comp_json_path.name if comp_json_path else None,
     )
 
     out_py_path.write_text(final_code, encoding="utf-8")

--- a/tritonparse/reproducer/templates/example.py
+++ b/tritonparse/reproducer/templates/example.py
@@ -6,6 +6,7 @@ It contains a smallest testing example for a Triton kernel.
 import gzip
 import hashlib
 import importlib
+import importlib.util
 import io
 import json
 import logging
@@ -15,6 +16,8 @@ from pathlib import Path
 from typing import Union
 
 import torch
+
+# {{IR_OVERRIDE_SETUP_PLACEHOLDER}}
 
 # {{KERNEL_SYSPATH_PLACEHOLDER}}
 

--- a/tritonparse/reproducer/types.py
+++ b/tritonparse/reproducer/types.py
@@ -6,10 +6,13 @@ class KernelImportMode(str, Enum):
     Kernel import strategy for reproducer generation.
 
     Inherits from str to allow direct string comparison and use in argparse.
+
+    Attributes:
+        DEFAULT: Import kernel from original file (current behavior).
+        COPY: Embed kernel source code directly in reproducer.
+        OVERRIDE_TTIR: Use TTIR from compilation event with monkeypatch.
     """
 
-    DEFAULT = "default"  # Import kernel from original file (current behavior)
-    COPY = "copy"  # Embed kernel source code directly in reproducer
-
-    # Future modes can be added here:
-    # OVERRIDE_TTIR = "override-ttir"  # Use TTIR from compilation event with monkeypatch
+    DEFAULT = "default"
+    COPY = "copy"
+    OVERRIDE_TTIR = "override-ttir"


### PR DESCRIPTION
## Overview

This PR adds a new `override-ttir` mode to the reproducer's `--kernel-import` parameter, enabling reproducers to use pre-compiled TTIR (Triton Intermediate Representation) from compilation events to bypass the Python frontend entirely. This complements the existing `default` and `copy` modes, providing three distinct strategies for kernel import handling.

## Motivation

When debugging Triton compiler backend issues, it's valuable to reproduce kernel behavior using the exact TTIR that was generated during the original compilation, rather than re-compiling from Python source. This:

1. **Isolates Backend Issues**: Eliminates Python frontend variability when debugging backend/LLVM issues
2. **Ensures Exact Reproduction**: Uses the identical IR that caused the original behavior
3. **Enables IR-Level Debugging**: Allows testing with modified TTIR files for compiler development
4. **Complements Existing Modes**: Provides a third option alongside source-based approaches

## Changes

### 1. Type System (`tritonparse/reproducer/types.py`)

Added `OVERRIDE_TTIR` to the `KernelImportMode` enum:

```python
class KernelImportMode(str, Enum):
    DEFAULT = "default"
    COPY = "copy"
    OVERRIDE_TTIR = "override-ttir"  # New mode
```

### 2. Template Updates (`tritonparse/reproducer/templates/example.py`)

- Added `import tempfile` for creating temporary TTIR files
- Added `# {{IR_OVERRIDE_SETUP_PLACEHOLDER}}` for injecting IR override setup code

### 3. Placeholder Replacer (`tritonparse/reproducer/placeholder_replacer.py`)

Implemented `_replace_ir_override_setup()` handler that generates:

**a) TTIR Extraction Function**
```python
def create_ttir_tempfile():
    """Extract TTIR from compilation event and create temporary file."""
    # Reads compilation JSON
    # Extracts TTIR content from payload.file_content[{kernel_name}.ttir]
    # Creates temporary .ttir file
    # Returns file path
```

**b) Monkeypatch Mechanism**
```python
# Patches triton.autotune to use ir_override
_original_autotune = triton.autotune

def _patched_autotune(configs, key=None, **kwargs):
    new_configs = [triton.Config(kwargs={}, ir_override=_ttir_file)]
    return _original_autotune(new_configs, key=[], **kwargs)

triton.autotune = _patched_autotune
```

Updated existing handlers:
- `_replace_kernel_syspath()`: Skips sys.path setup in override-ttir mode
- `_replace_kernel_import()`: Skips kernel import in override-ttir mode

### 4. Orchestrator (`tritonparse/reproducer/orchestrator.py`)

Added conditional compilation JSON saving:

```python
# Save compilation event JSON if using OVERRIDE_TTIR mode
comp_json_path = None
if kernel_import == KernelImportMode.OVERRIDE_TTIR:
    comp_json_path = temp_json_path.parent / f"{temp_json_path.stem}_compilation.json"
    save_prettified_json(context_bundle.raw_comp_event, comp_json_path)
```

### 5. CLI (`tritonparse/reproducer/cli.py`)

Updated help text to document all three modes:

```python
help=(
    "Kernel import strategy:\n"
    "  default: Import kernel from original file (current behavior)\n"
    "  copy: Embed kernel source code directly in reproducer\n"
    "  override-ttir: Use TTIR from compilation event (bypass Python frontend)\n"
    "Defaults to 'default'."
),
```

## Usage

### Command
```bash
python -m tritonparse reproduce trace.ndjson --kernel-import override-ttir
```

### Generated Files
- `repro_<timestamp>.py` - Main reproducer script with monkeypatched autotune
- `repro_context_<timestamp>.json` - Launch event data
- `repro_context_<timestamp>_compilation.json` - Compilation event data (contains TTIR)

### Generated Code Structure

The reproducer includes:

1. **Imports**: Standard imports plus `tempfile`
2. **IR Override Setup**:
   - `create_ttir_tempfile()`: Extracts TTIR and creates temp file
   - Monkeypatch of `triton.autotune` to use `ir_override`
3. **Skipped Sections**:
   - No sys.path manipulation
   - No kernel import statements
4. **Kernel Invocation**: Uses monkeypatched autotune with TTIR

## Three-Mode Comparison

| Feature | DEFAULT | COPY | OVERRIDE_TTIR |
|---------|---------|------|---------------|
| **CLI** | `--kernel-import default` | `--kernel-import copy` | `--kernel-import override-ttir` |
| **sys.path** | ✅ Modified | ❌ Skipped | ❌ Skipped |
| **Import** | ✅ From file | ❌ Embedded | ❌ Skipped |
| **Compilation** | Python → Triton JIT | Python → Triton JIT | TTIR → Direct |
| **Self-contained** | ❌ Needs original file | ✅ Fully self-contained | ✅ Fully self-contained  |


## Technical Details

### IR Override Mechanism

Triton supports loading pre-compiled IR via `triton.Config(ir_override=<path>)`. This PR:

1. Extracts TTIR from the compilation event's `file_content` field
2. Writes it to a temporary `.ttir` file
3. Patches `triton.autotune` to replace all configs with a single `ir_override` config
4. The patched autotune is invoked when the kernel runs, using the pre-compiled TTIR

### Monkeypatch Timing

Critical: The monkeypatch must execute **before** any kernel imports. This is ensured by:
- Placing `{{IR_OVERRIDE_SETUP_PLACEHOLDER}}` after standard imports but before kernel-related code
- Skipping kernel imports entirely in override-ttir mode

### Error Handling

- Validates that `comp_json_filename` is provided in override-ttir mode
- Runtime errors will occur if TTIR is missing from compilation event
- TTIR format compatibility depends on Triton version matching

## Testing

### Manual Testing
```bash
# Generate trace with TTIR (ensure TRITONPARSE_SAVE_IRS=1)
python your_kernel_script.py

# Generate reproducer with override-ttir mode
python -m tritonparse reproduce trace.ndjson --line 2 --kernel-import override-ttir

# Verify files
ls repro_output/kernel_name/
# Expected: repro_*.py, repro_context_*.json, repro_context_*_compilation.json

# Run reproducer
python repro_output/kernel_name/repro_*.py
```

## Backward Compatibility

✅ **Fully backward compatible**:
- Existing `default` and `copy` modes unchanged
- New placeholder returns empty string in non-override-ttir modes
- No breaking changes to existing API or behavior

## Limitations and Trade-offs

### OVERRIDE_TTIR Mode Limitations

**Bisect Compatibility Issue**: When using override-ttir reproducers for git bisection across Triton commits, the TTIR format may change between commits. This can cause:
- TTIR incompatibility with older/newer Triton versions
- Bisect failures before reaching the actual problematic commit
- False negatives where the reproducer fails due to IR format mismatch, not the actual bug

**Recommendation**: For bisecting Triton commits, prefer `default` or `copy` modes which re-compile from Python source at each commit.

### COPY Mode Limitations

**Nested Kernel Calls**: The current `copy` mode implementation only embeds the source code of the outermost kernel. If the kernel calls other kernels (nested kernel invocations), those inner kernels are **not** copied. This means:
- Inner kernel imports still rely on sys.path and external files
- The reproducer is not fully self-contained for multi-kernel scenarios
- Sharing may fail if recipients don't have access to the inner kernel files

**Recommendation**: For kernels with nested calls, use `default` mode and ensure all kernel files are shared, or manually copy all kernel sources.

### Mode Selection Guide

| Scenario | Recommended Mode | Reason |
|----------|------------------|--------|
| Git bisecting Triton | `default` or `copy` | Avoids TTIR format incompatibility |
| Nested kernel calls | `default` | Only outer kernel is copied in copy mode |
| Backend-only debugging | `override-ttir` | Isolates backend from frontend changes |
| Sharing single-kernel repro | `copy` | Self-contained for simple cases |
| Daily development | `default` | Most flexible and debuggable |

## Benefits

1. **Compiler Development**: Test backend changes with known-good TTIR
2. **Precise Reproduction**: Use exact IR that triggered issues
3. **Debugging Flexibility**: Manually modify TTIR files for testing
4. **Complete Coverage**: Three modes cover all reproducer use cases

## Future Enhancements

Potential follow-ups (out of scope for this PR):
- **Nested Kernel Support in COPY Mode**: Recursively copy all called kernels, not just the outermost one
- **Support for Other IR Formats**: LLVM IR, PTX, or other intermediate representations

cc @manman-ren 
