### PR TITLE
Add PACKAGE_PATH Support to check_new_commits.sh

### DIFF
--- a/.github/scripts/check_new_commits.sh
+++ b/.github/scripts/check_new_commits.sh
@@ -20,6 +20,7 @@ MAX_RETRIES=3
 RETRY_DELAY=5
 CURL_TIMEOUT=10
 PACKAGE_NAME="${PACKAGE_NAME:-tritonparse}"
+PACKAGE_PATH="${PACKAGE_PATH:-}"  # Optional: subdirectory to check (e.g., "python/")
 
 # Dependencies: This script requires 'jq' and 'curl' to be installed.
 # These are pre-installed on ubuntu-latest GitHub Actions runners.
@@ -99,7 +100,13 @@ main() {
     echo "Last nightly published at: $SINCE_DATE"
 
     # Step 6: Check for new commits since last nightly
-    COMMITS_SINCE=$(git log --since="$SINCE_DATE" --oneline | wc -l)
+    # If PACKAGE_PATH is set, only check commits in that subdirectory
+    if [ -n "$PACKAGE_PATH" ]; then
+        echo "Checking commits in path: $PACKAGE_PATH"
+        COMMITS_SINCE=$(git log --since="$SINCE_DATE" --oneline -- "$PACKAGE_PATH" | wc -l)
+    else
+        COMMITS_SINCE=$(git log --since="$SINCE_DATE" --oneline | wc -l)
+    fi
 
     if [ "$COMMITS_SINCE" -eq 0 ]; then
         echo "No new commits since last nightly, skipping publish"


### PR DESCRIPTION

## Summary

Add optional `PACKAGE_PATH` environment variable to `check_new_commits.sh` script for subdirectory filtering. This enables projects with Python packages in subdirectories to use this script for nightly PyPI publishing.

## Motivation

Projects like CUTracer have their Python package in a subdirectory (`python/`). Without path filtering, the nightly publish would trigger even when only C++/CUDA code changes, not the Python package.

## Changes

| File | Lines Changed |
|------|---------------|
| `.github/scripts/check_new_commits.sh` | +8 / -1 |

```diff
+PACKAGE_PATH="${PACKAGE_PATH:-}"  # Optional: subdirectory to check (e.g., "python/")

-COMMITS_SINCE=$(git log --since="$SINCE_DATE" --oneline | wc -l)
+if [ -n "$PACKAGE_PATH" ]; then
+    echo "Checking commits in path: $PACKAGE_PATH"
+    COMMITS_SINCE=$(git log --since="$SINCE_DATE" --oneline -- "$PACKAGE_PATH" | wc -l)
+else
+    COMMITS_SINCE=$(git log --since="$SINCE_DATE" --oneline | wc -l)
+fi
```

## Features

- **New**: `PACKAGE_PATH` environment variable for subdirectory filtering
- **Backward compatible**: Existing behavior unchanged when `PACKAGE_PATH` is not set

## Usage

### Default (entire repository)
```yaml
- name: Check for new commits
  run: bash .github/scripts/check_new_commits.sh
```

### With subdirectory filtering
```yaml
- name: Check for new commits
  env:
    PACKAGE_NAME: cutracer
    PACKAGE_PATH: python/
  run: bash .github/scripts/check_new_commits.sh
```

### Download and use from another project
```yaml
- name: Check for new commits
  env:
    PACKAGE_NAME: cutracer
    PACKAGE_PATH: python/
  run: |
    curl -fsSL https://raw.githubusercontent.com/meta-pytorch/tritonparse/main/.github/scripts/check_new_commits.sh | bash
```

## Test Plan

1. Verify existing tritonparse nightly workflow works unchanged
2. Test with `PACKAGE_PATH=python/` in a project with subdirectory structure
