### PR TITLE
[website] Remove unnecessary npm overrides for prismjs and dompurify

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -2413,15 +2413,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/dompurify": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.0.tgz",
-      "integrity": "sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.267",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
@@ -3494,6 +3485,15 @@
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
+      }
+    },
+    "node_modules/monaco-editor/node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/ms": {

--- a/website/package.json
+++ b/website/package.json
@@ -38,9 +38,5 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.50.1",
     "vite": "^7.3.0"
-  },
-  "overrides": {
-    "prismjs": "^1.30.0",
-    "dompurify": "^3.2.4"
   }
 }


### PR DESCRIPTION
## Summary

Dependencies now use secure versions natively. The `prismjs` and `dompurify` overrides were added previously to fix security vulnerabilities, but upstream packages have since updated their dependencies to use patched versions.

## Changes

- Remove `overrides` section from `package.json`
- Update `package-lock.json` to reflect native dependency resolution

## Test Plan

- Verified `npm ls prismjs` shows 1.30.0 (patched version)
- Verified `npm ls dompurify` shows 3.2.7 (> 3.2.4, patched version)
