### PR TITLE
Display Python source line numbers from original file offset

### DIFF
--- a/website/src/components/CodeViewer.tsx
+++ b/website/src/components/CodeViewer.tsx
@@ -158,6 +158,7 @@ interface CodeViewerProps {
   functionEndLine?: number; // Function definition end line (for highlighting in full file mode)
   initialScrollToLine?: number; // Line number to scroll to on initial render
   onScrollComplete?: () => void; // Callback fired when initial scroll completes
+  startingLineNumber?: number; // Starting line number for display (default: 1)
 }
 
 /**
@@ -586,6 +587,7 @@ const StandardCodeViewer: React.FC<CodeViewerProps> = ({
   onScrollComplete,
   functionStartLine,
   functionEndLine,
+  startingLineNumber = 1,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const hasScrolledRef = useRef(false);
@@ -645,8 +647,12 @@ const StandardCodeViewer: React.FC<CodeViewerProps> = ({
         language={highlighterLanguage}
         style={theme === "light" ? oneLight : oneDark}
         showLineNumbers
+        startingLineNumber={startingLineNumber}
         wrapLines
         lineProps={(lineNumber) => {
+          // lineNumber from SyntaxHighlighter already includes startingLineNumber offset
+          // so it represents the actual/absolute line number to display and use
+
           // Check if line is in function range
           const isInFunctionRange =
             functionStartLine !== undefined &&


### PR DESCRIPTION
Summary:
Fixes https://github.com/meta-pytorch/tritonparse/issues/74

When viewing IR code with Python source mapping, the Python source panel now displays line numbers starting from the original file's `start_line` instead of 1.

This makes IR-to-Python line number correlation intuitive - if TTIR/PTX references line 18, the Python panel also shows line 18, eliminating the need for mental arithmetic.

Changes:
- Added `startingLineNumber` prop to CodeViewer component
- Pass `pythonInfo.start_line` as startingLineNumber for Python CodeViewer
- Simplified `calculatePythonLines` to return absolute line numbers directly
- Simplified `handlePythonLineClick` to use line numbers directly (no conversion needed)

Differential Revision: D89905338


