### PR TITLE
Fix long kernel name overflow in IR Code view

### DIFF
--- a/website/src/components/CodeComparisonView.tsx
+++ b/website/src/components/CodeComparisonView.tsx
@@ -448,9 +448,9 @@ const CodeComparisonView: React.FC<CodeComparisonViewProps> = ({
                     flexDirection: "column",
                     position: "relative"
                 }}>
-                    <div className="bg-blue-600 text-white p-2 font-medium flex justify-between items-center">
-                        <span>{leftPanel_data.title}</span>
-                        <div className="flex items-center gap-2">
+                    <div className="bg-blue-600 text-white p-2 font-medium flex justify-between items-center min-w-0">
+                        <span className="truncate flex-1 min-w-0 mr-2" title={leftPanel_data.title}>{leftPanel_data.title}</span>
+                        <div className="flex items-center gap-2 flex-shrink-0">
                             <span className="text-sm bg-blue-700 px-2 py-1 rounded">
                                 {leftPanel_data.displayLanguage}
                             </span>
@@ -488,9 +488,9 @@ const CodeComparisonView: React.FC<CodeComparisonViewProps> = ({
                     flexDirection: "column",
                     position: "relative"
                 }}>
-                    <div className="bg-blue-600 text-white p-2 font-medium flex justify-between items-center">
-                        <span>{rightPanel_data.title}</span>
-                        <div className="flex items-center gap-2">
+                    <div className="bg-blue-600 text-white p-2 font-medium flex justify-between items-center min-w-0">
+                        <span className="truncate flex-1 min-w-0 mr-2" title={rightPanel_data.title}>{rightPanel_data.title}</span>
+                        <div className="flex items-center gap-2 flex-shrink-0">
                             <span className="text-sm bg-blue-700 px-2 py-1 rounded">
                                 {rightPanel_data.displayLanguage}
                             </span>
@@ -529,13 +529,13 @@ const CodeComparisonView: React.FC<CodeComparisonViewProps> = ({
                             flexDirection: "column",
                             position: "relative"
                         }}>
-                            <div className="bg-blue-600 text-white p-2 font-medium flex justify-between items-center">
-                                <span>
+                            <div className="bg-blue-600 text-white p-2 font-medium flex justify-between items-center min-w-0">
+                                <span className="truncate flex-1 min-w-0 mr-2" title={pythonInfo.isFullFileMode ? "Python Source (Full File)" : "Python Source"}>
                                     {pythonInfo.isFullFileMode
                                         ? "Python Source (Full File)"
                                         : "Python Source"}
                                 </span>
-                                <div className="flex items-center gap-2">
+                                <div className="flex items-center gap-2 flex-shrink-0">
                                     <span className="text-sm bg-blue-700 px-2 py-1 rounded">
                                         python
                                     </span>


### PR DESCRIPTION
Summary:
When kernel names are very long (e.g., `triton_red_fused_expand_index_select_mul_permute_select_sum_triu_unsqueeze_view_0.ttgir`), they would overflow and cause layout issues in the IR Code view panel headers, potentially overlapping with the language badge and copy button.

This change fixes the issue by:
1. Adding `truncate`, `flex-1`, `min-w-0` classes to the title span to enable text truncation with ellipsis
2. Adding `title` attribute to show the full kernel name on hover as a tooltip
3. Adding `flex-shrink-0` to the right-side button container to prevent it from being compressed
4. Adding `min-w-0` to the parent container to allow flex children to shrink properly

The fix is applied to all three panel headers: left IR panel, right IR panel, and Python Source panel.

before:
 {F1984430636} 

after:
 {F1984430639}

Differential Revision: D90133385


