### PR TITLE
Normalize CUDA Device to cuda:0

### DIFF
--- a/tritonparse/reproducer/templates/example.py
+++ b/tritonparse/reproducer/templates/example.py
@@ -67,6 +67,10 @@ def load_tensor(tensor_file_path: Union[str, Path], device: str = None) -> torch
         RuntimeError: If the tensor cannot be loaded
         ValueError: If the computed hash doesn't match the filename hash
     """
+    # Normalize cuda device to cuda:0
+    if device is not None and isinstance(device, str) and device.startswith("cuda"):
+        device = "cuda:0"
+
     blob_path = Path(tensor_file_path)
 
     if not blob_path.exists():
@@ -210,6 +214,9 @@ def _create_base_tensor(arg_info) -> torch.Tensor:
 
     shape = arg_info.get("shape", [])
     device = arg_info.get("device", "cpu")
+    # Normalize cuda device to cuda:0
+    if isinstance(device, str) and device.startswith("cuda"):
+        device = "cuda:0"
 
     # Extract statistical information if available
     mean = arg_info.get("mean")


### PR DESCRIPTION
fix https://github.com/meta-pytorch/tritonparse/issues/176
## Changes

This PR adds device normalization logic to ensure all tensors are created on `cuda:0`, regardless of the device specified in the JSON configuration.

## Modifications

### 1. `load_tensor()` function
- Added device normalization before loading tensor from file
- Any CUDA device string (e.g., `cuda`, `cuda:1`, `cuda:2`) is now mapped to `cuda:0`

### 2. `_create_base_tensor()` function  
- Added device normalization before creating new tensors
- Applies to all tensor types: floating-point, integer, complex, and unsigned integer

## Impact

- **Prevents multi-GPU issues**: All tensors are now consistently created on the same device
- **Backward compatible**: Non-CUDA devices (e.g., `cpu`) remain unchanged
- **Minimal code change**: Only two strategic locations modified for maximum coverage

## Testing

This change affects the template file used for generating reproducers. All generated test cases will now place tensors on `cuda:0` by default.

