### PR TITLE
[website] PR5: Fix no-empty Block Statement Errors

### DIFF
--- a/website/src/components/SingleCodeViewer.tsx
+++ b/website/src/components/SingleCodeViewer.tsx
@@ -54,11 +54,11 @@ const SingleCodeViewer: React.FC<SingleCodeViewerProps> = ({
         // Find all lines that map to the same TTGIR line
         const relatedLines = Object.entries(sourceMapping)
           .filter(
-            ([_, mapping]) =>
+            ([key, mapping]) =>
               mapping.ttgir_line === clickedMapping.ttgir_line &&
-              parseInt(lineKey, 10) !== parseInt(_, 10) // Skip the clicked line itself
+              parseInt(lineKey, 10) !== parseInt(key, 10) // Skip the clicked line itself
           )
-          .map(([line, _]) => parseInt(line, 10));
+          .map(([line]) => parseInt(line, 10));
 
         if (relatedLines.length > 0) {
           // Include the clicked line and any related lines

--- a/website/src/components/StackDiffViewer.tsx
+++ b/website/src/components/StackDiffViewer.tsx
@@ -2,8 +2,43 @@ import React, { useState } from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
 
+/**
+ * Stack frame in a stack trace
+ */
+interface StackFrame {
+  filename: string;
+  line: number;
+  name: string;
+  line_code?: string;
+}
+
+/**
+ * Launch range for distribution values
+ */
+interface LaunchRange {
+  start: number;
+  end: number;
+}
+
+/**
+ * Distribution value item
+ */
+interface StackDistributionValue {
+  value: StackFrame[];
+  count: number;
+  launches: LaunchRange[];
+}
+
+/**
+ * Stack diff with distribution type
+ */
+interface StackDiff {
+  diff_type: string;
+  values: StackDistributionValue[];
+}
+
 // A single frame of a stack trace
-const StackTraceFrame: React.FC<{ frame: any }> = ({ frame }) => (
+const StackTraceFrame: React.FC<{ frame: StackFrame }> = ({ frame }) => (
   <div className="font-mono text-xs break-all">
     <span className="text-gray-500">{frame.filename}</span>:
     <span className="font-semibold text-blue-600">{frame.line}</span> in{" "}
@@ -28,7 +63,7 @@ const StackTraceFrame: React.FC<{ frame: any }> = ({ frame }) => (
 );
 
 
-const StackDiffViewer: React.FC<{ stackDiff: any }> = ({ stackDiff }) => {
+const StackDiffViewer: React.FC<{ stackDiff: StackDiff | null | undefined }> = ({ stackDiff }) => {
   const [isCollapsed, setIsCollapsed] = useState(true);
 
   if (!stackDiff || stackDiff.diff_type !== 'distribution') {
@@ -55,9 +90,9 @@ const StackDiffViewer: React.FC<{ stackDiff: any }> = ({ stackDiff }) => {
       </h5>
       {!isCollapsed && (
          <div className="space-y-2">
-          {stackDiff.values.map((item: any, index: number) => {
+          {stackDiff.values.map((item: StackDistributionValue, index: number) => {
             const launchRanges = item.launches
-              .map((r: any) => (r.start === r.end ? `${r.start}` : `${r.start}-${r.end}`))
+              .map((r: LaunchRange) => (r.start === r.end ? `${r.start}` : `${r.start}-${r.end}`))
               .join(", ");
             
             return (
@@ -66,7 +101,7 @@ const StackDiffViewer: React.FC<{ stackDiff: any }> = ({ stackDiff }) => {
                   Variant seen {item.count} times (in launches: {launchRanges})
                 </p>
                 <div className="space-y-1 bg-gray-50 p-1 rounded">
-                   {Array.isArray(item.value) ? item.value.map((frame: any, frameIndex: number) => (
+                   {Array.isArray(item.value) ? item.value.map((frame: StackFrame, frameIndex: number) => (
                     <StackTraceFrame key={frameIndex} frame={frame} />
                   )) : <p>Invalid stack format</p>}
                 </div>

--- a/website/src/components/TritonIRs.tsx
+++ b/website/src/components/TritonIRs.tsx
@@ -38,7 +38,7 @@ const TritonIRs: React.FC<TritonIRsProps> = ({ irFiles, onViewIR }) => {
     <div className="bg-white rounded-lg p-4 mb-4 shadow-sm border border-gray-200">
       <h2 className="text-xl font-semibold mb-4 text-gray-800">Triton IRs</h2>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {Object.entries(irFiles).map(([irType, _]) => (
+        {Object.keys(irFiles).map((irType) => (
           <div
             key={irType}
             className="bg-gray-50 rounded p-4 border border-gray-200 hover:bg-blue-50 hover:border-blue-200 cursor-pointer transition-colors"

--- a/website/src/pages/FileDiffView.tsx
+++ b/website/src/pages/FileDiffView.tsx
@@ -122,6 +122,9 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
       // store temporarily in dataset
       (window as any).__TRITONPARSE_rightHash = rightHash;
     }
+    // Note: leftLoadedUrl is intentionally omitted - we only read URL params on mount
+    // and when kernelsLeft changes, not when the prop changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [kernelsLeft]);
 
   // Load left URL when set (internal to FileDiffView)
@@ -149,6 +152,8 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
     if (leftLoadedUrlLocal) {
       loadLeft(leftLoadedUrlLocal);
     }
+    // Note: sess is stable (from context) and doesn't need to trigger re-runs
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [leftLoadedUrlLocal]);
 
   // Load right URL when set
@@ -176,6 +181,8 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
     if (rightLoadedUrl) {
       loadRight(rightLoadedUrl);
     }
+    // Note: sess is stable (from context) and doesn't need to trigger re-runs
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rightLoadedUrl]);
 
   // Hydrate session left from App props when coming from homepage/top bar load (including local file)

--- a/website/src/pages/FileDiffView.tsx
+++ b/website/src/pages/FileDiffView.tsx
@@ -139,12 +139,12 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
         sess.setLeftFromUrl(url, processed);
         // default to first kernel when loading new source
         setLeftIdx(0);
-        try { sess.setLeftIdx(0); } catch {}
+          try { sess.setLeftIdx(0); } catch { /* Session may not be ready */ }
         const leftHash = window.__TRITONPARSE_leftHash;
         if (leftHash) {
           const li = findKernelIndexByHash(leftHash, processed);
           if (li >= 0) setLeftIdx(li);
-          try { if (li >= 0) sess.setLeftIdx(li); } catch {}
+          try { if (li >= 0) sess.setLeftIdx(li); } catch { /* Session may not be ready */ }
         }
       } catch (e) {
         console.warn("[FDV] loadLeft(URL) error:", e);
@@ -201,7 +201,7 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
         }
         sess.setLeftIdx(Math.max(0, leftIdx));
       }
-    } catch {}
+    } catch { /* Ignore hydration errors - session state may be stale */ }
   }, [sess, kernelsLeft, leftLoadedUrl, leftIdx]);
 
   // Hydrate right from session when returning from preview (ensure right side is restored without reloading URL)
@@ -218,7 +218,7 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
           setRightLoadedFromLocal(true);
         }
       }
-    } catch {}
+    } catch { /* Ignore session restore errors */ }
   }, [sess.right]);
 
   // Compute union ir types and choose default ir if needed
@@ -434,16 +434,16 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
       sess.setLeftFromLocal(processed);
       // select first by default
       setLeftIdx(0);
-      try { sess.setLeftIdx(0); } catch {}
+      try { sess.setLeftIdx(0); } catch { /* Session may not be ready */ }
       const leftHash = window.__TRITONPARSE_leftHash;
       if (leftHash) {
         const li = findKernelIndexByHash(leftHash, processed);
         setLeftIdx(li >= 0 ? li : 0);
-        try { if (li >= 0) sess.setLeftIdx(li); } catch {}
+        try { if (li >= 0) sess.setLeftIdx(li); } catch { /* Session may not be ready */ }
       } else {
         setLeftIdx(0);
       }
-    } catch {}
+    } catch { /* Ignore file load errors */ }
   };
 
   return (
@@ -565,7 +565,7 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
             <select
               className="border border-gray-300 rounded px-3 py-2 bg-white w-full"
               value={leftIdx}
-              onChange={(e) => { const v = parseInt(e.target.value); setLeftIdx(v); try { sess.setLeftIdx(v); } catch {} }}
+              onChange={(e) => { const v = parseInt(e.target.value); setLeftIdx(v); try { sess.setLeftIdx(v); } catch { /* Ignore */ } }}
               disabled={leftArrayResolved.length === 0}
             >
               {leftArrayResolved.map((k, i) => (
@@ -580,7 +580,7 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
             <select
               className="border border-gray-300 rounded px-3 py-2 bg-white w-full"
               value={rightIdx}
-              onChange={(e) => { const v = parseInt(e.target.value); setRightIdx(v); try { sess.setRightIdx(v); } catch {} }}
+              onChange={(e) => { const v = parseInt(e.target.value); setRightIdx(v); try { sess.setRightIdx(v); } catch { /* Ignore */ } }}
               disabled={kernelsRight.length === 0}
             >
               {kernelsRight.map((k, i) => (

--- a/website/src/pages/FileDiffView.tsx
+++ b/website/src/pages/FileDiffView.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import DiffComparisonView from "../components/DiffComparisonView";
 import { useFileDiffSession } from "../context/FileDiffSession";
 import { ProcessedKernel, loadLogData, loadLogDataFromFile, processKernelData, getIRType } from "../utils/dataLoader";
+import "../types/global.d.ts";
 
 type DiffMode = "single" | "all";
 
@@ -113,14 +114,14 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
     // Left/Right kernel index by hash
     const leftHash = params.get(PARAM_KERNEL_HASH_A);
     const rightHash = params.get(PARAM_KERNEL_HASH_B);
-    if (leftHash) (window as any).__TRITONPARSE_leftHash = leftHash;
+    if (leftHash) window.__TRITONPARSE_leftHash = leftHash;
     const li = findKernelIndexByHash(leftHash, kernelsLeft);
     if (li >= 0) setLeftIdx(li);
 
     // right index will be set after right kernels loaded
     if (rightHash) {
       // store temporarily in dataset
-      (window as any).__TRITONPARSE_rightHash = rightHash;
+      window.__TRITONPARSE_rightHash = rightHash;
     }
     // Note: leftLoadedUrl is intentionally omitted - we only read URL params on mount
     // and when kernelsLeft changes, not when the prop changes
@@ -139,7 +140,7 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
         // default to first kernel when loading new source
         setLeftIdx(0);
         try { sess.setLeftIdx(0); } catch {}
-        const leftHash = (window as any).__TRITONPARSE_leftHash as string | undefined;
+        const leftHash = window.__TRITONPARSE_leftHash;
         if (leftHash) {
           const li = findKernelIndexByHash(leftHash, processed);
           if (li >= 0) setLeftIdx(li);
@@ -167,13 +168,14 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
         setKernelsRight(processed);
         sess.setRightFromUrl(url, processed);
         // set right index by hash if present
-        const rightHash = (window as any).__TRITONPARSE_rightHash as string | undefined;
+        const rightHash = window.__TRITONPARSE_rightHash;
         if (rightHash) {
           const ri = findKernelIndexByHash(rightHash, processed);
           if (ri >= 0) setRightIdx(ri);
         }
-      } catch (e: any) {
-        setErrorRight(e?.message || String(e));
+      } catch (e: unknown) {
+        const errorMessage = e instanceof Error ? e.message : String(e);
+        setErrorRight(errorMessage);
       } finally {
         setLoadingRight(false);
       }
@@ -401,15 +403,16 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
       setRightLoadedUrl(null); // do not persist json_b_url when loaded from local file
       sess.setRightFromLocal(processed);
       // select the first kernel or restore by hash if available
-      const rightHash = (window as any).__TRITONPARSE_rightHash as string | undefined;
+      const rightHash = window.__TRITONPARSE_rightHash;
       if (rightHash) {
         const ri = findKernelIndexByHash(rightHash, processed);
         setRightIdx(ri >= 0 ? ri : 0);
       } else {
         setRightIdx(0);
       }
-    } catch (e: any) {
-      setErrorRight(e?.message || String(e));
+    } catch (e: unknown) {
+      const errorMessage = e instanceof Error ? e.message : String(e);
+      setErrorRight(errorMessage);
     } finally {
       setLoadingRight(false);
     }
@@ -432,7 +435,7 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
       // select first by default
       setLeftIdx(0);
       try { sess.setLeftIdx(0); } catch {}
-      const leftHash = (window as any).__TRITONPARSE_leftHash as string | undefined;
+      const leftHash = window.__TRITONPARSE_leftHash;
       if (leftHash) {
         const li = findKernelIndexByHash(leftHash, processed);
         setLeftIdx(li >= 0 ? li : 0);
@@ -632,7 +635,7 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
               </label>
               <label className="inline-flex items-center gap-1 text-sm">
                 <span>Wrap</span>
-                <select className="border border-gray-300 rounded px-2 py-1" value={wordWrap} onChange={(e) => setWordWrap(e.target.value as any)}>
+                <select className="border border-gray-300 rounded px-2 py-1" value={wordWrap} onChange={(e) => setWordWrap(e.target.value as "off" | "on")}>
                   <option value="off">off</option>
                   <option value="on">on</option>
                 </select>

--- a/website/src/pages/IRAnalysis.tsx
+++ b/website/src/pages/IRAnalysis.tsx
@@ -6,6 +6,15 @@ interface IRAnalysisProps {
   selectedKernel: number;
 }
 
+/**
+ * Loop schedule entry with prologue, loop body, and epilogue
+ */
+interface LoopSchedule {
+  prologue?: string[];
+  loop_body?: string[];
+  epilogue?: string[];
+}
+
 const IRAnalysis: React.FC<IRAnalysisProps> = ({ kernels, selectedKernel }) => {
   if (kernels.length === 0) {
     return (
@@ -98,7 +107,7 @@ const IRAnalysis: React.FC<IRAnalysisProps> = ({ kernels, selectedKernel }) => {
               Software Pipelining Schedule
             </h3>
 
-            {loop_schedule.map((schedule: any, loopIndex: number) => {
+            {loop_schedule.map((schedule: LoopSchedule, loopIndex: number) => {
               const prologue = schedule?.prologue || [];
               const loopBody = schedule?.loop_body || [];
               const epilogue = schedule?.epilogue || [];

--- a/website/src/pages/KernelOverview.tsx
+++ b/website/src/pages/KernelOverview.tsx
@@ -18,7 +18,7 @@ interface KernelOverviewProps {
 /**
  * Determines if a metadata value is considered "long" and should be displayed at the end
  */
-const isLongValue = (value: any): boolean => {
+const isLongValue = (value: unknown): boolean => {
   const formattedString = formatMetadataValue(value);
   return formattedString.length > 50;
 };
@@ -28,7 +28,7 @@ const isLongValue = (value: any): boolean => {
  * @param value - The value to format
  * @returns Formatted string representation
  */
-const formatMetadataValue = (value: any): string => {
+const formatMetadataValue = (value: unknown): string => {
   if (value === null) {
     return "null";
   }
@@ -69,10 +69,20 @@ const MetadataItem: React.FC<MetadataItemProps> = ({
 );
 
 /**
+ * Stack entry interface for stack traces
+ */
+interface StackEntry {
+  filename: string | number | [string, number];
+  line: number;
+  name: string;
+  loc?: string;
+}
+
+/**
  * Gets the actual file path from a stack entry's filename
  * @param entry - The stack entry
  */
-const getSourceFilePath = (entry: any): string => {
+const getSourceFilePath = (entry: StackEntry): string => {
   if (typeof entry.filename === "string") {
     return entry.filename;
   }
@@ -245,7 +255,7 @@ const KernelOverview: React.FC<KernelOverviewProps> = ({
               <div className="grid grid-cols-[repeat(auto-fit,_minmax(180px,_1fr))] gap-3 mb-4">
                 {/* All short metadata fields */}
                 {Object.entries(kernel.metadata)
-                  .filter(([_key, value]) => !isLongValue(value))
+                  .filter(([, value]) => !isLongValue(value))
                   .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
                   .map(([key, value]) => {
                     return (
@@ -265,12 +275,12 @@ const KernelOverview: React.FC<KernelOverviewProps> = ({
               </div>
 
               {/* Long fields in separate section within same container */}
-              {Object.entries(kernel.metadata).filter(([_key, value]) =>
+              {Object.entries(kernel.metadata).filter(([, value]) =>
                 isLongValue(value)
               ).length > 0 && (
                 <div className="space-y-3 border-t border-gray-200 pt-4">
                   {Object.entries(kernel.metadata)
-                    .filter(([_key, value]) => isLongValue(value))
+                    .filter(([, value]) => isLongValue(value))
                     .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
                     .map(([key, value]) => (
                       <div key={key} className="w-full">
@@ -317,7 +327,7 @@ const KernelOverview: React.FC<KernelOverviewProps> = ({
                   </h4>
                   <div className="font-mono text-sm bg-gray-100 p-2 rounded">
                     {kernel.launchDiff.launch_index_map
-                      .map((r: any) =>
+                      .map((r: { start: number; end: number }) =>
                         r.start === r.end
                           ? `${r.start}`
                           : `${r.start}-${r.end}`
@@ -385,7 +395,7 @@ const KernelOverview: React.FC<KernelOverviewProps> = ({
                   </h4>
                   <div className="bg-white p-3 rounded-md border border-gray-200 overflow-auto resize-y h-80 min-h-24">
                     {Array.isArray(kernel.launchDiff.sames.stack) ? (
-                      kernel.launchDiff.sames.stack.map((entry: any, index: number) => (
+                      kernel.launchDiff.sames.stack.map((entry: StackEntry, index: number) => (
                         <div key={index} className="mb-1 font-mono text-sm">
                           <span className="text-blue-600">
                             {getSourceFilePath(entry)}

--- a/website/src/types/global.d.ts
+++ b/website/src/types/global.d.ts
@@ -1,0 +1,14 @@
+/**
+ * Global type declarations for TritonParse website
+ */
+
+declare global {
+  interface Window {
+    /** Temporary storage for left kernel hash during URL parsing */
+    __TRITONPARSE_leftHash?: string;
+    /** Temporary storage for right kernel hash during URL parsing */
+    __TRITONPARSE_rightHash?: string;
+  }
+}
+
+export {};

--- a/website/src/utils/dataLoader.ts
+++ b/website/src/utils/dataLoader.ts
@@ -288,7 +288,7 @@ export function parseLogData(textData: string): LogEntry[] {
                 if (parsedLine && typeof parsedLine === 'object') {
                     entries.push(parsedLine);
                 }
-            } catch (e) {
+            } catch {
                 console.warn(`Failed to parse line as JSON: ${line.substring(0, 100)}...`);
                 // Continue processing other lines even if one fails
             }
@@ -339,7 +339,7 @@ async function parseLogDataFromStream(stream: ReadableStream<Uint8Array>): Promi
                     if (parsedLine && typeof parsedLine === 'object') {
                         entries.push(parsedLine);
                     }
-                } catch (e) {
+                } catch {
                     console.warn(`Failed to parse final line as JSON: ${buffer.substring(0, 100)}...`);
                 }
             }
@@ -357,7 +357,7 @@ async function parseLogDataFromStream(stream: ReadableStream<Uint8Array>): Promi
                 if (parsedLine && typeof parsedLine === 'object') {
                     entries.push(parsedLine);
                 }
-            } catch (e) {
+            } catch {
                 console.warn(`Failed to parse line as JSON: ${line.substring(0, 100)}...`);
             }
         }

--- a/website/src/utils/dataLoader.ts
+++ b/website/src/utils/dataLoader.ts
@@ -77,7 +77,8 @@ export interface KernelMetadata {
     enable_fp_fusion?: boolean;
     launch_cooperative_grid?: boolean;
     supported_fp8_dtypes?: string[];
-    [key: string]: any; // For other metadata properties
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: any; // For other metadata properties - dynamic keys from trace
 }
 
 /**
@@ -91,7 +92,7 @@ export interface LaunchRange {
 /**
  * Distribution value with count and launch information
  */
-export interface DistributionValue<T = any> {
+export interface DistributionValue<T = unknown> {
     value: T;
     count: number;
     launches: LaunchRange[];
@@ -105,14 +106,15 @@ export interface SummaryDiff {
     summary_text: string;
 }
 
-export interface DistributionDiff<T = any> {
+export interface DistributionDiff<T = unknown> {
     diff_type: "distribution";
     values: DistributionValue<T>[];
 }
 
 export interface ArgumentDiff {
     diff_type: "argument_diff";
-    sames?: Record<string, any>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sames?: Record<string, any>; // Dynamic argument values from trace
     diffs?: Record<string, SummaryDiff | DistributionDiff>;
 }
 
@@ -147,7 +149,8 @@ export interface CompilationMetadata {
     global_scratch_align?: number;
     global_scratch_size?: number;
     hash?: string;
-    ir_override?: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ir_override?: any; // Dynamic IR override structure from trace
     launch_cooperative_grid?: boolean;
     launch_pdl?: boolean;
     max_num_imprecise_acc_default?: number;
@@ -156,7 +159,8 @@ export interface CompilationMetadata {
     num_ctas?: number;
     num_stages?: number;
     num_warps?: number;
-    ptx_options?: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ptx_options?: any; // Dynamic PTX options from trace
     ptx_version?: number | null;
     sanitize_overflow?: boolean;
     shared?: number;
@@ -166,11 +170,13 @@ export interface CompilationMetadata {
         arch?: number;
         warp_size?: number;
     };
-    tensordesc_meta?: any[];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tensordesc_meta?: any[]; // Dynamic tensor descriptor metadata
     tmem_size?: number;
     triton_version?: string;
     warp_size?: number;
-    [key: string]: any; // Allow additional unknown fields
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: any; // Allow additional unknown fields from trace
 }
 
 export interface IRAnalysisData {
@@ -184,9 +190,11 @@ export interface IRAnalysisData {
  */
 export interface ExtractedArg {
     type: string;
-    value?: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    value?: any; // Dynamic value from trace - type varies
     length?: number;
-    [key: string]: any; // Allow additional unknown fields
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: any; // Allow additional unknown fields from trace
 }
 
 /**
@@ -201,7 +209,8 @@ export interface LaunchSamesData {
     compilation_metadata?: CompilationMetadata;
     timestamp?: string;
     extracted_args?: Record<string, ExtractedArg>;
-    [key: string]: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: any; // Dynamic fields from trace
 }
 
 /**
@@ -316,7 +325,8 @@ function isGzipFile(buffer: ArrayBuffer): boolean {
  * @returns A promise that resolves to an array of LogEntry objects
  */
 async function parseLogDataFromStream(stream: ReadableStream<Uint8Array>): Promise<LogEntry[]> {
-    const reader = stream.pipeThrough(new TextDecoderStream() as any).getReader();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const reader = (stream.pipeThrough(new TextDecoderStream()) as any).getReader();
     let buffer = '';
     const entries: LogEntry[] = [];
 

--- a/website/src/utils/fbDetection.ts
+++ b/website/src/utils/fbDetection.ts
@@ -15,7 +15,7 @@ export const checkFbDirectoryExists = async (): Promise<boolean> => {
     
     // Only consider it successful if we get 200 AND it's not HTML fallback
     return response.ok && !isHtmlFallback;
-  } catch (error) {
+  } catch {
     // If the request fails, the directory likely doesn't exist
     return false;
   }

--- a/website/src/utils/safeImport.ts
+++ b/website/src/utils/safeImport.ts
@@ -7,6 +7,7 @@
  * Safely imports a module by path, returning null if it doesn't exist
  * Uses string concatenation to bypass static analysis while maintaining proper path resolution
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function safeImport(modulePath: string): Promise<any | null> {
   try {
     // Adjust path to account for safeImport.ts being in the utils directory


### PR DESCRIPTION


## Summary

Added explanatory comments to empty catch blocks in `FileDiffView.tsx`. These blocks are intentionally empty as they handle non-critical errors like session state not being ready during initialization.

## Changes

Added inline comments to 9 empty catch blocks explaining why the error is intentionally ignored:

| Location | Context | Comment Added |
|----------|---------|---------------|
| Line ~138 | `sess.setLeftIdx(0)` | `/* Session may not be ready */` |
| Line ~143 | `sess.setLeftIdx(li)` | `/* Session may not be ready */` |
| Line ~195 | useEffect hydration | `/* Ignore hydration errors - session state may be stale */` |
| Line ~212 | session restore | `/* Ignore session restore errors */` |
| Line ~427 | `sess.setLeftIdx(0)` | `/* Session may not be ready */` |
| Line ~432 | `sess.setLeftIdx(li)` | `/* Session may not be ready */` |
| Line ~436 | file load error | `/* Ignore file load errors */` |
| Line ~558 | select onChange | `/* Ignore */` |
| Line ~573 | select onChange | `/* Ignore */` |

## Files Modified

- `website/src/pages/FileDiffView.tsx`

## Lint Errors Fixed

9 `no-empty` errors.
