### PR TITLE
Change --line to 0-based index for reproduce command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,4 +55,4 @@ clean:
 
 install-dev:
 	@echo "Installing development dependencies..."
-	pip install black usort ruff coverage
+	pip install -U black usort ruff coverage

--- a/README.md
+++ b/README.md
@@ -102,8 +102,9 @@ tritonparse.utils.unified_parse("./logs/", out="./parsed_output")
 Extract any kernel into a standalone, executable Python script for debugging or testing:
 
 ```bash
-# Generate reproducer from first launch event
-tritonparseoss reproduce ./parsed_output/trace.ndjson.gz --line 2 --out-dir repro_output
+# Generate reproducer for the first launch event
+# (--line is 0-based: line 0 is compilation event, line 1 is first launch event)
+tritonparseoss reproduce ./parsed_output/trace.ndjson.gz --line 1 --out-dir repro_output
 
 # Run the generated reproducer
 cd repro_output/<kernel_name>/

--- a/tritonparse/cli.py
+++ b/tritonparse/cli.py
@@ -30,7 +30,7 @@ def main():
         epilog=(
             "Examples:\n"
             f"  {prog_name} parse /path/to/logs --out parsed_output\n"
-            f"  {prog_name} reproduce /path/to/trace.ndjson --line 2 --out-dir repro_output\n"
+            f"  {prog_name} reproduce /path/to/trace.ndjson --line 1 --out-dir repro_output\n"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -77,7 +77,7 @@ def main():
 
         reproduce(
             input_path=args.input,
-            line_index=args.line - 1,  # Convert 1-based line number to 0-based index
+            line_index=args.line,
             out_dir=args.out_dir,
             template=args.template,
             kernel_import=args.kernel_import,

--- a/tritonparse/reproducer/cli.py
+++ b/tritonparse/reproducer/cli.py
@@ -11,10 +11,10 @@ def _add_reproducer_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--line",
         type=int,
-        default=1,
+        default=0,
         help=(
-            "The line number (1-based) of the launch event in the input file to reproduce. "
-            "Defaults to 1."
+            "The line index (0-based) of the launch event in the input file to reproduce. "
+            "Defaults to 0 (first launch event)."
         ),
     )
     parser.add_argument(

--- a/tritonparse/reproducer/templates/tritonbench.py
+++ b/tritonparse/reproducer/templates/tritonbench.py
@@ -5,13 +5,13 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Tuple
 
 import torch
-
-logger = logging.getLogger(__name__)
 from tritonbench.utils.triton_op import (
     BenchmarkOperator,
     register_benchmark,
     REGISTERED_X_VALS,
 )
+
+logger = logging.getLogger(__name__)
 
 
 imported_kernel_function: Optional[Callable[[Tuple[int], Dict[str, Any]], None]] = None


### PR DESCRIPTION

## Summary

This PR changes the `--line` argument in the `reproduce` command from 1-based to 0-based indexing, aligning with Python conventions.

## Changes

- **`reproducer/cli.py`**: Changed `--line` default from 1 to 0, updated help text to indicate 0-based indexing
- **`cli.py`**: Removed the `-1` conversion, updated CLI example to use `--line 1`
- **`README.md`**: Updated example with explanation that line 0 is compilation event, line 1 is first launch event
- **`reproducer/templates/tritonbench.py`**: Fixed import order (lint fix)
- **`Makefile`**: Added `-U` flag to pip install (minor fix)

## Breaking Change

The `--line` argument is now **0-based** instead of 1-based:
- `--line 0` = first event (compilation)
- `--line 1` = second event (first launch)

Users who previously used `--line 1` to get the first event should now use `--line 0`.

## Testing

Existing `test_reproducer_end_to_end` test already uses 0-based `line_index` internally, no test changes needed.

