### PR TITLE
[BE] Fix import sorting to comply with latest usort version

### DIFF
--- a/tritonparse/reproducer/placeholder_replacer.py
+++ b/tritonparse/reproducer/placeholder_replacer.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, Protocol
 
 from tritonparse.reproducer.function_extractor import extract_utility_functions
 from tritonparse.reproducer.ingestion.ndjson import ContextBundle
-
 from tritonparse.reproducer.templates.utils import (
     _disable_triton_autotune,
     get_function_source,

--- a/tritonparse/reproducer/utils.py
+++ b/tritonparse/reproducer/utils.py
@@ -12,7 +12,6 @@ from pathlib import Path
 
 import torch
 import triton.language as tl
-
 from tritonparse.tools.load_tensor import load_tensor
 from tritonparse.tp_logger import logger
 


### PR DESCRIPTION



**Problem:** The GitHub CI format-check was failing with usort errors on `placeholder_replacer.py` and [`**utils.py**`](command:code-compose.open?%5B%22%2Fhome%2Fyhao%2Ftritonparse_oss%2Ftritonparse%2Freproducer%2Futils.py%22%2Cnull%5D "utils.py"), even though local `make format` passed without issues. This was caused by version inconsistency - the CI server was using a newer version of usort than what was available locally.

**Solution:**

*   Upgraded usort to the latest version locally
*   Applied usort formatting to fix import ordering in the affected files
*   This ensures consistency between local development and CI environments

**Files Changed:**

*   `tritonparse/reproducer/placeholder_replacer.py`
*   [`**utils.py**`](command:code-compose.open?%5B%22%2Fhome%2Fyhao%2Ftritonparse_oss%2Ftritonparse%2Freproducer%2Futils.py%22%2Cnull%5D "tritonparse/reproducer/utils.py")

**Testing:**

*   ✅ `make format-check` passes locally
*   ✅ All formatting tools (usort, ruff, black) complete successfully