### PR TITLE
[website] PR: Fix Python Source Line Highlight Clearing

### DIFF
--- a/website/src/components/CodeComparisonView.tsx
+++ b/website/src/components/CodeComparisonView.tsx
@@ -376,6 +376,10 @@ const CodeComparisonView: React.FC<CodeComparisonViewProps> = ({
     const handlePythonLineClick = useCallback(
         (lineNumber: number) => {
             if (!pythonMapping) {
+                // No mapping available: highlight clicked Python line, clear IR panels
+                updateHighlights('left', []);
+                updateHighlights('right', []);
+                updateHighlights('python', [lineNumber]);
                 return;
             }
 
@@ -386,6 +390,10 @@ const CodeComparisonView: React.FC<CodeComparisonViewProps> = ({
 
             const mapping = pythonMapping[absoluteLineNumber.toString()];
             if (!mapping) {
+                // No mapping for this line: highlight clicked Python line, clear IR panels
+                updateHighlights('left', []);
+                updateHighlights('right', []);
+                updateHighlights('python', [lineNumber]);
                 return;
             }
 
@@ -414,7 +422,8 @@ const CodeComparisonView: React.FC<CodeComparisonViewProps> = ({
             pythonInfo,
             calculateMappedLines,
             leftPanel_data.title,
-            rightPanel_data.title
+            rightPanel_data.title,
+            updateHighlights
         ]
     );
 


### PR DESCRIPTION
## Summary

Fix inconsistent highlighting behavior in the IR code view when clicking Python source lines that have no corresponding IR mappings.

## Problem

In the IR code view interface, when clicking lines in the Python source panel:

| Scenario | Previous Behavior | Expected Behavior |
|----------|------------------|-------------------|
| Line **has** IR mapping | ✅ Clicked line highlights, corresponding IR lines highlight | Correct |
| Line **has no** IR mapping | ❌ Nothing happens, previous highlights remain | Should clear highlights |

This created a confusing user experience where clicking a line without mappings appeared to do nothing, leaving stale highlights from a previous selection visible.

## Root Cause Analysis

**File**: `website/src/components/CodeComparisonView.tsx`
**Function**: `handlePythonLineClick` (lines 376-419)

The function had early `return` statements that exited without updating highlight state:

```typescript
const handlePythonLineClick = useCallback(
    (lineNumber: number) => {
        if (!pythonMapping) {
            return;  // ← BUG: Returns without clearing highlights
        }
        // ...
        const mapping = pythonMapping[absoluteLineNumber.toString()];
        if (!mapping) {
            return;  // ← BUG: Returns without clearing highlights
        }
        // Only reaches highlight update code if mapping exists
    },
    [...]
);
```

**Contrast with correct behavior in `handlePanelLineClick`** (lines 332-339):

```typescript
if (!sourceMapping || !sourceMapping[lineNumber]) {
    // ✅ CORRECT: Clears other panels, highlights clicked line
    updateHighlights(panelType, [lineNumber]);
    updateHighlights(isLeftPanel ? 'right' : 'left', []);
    updateHighlights('python', []);
    return;
}
```

## Solution

Modified `handlePythonLineClick` to call `updateHighlights` before early returns, matching the behavior of `handlePanelLineClick`:

```typescript
const handlePythonLineClick = useCallback(
    (lineNumber: number) => {
        if (!pythonMapping) {
            // NEW: Highlight clicked Python line, clear IR panels
            updateHighlights('left', []);
            updateHighlights('right', []);
            updateHighlights('python', [lineNumber]);
            return;
        }

        const absoluteLineNumber = pythonInfo.isFullFileMode
            ? lineNumber
            : lineNumber + pythonInfo.start_line - 1;

        const mapping = pythonMapping[absoluteLineNumber.toString()];
        if (!mapping) {
            // NEW: Highlight clicked Python line, clear IR panels
            updateHighlights('left', []);
            updateHighlights('right', []);
            updateHighlights('python', [lineNumber]);
            return;
        }

        // ... rest of function unchanged
    },
    [
        pythonMapping,
        pythonInfo,
        calculateMappedLines,
        leftPanel_data.title,
        rightPanel_data.title,
        updateHighlights  // Added to dependency array
    ]
);
```

## Changes

| File | Change |
|------|--------|
| `website/src/components/CodeComparisonView.tsx` | Added highlight clearing logic for no-mapping cases in `handlePythonLineClick` |

## Behavior After Fix

| Scenario | New Behavior |
|----------|-------------|
| Line **has** IR mapping | Clicked Python line highlights, corresponding IR lines highlight |
| Line **has no** IR mapping | Clicked Python line highlights, IR panel highlights are **cleared** |

This provides consistent visual feedback: clicking any line always results in that line being highlighted, and stale highlights from previous selections are always cleared.

## Testing

1. Open the TritonParse website
2. Navigate to IR code view with a loaded trace
3. Click a Python source line that has IR mappings
   - Verify: Python line and corresponding IR lines highlight
4. Click a Python source line **without** IR mappings (e.g., comments, blank lines)
   - Verify: Clicked Python line highlights
   - Verify: Previous IR panel highlights are cleared
5. Run `npm run lint` to verify no lint errors

## Alternative Considered

**Option 2**: Use a different color to indicate "no mapping" state.

This was rejected because:
- More complex to implement (requires additional CSS and state)
- Less intuitive than simply clearing highlights
- The current approach matches the existing behavior in `handlePanelLineClick`
