### PR TITLE
[pypi] Switch to PyPI Trusted Publishing

### DIFF
--- a/.github/workflows/nightly-pypi.yml
+++ b/.github/workflows/nightly-pypi.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write  # Required for Trusted Publishing (OIDC)
 
 jobs:
   build-and-publish:
@@ -67,10 +68,9 @@ jobs:
           pip install twine
           twine check dist/*
 
-      - name: Publish to PyPI (API token)
+      - name: Publish to PyPI (Trusted Publishing)
         if: (github.event_name == 'schedule' || github.ref_type == 'tag') && steps.check.outputs.should_publish != 'false'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          attestations: true
           skip-existing: true


### PR DESCRIPTION


## Summary

This PR migrates the PyPI publishing workflow from API token authentication to Trusted Publishing (OIDC).

## Changes

- Added `id-token: write` permission for OIDC token generation
- Removed `user` and `password` parameters from the publish step
- Enabled `attestations: true` for package provenance

## Why

Trusted Publishing provides:
- **No secrets to manage**: Eliminates the need for API tokens stored in GitHub Secrets
- **Better security**: Uses short-lived OIDC tokens instead of long-lived API tokens
- **Attestations support**: Enables cryptographic proof of package provenance

## Required Setup

Before merging, configure Trusted Publisher on PyPI:

1. Go to https://pypi.org/manage/project/tritonparse/settings/publishing/
2. Add a new publisher with:
   - **Owner**: `meta-pytorch`
   - **Repository**: `tritonparse`
   - **Workflow name**: `nightly-pypi.yml`
   - **Environment**: (leave empty)

## References

- [PyPI Trusted Publishers Documentation](https://docs.pypi.org/trusted-publishers/)
- [GitHub Actions Publishing Guide](https://docs.pypi.org/trusted-publishers/using-a-publisher/)
