### PR TITLE
[website] Sort Compilation Metadata Attributes Alphabetically

### DIFF
--- a/website/src/pages/KernelOverview.tsx
+++ b/website/src/pages/KernelOverview.tsx
@@ -246,6 +246,7 @@ const KernelOverview: React.FC<KernelOverviewProps> = ({
                 {/* All short metadata fields */}
                 {Object.entries(kernel.metadata)
                   .filter(([_key, value]) => !isLongValue(value))
+                  .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
                   .map(([key, value]) => {
                     return (
                       <MetadataItem
@@ -270,6 +271,7 @@ const KernelOverview: React.FC<KernelOverviewProps> = ({
                 <div className="space-y-3 border-t border-gray-200 pt-4">
                   {Object.entries(kernel.metadata)
                     .filter(([_key, value]) => isLongValue(value))
+                    .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
                     .map(([key, value]) => (
                       <div key={key} className="w-full">
                         <span className="text-sm font-medium text-gray-500 block mb-1">
@@ -395,8 +397,8 @@ const KernelOverview: React.FC<KernelOverviewProps> = ({
                       ))
                     ) : (
                       <pre className="font-mono text-sm text-gray-700 whitespace-pre-wrap break-all">
-                        {typeof kernel.launchDiff.sames.stack === 'string' 
-                          ? kernel.launchDiff.sames.stack 
+                        {typeof kernel.launchDiff.sames.stack === 'string'
+                          ? kernel.launchDiff.sames.stack
                           : JSON.stringify(kernel.launchDiff.sames.stack, null, 2)}
                       </pre>
                     )}


### PR DESCRIPTION
## Overview
This PR improves the readability of the Compilation Metadata section in the TritonParse website by sorting attributes alphabetically within both short and long value sections.

Fix https://github.com/meta-pytorch/tritonparse/issues/77

## Changes Made
- Added alphabetical sorting using `.sort()` with `localeCompare()` for short metadata fields
- Added alphabetical sorting using `.sort()` with `localeCompare()` for long metadata fields
- Maintained the existing separation between short-value and long-value sections
- No functional changes - purely UI/UX improvement

## Technical Details
**File Modified:** `website/src/pages/KernelOverview.tsx`

**Before:**
Metadata attributes were displayed in their original object insertion order, making it difficult to locate specific attributes quickly.

**After:**
All attributes within each section (short values and long values) are now sorted alphabetically (A-Z), while maintaining the two-section layout:
- Short values section: displays compact attributes in a responsive grid
- Long values section: displays lengthy attributes in a vertical layout

## Benefits
- **Improved readability:** Users can quickly locate specific metadata attributes
- **Better consistency:** Predictable ordering across different kernel compilations
- **Enhanced UX:** Reduces cognitive load when scanning for specific information

## Testing
- No new tests required (UI-only change)
- Verified no TypeScript/linting errors
- Tested with existing trace files to confirm proper sorting

## Related Files
- `/home/yhao/tritonparse_oss/website/src/pages/KernelOverview.tsx`
