### PR TITLE
Add `info` CLI Subcommand

### DIFF
--- a/tests/test_tritonparse.py
+++ b/tests/test_tritonparse.py
@@ -307,6 +307,35 @@ module {
 
         print("✓ All loc alias parsing tests passed")
 
+    def test_load_ndjson_gzip_support(self):
+        """Test that load_ndjson can load .ndjson.gz files."""
+        from pathlib import Path
+
+        from tritonparse.tools.prettify_ndjson import load_ndjson
+
+        # Use existing .ndjson.gz test file
+        gz_file = (
+            Path(__file__).parent
+            / "example_output/parsed_output_complex/dedicated_log_triton_trace_findhao__mapped.ndjson.gz"
+        )
+
+        # Verify file exists
+        self.assertTrue(gz_file.exists(), f"Test file not found: {gz_file}")
+
+        # Load and verify
+        events = load_ndjson(gz_file)
+        self.assertIsInstance(events, list)
+        self.assertGreater(len(events), 0, "Should load at least one event")
+
+        # Verify we have expected event types
+        event_types = {e.get("event_type") for e in events if isinstance(e, dict)}
+        self.assertTrue(
+            "compilation" in event_types or "launch" in event_types,
+            f"Expected compilation or launch events, got: {event_types}",
+        )
+
+        print(f"✓ Successfully loaded {len(events)} events from .ndjson.gz file")
+
 
 class TestTritonparseCUDA(unittest.TestCase):
     """CUDA tests (require GPU)"""

--- a/tests/test_tritonparse.py
+++ b/tests/test_tritonparse.py
@@ -14,6 +14,7 @@ import tempfile
 import unittest
 from collections import defaultdict
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Union
 
 import torch
@@ -21,6 +22,7 @@ import torch._inductor.config as inductor_config
 import triton  # @manual=//triton:triton
 import triton.language as tl  # @manual=//triton:triton
 import tritonparse.context_manager
+import tritonparse.reproducer.orchestrator
 import tritonparse.structured_logging
 import tritonparse.utils
 from triton import knobs  # @manual=//triton:triton
@@ -137,6 +139,26 @@ def clear_all_caches(*kernels):
 
 class TestTritonparseCPU(unittest.TestCase):
     """CPU-only tests (no CUDA required)"""
+
+    def _get_test_ndjson_file(self):
+        """Get the test NDJSON file path."""
+        gz_file = (
+            Path(__file__).parent
+            / "example_output/parsed_output_complex/dedicated_log_triton_trace_findhao__mapped.ndjson.gz"
+        )
+        self.assertTrue(gz_file.exists(), f"Test file not found: {gz_file}")
+        return gz_file
+
+    def setup_temp_reproduce_dir(self):
+        """Setup temporary directory for reproduce tests."""
+        temp_dir = tempfile.mkdtemp()
+        out_dir = os.path.join(temp_dir, "repro_output")
+        return temp_dir, out_dir
+
+    def cleanup_temp_reproduce_dir(self, temp_dir):
+        """Cleanup temporary directory for reproduce tests."""
+        if not TEST_KEEP_OUTPUT:
+            shutil.rmtree(temp_dir, ignore_errors=True)
 
     def test_callsite_parsing(self):
         """Test parsing of callsite locations in TTIR/TTGIR"""
@@ -481,6 +503,116 @@ module {
         self.assertIn("has only 4 launches", error_msg)
         self.assertIn("--launch-id 10", error_msg)
         self.assertIn("Valid range: 0 to 3", error_msg)
+
+    def test_reproduce_mutual_exclusivity(self):
+        """Test that --line and --kernel/--launch-id are mutually exclusive."""
+        import argparse
+
+        from tritonparse.reproducer.cli import _add_reproducer_args
+
+        parser = argparse.ArgumentParser()
+        _add_reproducer_args(parser)
+
+        # Test: both --line and --kernel provided should raise error
+        # Create a mock parser with error method
+        mock_parser = argparse.ArgumentParser()
+        _add_reproducer_args(mock_parser)
+        args = mock_parser.parse_args(
+            ["test.ndjson", "--line", "5", "--kernel", "matmul_kernel"]
+        )
+
+        # The mutual exclusivity check happens in cli.py main()
+        # We test that args are parsed correctly, and the check will happen there
+        self.assertEqual(args.kernel, "matmul_kernel")
+        self.assertEqual(args.line, 5)
+
+        # Test: only --kernel should work (line defaults to 0, which is allowed)
+        args = parser.parse_args(["test.ndjson", "--kernel", "matmul_kernel"])
+        self.assertEqual(args.kernel, "matmul_kernel")
+        self.assertEqual(args.line, 0)  # default value, allowed with --kernel
+
+        # Test: only --line should work
+        args = parser.parse_args(["test.ndjson", "--line", "5"])
+        self.assertEqual(args.line, 5)
+        self.assertIsNone(args.kernel)
+
+    def test_reproduce_kernel_launch_id(self):
+        """End-to-end test: reproduce using --kernel and --launch-id."""
+        gz_file = self._get_test_ndjson_file()
+        temp_dir, out_dir = self.setup_temp_reproduce_dir()
+
+        try:
+            # Test reproducing fused_op_kernel launch_id=0
+            result = tritonparse.reproducer.orchestrator.reproduce(
+                input_path=str(gz_file),
+                line_index=0,  # Placeholder, will be recalculated from kernel_name
+                out_dir=out_dir,
+                template="example",
+                kernel_name="fused_op_kernel",
+                launch_id=0,
+            )
+
+            # Verify output structure
+            self.assertIn("kernel", result)
+            self.assertIn("repro_script", result)
+            self.assertIn("repro_context", result)
+            self.assertTrue(os.path.exists(result["repro_script"]))
+            self.assertTrue(os.path.exists(result["repro_context"]))
+
+            # Verify the script contains kernel name
+            script_content = Path(result["repro_script"]).read_text()
+            self.assertIn("fused_op_kernel", script_content)
+
+        finally:
+            self.cleanup_temp_reproduce_dir(temp_dir)
+
+    def test_reproduce_kernel_not_found(self):
+        """Test that proper error is raised when kernel not found."""
+        gz_file = self._get_test_ndjson_file()
+        temp_dir, out_dir = self.setup_temp_reproduce_dir()
+
+        try:
+            with self.assertRaises(ValueError) as cm:
+                tritonparse.reproducer.orchestrator.reproduce(
+                    input_path=str(gz_file),
+                    line_index=0,  # Placeholder, will be recalculated from kernel_name
+                    out_dir=out_dir,
+                    template="example",
+                    kernel_name="nonexistent_kernel",
+                    launch_id=0,
+                )
+
+            error_msg = str(cm.exception)
+            self.assertIn("not found", error_msg)
+            self.assertIn("nonexistent_kernel", error_msg)
+
+        finally:
+            self.cleanup_temp_reproduce_dir(temp_dir)
+
+    def test_reproduce_launch_id_out_of_range(self):
+        """Test that proper error is raised when launch_id is out of range."""
+        gz_file = self._get_test_ndjson_file()
+        temp_dir, out_dir = self.setup_temp_reproduce_dir()
+
+        try:
+            # fused_op_kernel has only 4 launches (0-3), test with launch_id=10
+            with self.assertRaises(ValueError) as cm:
+                tritonparse.reproducer.orchestrator.reproduce(
+                    input_path=str(gz_file),
+                    line_index=0,  # Placeholder, will be recalculated from kernel_name
+                    out_dir=out_dir,
+                    template="example",
+                    kernel_name="fused_op_kernel",
+                    launch_id=10,
+                )
+
+            error_msg = str(cm.exception)
+            self.assertIn("has only 4 launches", error_msg)
+            self.assertIn("--launch-id 10", error_msg)
+            self.assertIn("Valid range: 0 to 3", error_msg)
+
+        finally:
+            self.cleanup_temp_reproduce_dir(temp_dir)
 
 
 class TestTritonparseCUDA(unittest.TestCase):

--- a/tritonparse/cli.py
+++ b/tritonparse/cli.py
@@ -68,6 +68,10 @@ def main():
         }
         unified_parse(**parse_args)
     elif args.func == "reproduce":
+        # Check mutual exclusivity between --line and --kernel/--launch-id
+        if args.kernel and args.line != 0:
+            repro_parser.error("--line and --kernel/--launch-id are mutually exclusive")
+
         replacer = None
         if args.use_fbcode:
             from tritonparse.fb.reproducer.replacer import FBCodePlaceholderReplacer
@@ -77,9 +81,11 @@ def main():
 
         reproduce(
             input_path=args.input,
-            line_index=args.line,
+            line_index=args.line if not args.kernel else 0,
             out_dir=args.out_dir,
             template=args.template,
+            kernel_name=args.kernel,
+            launch_id=args.launch_id if args.kernel else 0,
             kernel_import=args.kernel_import,
             replacer=replacer,
         )

--- a/tritonparse/cli.py
+++ b/tritonparse/cli.py
@@ -4,6 +4,7 @@ import argparse
 from importlib.metadata import PackageNotFoundError, version
 
 from .common import is_fbcode
+from .info.cli import _add_info_args, info_command
 from .reproducer.cli import _add_reproducer_args
 from .reproducer.orchestrator import reproduce
 from .utils import _add_parse_args, unified_parse
@@ -31,6 +32,8 @@ def main():
             "Examples:\n"
             f"  {prog_name} parse /path/to/logs --out parsed_output\n"
             f"  {prog_name} reproduce /path/to/trace.ndjson --line 1 --out-dir repro_output\n"
+            f"  {prog_name} info /path/to/trace.ndjson\n"
+            f"  {prog_name} info /path/to/trace.ndjson --kernel matmul_kernel\n"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -59,6 +62,14 @@ def main():
     )
     _add_reproducer_args(repro_parser)
     repro_parser.set_defaults(func="reproduce")
+
+    # info subcommand
+    info_parser = subparsers.add_parser(
+        "info",
+        help="Query kernel information from trace file",
+    )
+    _add_info_args(info_parser)
+    info_parser.set_defaults(func="info")
 
     args = parser.parse_args()
 
@@ -89,6 +100,8 @@ def main():
             kernel_import=args.kernel_import,
             replacer=replacer,
         )
+    elif args.func == "info":
+        info_command(input_path=args.input, kernel_name=args.kernel)
     else:
         raise RuntimeError(f"Unknown command: {args.func}")
 

--- a/tritonparse/info/__init__.py
+++ b/tritonparse/info/__init__.py
@@ -11,14 +11,20 @@ This module provides core query functions for kernel information:
 
 from tritonparse.info.kernel_query import (
     find_launch_index_by_kernel,
+    find_similar_kernels,
     KernelSummary,
     LaunchInfo,
     list_kernels,
+    list_kernels_fast,
+    list_launches_for_kernel,
 )
 
 __all__ = [
     "KernelSummary",
     "LaunchInfo",
     "list_kernels",
+    "list_kernels_fast",
+    "list_launches_for_kernel",
     "find_launch_index_by_kernel",
+    "find_similar_kernels",
 ]

--- a/tritonparse/info/__init__.py
+++ b/tritonparse/info/__init__.py
@@ -1,0 +1,25 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Info module for querying kernel information from NDJSON trace files.
+
+This module provides core query functions for kernel information:
+- Listing all kernels with their launch counts
+- Finding launch events by kernel name and launch ID
+- Querying launch information for specific kernels
+"""
+
+from tritonparse.info.kernel_query import (
+    KernelSummary,
+    LaunchInfo,
+    find_launch_index_by_kernel,
+    list_kernels,
+)
+
+__all__ = [
+    "KernelSummary",
+    "LaunchInfo",
+    "list_kernels",
+    "find_launch_index_by_kernel",
+]
+

--- a/tritonparse/info/__init__.py
+++ b/tritonparse/info/__init__.py
@@ -10,9 +10,9 @@ This module provides core query functions for kernel information:
 """
 
 from tritonparse.info.kernel_query import (
+    find_launch_index_by_kernel,
     KernelSummary,
     LaunchInfo,
-    find_launch_index_by_kernel,
     list_kernels,
 )
 
@@ -22,4 +22,3 @@ __all__ = [
     "list_kernels",
     "find_launch_index_by_kernel",
 ]
-

--- a/tritonparse/info/cli.py
+++ b/tritonparse/info/cli.py
@@ -13,7 +13,6 @@ from typing import Optional
 
 from tritonparse.info.kernel_query import (
     find_similar_kernels,
-    list_kernels,
     list_kernels_fast,
     list_launches_for_kernel,
 )
@@ -95,7 +94,9 @@ def info_command(input_path: str, kernel_name: Optional[str] = None) -> None:
                 similar = find_similar_kernels(events, kernel_name, n=3)
                 if similar:
                     print("\nDid you mean one of these?")
-                    all_kernels = list_kernels_fast(events)  # Use fast path for consistency
+                    all_kernels = list_kernels_fast(
+                        events
+                    )  # Use fast path for consistency
                     kernel_dict = {k.name: k for k in all_kernels}
                     for name in similar:
                         count = kernel_dict[name].total_launches

--- a/tritonparse/info/cli.py
+++ b/tritonparse/info/cli.py
@@ -1,0 +1,120 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+CLI implementation for the info subcommand.
+
+This module provides command-line interface for querying kernel information
+from NDJSON trace files.
+"""
+
+import argparse
+import tempfile
+from typing import Optional
+
+from tritonparse.info.kernel_query import (
+    find_similar_kernels,
+    list_kernels,
+    list_kernels_fast,
+    list_launches_for_kernel,
+)
+from tritonparse.info.parse_helper import parse_and_compress_raw_log
+from tritonparse.tools.prettify_ndjson import load_ndjson
+
+
+def _add_info_args(parser: argparse.ArgumentParser) -> None:
+    """Add arguments for the info subcommand."""
+    parser.add_argument(
+        "input",
+        help="Path to ndjson/ndjson.gz/.bin.ndjson file",
+    )
+    parser.add_argument(
+        "--kernel",
+        type=str,
+        default=None,
+        help="Kernel name to list launches for",
+    )
+
+
+def info_command(input_path: str, kernel_name: Optional[str] = None) -> None:
+    """
+    Main function for the info command.
+
+    Args:
+        input_path: Path to ndjson file
+        kernel_name: Optional kernel name to list launches for
+    """
+    # 1. Load and detect type
+    events = load_ndjson(input_path)
+    has_launch_diff = any(e.get("event_type") == "launch_diff" for e in events)
+
+    # 2. If no launch_diff, auto-parse
+    if not has_launch_diff:
+        print(
+            f"Input file '{input_path}' appears to be raw log (no launch_diff events)."
+        )
+        print("Parsing automatically to generate launch_diff events...")
+
+        temp_dir = tempfile.mkdtemp(prefix="tritonparse_info_")
+
+        try:
+            # Parse and compress (reuses parse module's functions)
+            parsed_file = parse_and_compress_raw_log(
+                input_path,
+                output_dir=temp_dir,
+                split_inductor_compilations=False,
+                verbose=False,
+            )
+
+            # Load compressed file (load_ndjson supports .ndjson.gz)
+            events = load_ndjson(parsed_file)
+
+            print(f"✓ Parsed and compressed file: {parsed_file}")
+            print(f"  (Temporary directory: {temp_dir})")
+        except Exception as e:
+            raise RuntimeError(f"Failed to parse input file '{input_path}': {e}") from e
+    else:
+        print(f"Using parsed trace file: {input_path}")
+
+    # 3. Process query
+    if kernel_name:
+        # List launches for specific kernel
+        try:
+            launches = list_launches_for_kernel(events, kernel_name)
+            print(f"\nLaunches for '{kernel_name}':")
+            print("-" * 60)
+            for launch in launches:
+                grid_str = str(launch.grid) if launch.grid else "N/A"
+                print(
+                    f"  id={launch.launch_id:3d}  line {launch.line_index:5d}  grid={grid_str}"
+                )
+        except ValueError as e:
+            error_msg = str(e)
+            print(f"\nError: {error_msg}")
+            # Try to suggest similar kernels
+            try:
+                similar = find_similar_kernels(events, kernel_name, n=3)
+                if similar:
+                    print("\nDid you mean one of these?")
+                    all_kernels = list_kernels_fast(events)  # Use fast path for consistency
+                    kernel_dict = {k.name: k for k in all_kernels}
+                    for name in similar:
+                        count = kernel_dict[name].total_launches
+                        print(f"  - {name} ({count} launches)")
+                    print("\nUse 'tritonparseoss info <file>' to list all kernels.")
+            except Exception:
+                pass  # Ignore errors in suggestion
+            raise
+    else:
+        # List all kernels
+        kernels = list_kernels_fast(events)
+        print(f"\nKernels in {input_path}:")
+        print("-" * 60)
+        for kernel in kernels:
+            if kernel.total_launches > 0:
+                max_id = kernel.total_launches - 1
+                print(
+                    f"  {kernel.name:30s} {kernel.total_launches:3d} launches "
+                    f"(id: 0-{max_id})"
+                )
+            else:
+                print(f"  {kernel.name:30s} {kernel.total_launches:3d} launches")

--- a/tritonparse/info/kernel_query.py
+++ b/tritonparse/info/kernel_query.py
@@ -1,0 +1,108 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Core query functions for kernel information from NDJSON trace files.
+
+This module provides functions to query kernel launch information from parsed
+event lists. It supports both raw log files and parsed ndjson files (with launch_diff events).
+"""
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+
+@dataclass
+class KernelSummary:
+    """Summary information about a kernel."""
+
+    name: str
+    hash: str
+    total_launches: int
+
+
+@dataclass
+class LaunchInfo:
+    """Information about a specific kernel launch."""
+
+    launch_id: int  # 0-based
+    line_index: int  # 0-based (index in events list)
+    grid: List[int]
+
+
+def list_kernels(events: List[Dict[str, Any]]) -> List[KernelSummary]:
+    """
+    List all kernels with their launch counts.
+
+    Args:
+        events: List of parsed event dictionaries from NDJSON file
+
+    Returns:
+        List of KernelSummary objects, sorted by kernel name
+    """
+    # Count launches per kernel
+    kernel_counts: Dict[str, Dict[str, Any]] = defaultdict(
+        lambda: {"hash": "", "count": 0}
+    )
+
+    for event in events:
+        if event.get("event_type") != "launch":
+            continue
+
+        comp_meta = event.get("compilation_metadata", {})
+        kernel_name = comp_meta.get("name")
+        kernel_hash = comp_meta.get("hash", "")
+
+        if kernel_name:
+            kernel_counts[kernel_name]["hash"] = kernel_hash
+            kernel_counts[kernel_name]["count"] += 1
+
+    # Convert to KernelSummary list
+    summaries = [
+        KernelSummary(name=name, hash=info["hash"], total_launches=info["count"])
+        for name, info in kernel_counts.items()
+    ]
+
+    # Sort by kernel name for consistent output
+    summaries.sort(key=lambda x: x.name)
+
+    return summaries
+
+
+def find_launch_index_by_kernel(
+    events: List[Dict[str, Any]], kernel_name: str, launch_id: int
+) -> int:
+    """
+    Find the 0-based line index for a kernel's N-th launch.
+
+    Args:
+        events: List of parsed event dictionaries
+        kernel_name: Exact kernel name to match (case-sensitive)
+        launch_id: 0-based launch index for the kernel
+
+    Returns:
+        0-based line index (index in events list)
+
+    Raises:
+        ValueError: If kernel not found or launch_id out of range
+    """
+    count = 0
+    for i, event in enumerate(events):
+        if event.get("event_type") != "launch":
+            continue
+
+        comp_meta = event.get("compilation_metadata", {})
+        name = comp_meta.get("name")
+        if name == kernel_name:
+            if count == launch_id:
+                return i
+            count += 1
+
+    if count == 0:
+        raise ValueError(f"Kernel '{kernel_name}' not found")
+    else:
+        raise ValueError(
+            f"Kernel '{kernel_name}' has only {count} launches, "
+            f"but --launch-id {launch_id} was requested. Valid range: 0 to {count - 1}"
+        )
+

--- a/tritonparse/info/kernel_query.py
+++ b/tritonparse/info/kernel_query.py
@@ -105,4 +105,3 @@ def find_launch_index_by_kernel(
             f"Kernel '{kernel_name}' has only {count} launches, "
             f"but --launch-id {launch_id} was requested. Valid range: 0 to {count - 1}"
         )
-

--- a/tritonparse/info/kernel_query.py
+++ b/tritonparse/info/kernel_query.py
@@ -7,6 +7,7 @@ This module provides functions to query kernel launch information from parsed
 event lists. It supports both raw log files and parsed ndjson files (with launch_diff events).
 """
 
+import difflib
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, Dict, List
@@ -105,3 +106,104 @@ def find_launch_index_by_kernel(
             f"Kernel '{kernel_name}' has only {count} launches, "
             f"but --launch-id {launch_id} was requested. Valid range: 0 to {count - 1}"
         )
+
+
+def list_launches_for_kernel(
+    events: List[Dict[str, Any]], kernel_name: str
+) -> List[LaunchInfo]:
+    """
+    List all launches for a specific kernel.
+
+    Args:
+        events: List of parsed event dictionaries
+        kernel_name: Exact kernel name to match (case-sensitive)
+
+    Returns:
+        List of LaunchInfo objects for the kernel, sorted by launch_id
+
+    Raises:
+        ValueError: If kernel not found
+    """
+    launches = []
+    launch_id = 0
+
+    for i, event in enumerate(events):
+        if event.get("event_type") != "launch":
+            continue
+
+        comp_meta = event.get("compilation_metadata", {})
+        name = comp_meta.get("name")
+        if name == kernel_name:
+            # Extract grid information from launch event
+            grid = event.get("grid", [])
+            launches.append(LaunchInfo(launch_id=launch_id, line_index=i, grid=grid))
+            launch_id += 1
+
+    if not launches:
+        raise ValueError(f"Kernel '{kernel_name}' not found")
+
+    return launches
+
+
+def find_similar_kernels(
+    events: List[Dict[str, Any]], kernel_name: str, n: int = 3
+) -> List[str]:
+    """
+    Find similar kernel names using fuzzy matching.
+
+    Args:
+        events: List of parsed event dictionaries
+        kernel_name: Kernel name to find similar matches for
+        n: Maximum number of matches to return
+
+    Returns:
+        List of similar kernel names (may be empty if no matches found)
+    """
+    all_kernels = list_kernels(events)
+    all_names = [k.name for k in all_kernels]
+    return difflib.get_close_matches(kernel_name, all_names, n=n, cutoff=0.6)
+
+
+def list_kernels_fast(events: List[Dict[str, Any]]) -> List[KernelSummary]:
+    """
+    Fast kernel listing using launch_diff events when available.
+
+    If launch_diff events are present, uses them for fast listing.
+    Otherwise, falls back to list_kernels().
+
+    Args:
+        events: List of parsed event dictionaries
+
+    Returns:
+        List of KernelSummary objects, sorted by kernel name
+    """
+    # Check if launch_diff events are available
+    launch_diff_events = [e for e in events if e.get("event_type") == "launch_diff"]
+
+    if launch_diff_events:
+        # Use launch_diff events for fast listing
+        # Merge kernels with the same name (sum up launches)
+        kernel_dict: Dict[str, KernelSummary] = {}
+        for event in launch_diff_events:
+            name = event.get("name", "")
+            if not name:
+                continue
+            hash_val = event.get("hash", "")
+            launches = event.get("total_launches", 0)
+
+            if name in kernel_dict:
+                # Merge: sum up launches, keep first hash
+                kernel_dict[name].total_launches += launches
+            else:
+                kernel_dict[name] = KernelSummary(
+                    name=name,
+                    hash=hash_val,
+                    total_launches=launches,
+                )
+
+        summaries = list(kernel_dict.values())
+        summaries.sort(key=lambda x: x.name)
+        return summaries
+    else:
+        # Fall back to full traversal
+        return list_kernels(events)

--- a/tritonparse/info/parse_helper.py
+++ b/tritonparse/info/parse_helper.py
@@ -1,0 +1,70 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Helper functions for parsing raw log files in the info module.
+
+This module provides utilities to parse and compress raw log files,
+reusing functionality from the parse module.
+"""
+
+from pathlib import Path
+
+from tritonparse.common import gzip_single_file
+from tritonparse.trace_processor import parse_single_file
+
+
+def parse_and_compress_raw_log(
+    input_path: str,
+    output_dir: str,
+    split_inductor_compilations: bool = False,
+    verbose: bool = False,
+) -> Path:
+    """
+    Parse a raw log file, compress it, and return the path to the compressed parsed file.
+
+    This function reuses the parse module's functionality:
+    - parse_single_file: Parse the file
+    - gzip_single_file: Compress the parsed file
+
+    Args:
+        input_path: Path to raw log file
+        output_dir: Directory to save parsed file
+        split_inductor_compilations: Whether to split by inductor compilations
+        verbose: Whether to print verbose information
+
+    Returns:
+        Path to the generated compressed parsed file (.ndjson.gz)
+
+    Raises:
+        RuntimeError: If parsing fails or parsed file not found
+    """
+    # 1. Parse the file (generates uncompressed .ndjson)
+    parse_single_file(
+        input_path,
+        output_dir=output_dir,
+        split_inductor_compilations=split_inductor_compilations,
+    )
+
+    # 2. Calculate expected output filename
+    input_path_obj = Path(input_path)
+    file_name = input_path_obj.name
+
+    if input_path.endswith(".bin.ndjson"):
+        file_name_without_ext = file_name[:-11]  # Remove ".bin.ndjson"
+    else:
+        file_name_without_ext = input_path_obj.stem  # Remove all extensions
+        # If there's still a .ndjson extension, remove it
+        if file_name_without_ext.endswith(".ndjson"):
+            file_name_without_ext = file_name_without_ext[:-7]
+
+    uncompressed_file = Path(output_dir) / f"{file_name_without_ext}_mapped.ndjson"
+
+    if not uncompressed_file.exists():
+        raise RuntimeError(
+            f"Failed to generate parsed file. Expected: {uncompressed_file}"
+        )
+
+    # 3. Compress the file (reusing parse module's function)
+    compressed_file = gzip_single_file(str(uncompressed_file), verbose=verbose)
+
+    return Path(compressed_file)  # Returns .ndjson.gz path

--- a/tritonparse/reproducer/cli.py
+++ b/tritonparse/reproducer/cli.py
@@ -14,7 +14,26 @@ def _add_reproducer_args(parser: argparse.ArgumentParser) -> None:
         default=0,
         help=(
             "The line index (0-based) of the launch event in the input file to reproduce. "
-            "Defaults to 0 (first launch event)."
+            "Defaults to 0 (first launch event). Mutually exclusive with --kernel/--launch-id."
+        ),
+    )
+    parser.add_argument(
+        "--kernel",
+        type=str,
+        default=None,
+        help=(
+            "Kernel name (exact match, case-sensitive) to reproduce. "
+            "Use with --launch-id to specify which launch of the kernel. "
+            "Mutually exclusive with --line."
+        ),
+    )
+    parser.add_argument(
+        "--launch-id",
+        type=int,
+        default=0,
+        help=(
+            "0-based launch index for the kernel specified by --kernel. "
+            "Defaults to 0 (first launch). Only used when --kernel is provided."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION


## Summary

This PR adds the `info` subcommand to query kernel information from NDJSON trace files. It automatically detects raw logs and parses them, enabling users to list kernels and their launches without manual parsing.

## Changes

- **`info/cli.py`** (NEW):
  - `_add_info_args()`: Add CLI arguments for info subcommand
  - `info_command()`: Main command implementation
  - Auto-detects raw logs (no launch_diff events) and parses them automatically
  - Supports listing all kernels or launches for a specific kernel
  - Provides fuzzy matching suggestions when kernel not found

- **`info/parse_helper.py`** (NEW):
  - `parse_and_compress_raw_log()`: Parse and compress raw log files
  - Reuses `parse_single_file()` and `gzip_single_file()` from parse module
  - Handles file naming for various input formats (.ndjson, .ndjson.gz, .bin.ndjson)

- **`info/kernel_query.py`**:
  - `list_launches_for_kernel()`: List all launches for a specific kernel with grid info
  - `find_similar_kernels()`: Fuzzy matching using `difflib.get_close_matches()`
  - `list_kernels_fast()`: Optimized listing using `launch_diff` events when available
    - Merges kernels with same name (sums up launches)
    - Falls back to `list_kernels()` for raw logs

- **`info/__init__.py`**:
  - Export new functions: `list_launches_for_kernel`, `find_similar_kernels`, `list_kernels_fast`

- **`cli.py`**:
  - Add `info` subcommand integration
  - Import `_add_info_args` and `info_command` from `info.cli`
  - Update help examples

- **`tests/test_tritonparse.py`**:
  - `test_info_kernel_query_functions()`: Combined unit test for 3 query functions
  - `test_info_list_kernels()`: Integration test for listing all kernels
  - `test_info_kernel_launches()`: Integration test for listing kernel launches
  - `test_info_kernel_not_found()`: Integration test for error handling with suggestions

## Usage

```bash
# List all kernels with launch counts
tritonparseoss info trace.ndjson

# Output example:
# Kernels in trace.ndjson:
#   fused_op_kernel        4 launches (id: 0-3)
#   matmul_kernel       1553 launches (id: 0-1552)

# List launches for a specific kernel
tritonparseoss info trace.ndjson --kernel matmul_kernel

# Output example:
# Launches for 'matmul_kernel':
#   id=  0  line   123  grid=[128, 1, 1]
#   id=  1  line   456  grid=[256, 1, 1]
#   ...

# Works with raw logs (auto-parses)
tritonparseoss info raw_trace.ndjson
# Automatically parses and compresses, then queries
```

## Features

- **Auto-parsing**: Automatically detects and parses raw logs (no launch_diff events)
- **Compression**: Parsed files are automatically compressed using parse module's gzip functionality
- **Performance**: Uses `launch_diff` events for fast kernel listing when available
- **Error handling**: Suggests similar kernel names when kernel not found
- **Temporary files**: Parsed files saved to temp directory (not cleaned up, user can reuse)

## Testing

- 1 combined unit test covering 3 query functions
- 3 integration tests covering CLI functionality
- All tests use real data from test fixtures
- Tests verify both fast path (launch_diff) and slow path (full traversal)

## Notes

- Temporary directories are not cleaned up (as per design requirement)
- Parsed files are compressed (.ndjson.gz) for consistency with parse module
- Kernel name matching is case-sensitive (exact match only)
- Fuzzy matching uses 0.6 cutoff threshold for similarity

# Test Plan

```bash
% python -m unittest tests.test_tritonparse.TestTritonparseCPU.test_info_kernel_query_functions tests.test_tritonparse.TestTritonparseCPU.test_info_list_kernels tests.test_tritonparse.TestTritonparseCPU.test_info_kernel_launches tests.test_tritonparse.TestTritonparseCPU.test_info_kernel_not_found  -v
test_info_kernel_query_functions (tests.test_tritonparse.TestTritonparseCPU.test_info_kernel_query_functions)
Test info module kernel query functions. ... ok
test_info_list_kernels (tests.test_tritonparse.TestTritonparseCPU.test_info_list_kernels)
Integration test: info command lists all kernels. ... ok
test_info_kernel_launches (tests.test_tritonparse.TestTritonparseCPU.test_info_kernel_launches)
Integration test: info command lists launches for specific kernel. ... ok
test_info_kernel_not_found (tests.test_tritonparse.TestTritonparseCPU.test_info_kernel_not_found)
Integration test: info command handles kernel not found. ... ok

----------------------------------------------------------------------
Ran 4 tests in 0.708s

OK
```