### PR TITLE
Add horizontal scroll tip banner for code panels

### DIFF
--- a/tests/example_output/sass_test_data/test_kernel.sass
+++ b/tests/example_output/sass_test_data/test_kernel.sass
@@ -1,0 +1,78 @@
+Function:test_kernel
+	//## File "/home/test/tritonparse/tests/gpu/test_structured_logging.py", line 140
+	//## File ".nv_debug_ptx_txt", line 19
+        /*0000*/                   LDC R1, c[0x0][0x28] ;
+	//## File "/home/test/tritonparse/tests/gpu/test_structured_logging.py", line 143
+	//## File ".nv_debug_ptx_txt", line 37
+        /*0010*/                   S2R R0, SR_TID.X ;
+	//## File "/home/test/tritonparse/tests/gpu/test_structured_logging.py", line 148
+	//## File ".nv_debug_ptx_txt", line 57
+        /*0020*/                   LDC.64 R4, c[0x0][0x218] ;
+	//## File "/home/test/tritonparse/tests/gpu/test_structured_logging.py", line 144
+	//## File ".nv_debug_ptx_txt", line 43
+        /*0030*/                   ULDC UR4, c[0x0][0x220] ;
+	//## File "/home/test/tritonparse/tests/gpu/test_structured_logging.py", line 146
+	//## File ".nv_debug_ptx_txt", line 51
+        /*0040*/                   BSSY B0, `(.L_x_0) ;
+	//## File "/home/test/tritonparse/tests/gpu/test_structured_logging.py", line 141
+	//## File ".nv_debug_ptx_txt", line 32
+        /*0050*/                   S2R R7, SR_CTAID.X ;
+	//## File "/home/test/tritonparse/tests/gpu/test_structured_logging.py", line 146
+	//## File ".nv_debug_ptx_txt", line 51
+        /*0060*/                   CS2R R2, SRZ ;
+	//## File "/home/test/tritonparse/tests/gpu/test_structured_logging.py", line 143
+	//## File ".nv_debug_ptx_txt", line 38
+        /*0070*/                   SHF.L.U32 R0, R0, 0x1, RZ ;
+	//## File ".nv_debug_ptx_txt", line 39
+        /*0080*/                   LOP3.LUT R0, R0, 0xfe, RZ, 0xc0, !PT ;
+	//## File ".nv_debug_ptx_txt", line 41
+        /*0090*/                   LEA R7, R7, R0, 0x8 ;
+	//## File "/home/test/tritonparse/tests/gpu/test_structured_logging.py", line 144
+	//## File ".nv_debug_ptx_txt", line 43
+        /*00a0*/                   ISETP.GE.AND P0, PT, R7.reuse, UR4, PT ;
+	//## File ".nv_debug_ptx_txt", line 19
+        /*00b0*/                   ULDC.64 UR4, c[0x0][0x208] ;
+	//## File "/home/test/tritonparse/tests/gpu/test_structured_logging.py", line 148
+	//## File ".nv_debug_ptx_txt", line 57
+        /*00c0*/                   IMAD.WIDE R4, R7, 0x4, R4 ;
+	//## File "/home/test/tritonparse/tests/gpu/test_structured_logging.py", line 146
+	//## File ".nv_debug_ptx_txt", line 51
+        /*00d0*/               @P0 BRA `(.L_x_1) ;
+	//## File ".nv_debug_ptx_txt", line 46
+        /*00e0*/                   LDC.64 R2, c[0x0][0x210] ;
+        /*00f0*/                   IMAD.WIDE R2, R7, 0x4, R2 ;
+	//## File ".nv_debug_ptx_txt", line 51
+        /*0100*/                   LDG.E.64 R2, desc[UR4][R2.64] ;
+.L_x_1:
+        /*0110*/                   BSYNC B0 ;
+.L_x_0:
+	//## File "/home/test/tritonparse/tests/gpu/test_structured_logging.py", line 148
+	//## File ".nv_debug_ptx_txt", line 60
+        /*0120*/               @P0 EXIT ;
+	//## File "/home/test/tritonparse/tests/gpu/test_structured_logging.py", line 147
+	//## File ".nv_debug_ptx_txt", line 54
+        /*0130*/                   FADD R2, R2, 1 ;
+	//## File ".nv_debug_ptx_txt", line 55
+        /*0140*/                   FADD R3, R3, 1 ;
+	//## File "/home/test/tritonparse/tests/gpu/test_structured_logging.py", line 148
+	//## File ".nv_debug_ptx_txt", line 60
+        /*0150*/                   STG.E.64 desc[UR4][R4.64], R2 ;
+	//## File ".nv_debug_ptx_txt", line 63
+        /*0160*/                   EXIT ;
+.L_x_2:
+        /*0170*/                   BRA `(.L_x_2);
+        /*0180*/                   NOP;
+        /*0190*/                   NOP;
+        /*01a0*/                   NOP;
+        /*01b0*/                   NOP;
+        /*01c0*/                   NOP;
+        /*01d0*/                   NOP;
+        /*01e0*/                   NOP;
+        /*01f0*/                   NOP;
+.L_x_3:
+
+
+//--------------------- SYMBOLS --------------------------
+
+	.type		.nv.reservedSmem.offset0,@object
+	.size		.nv.reservedSmem.offset0,0x4

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -36,6 +36,20 @@ def get_test_ndjson_file():
     return gz_file
 
 
+def get_sass_test_file(filename: str) -> Path:
+    """Get path to SASS test data file.
+
+    Args:
+        filename: Name of the file in sass_test_data directory (e.g., "test_kernel.sass")
+
+    Returns:
+        Path to the test file
+    """
+    test_file = Path(__file__).parent / "example_output/sass_test_data" / filename
+    assert test_file.exists(), f"Test file not found: {test_file}"
+    return test_file
+
+
 def setup_temp_reproduce_dir():
     """Setup temporary directory for reproduce tests."""
     temp_dir = tempfile.mkdtemp()

--- a/tritonparse/parse/ir_parser.py
+++ b/tritonparse/parse/ir_parser.py
@@ -34,6 +34,10 @@ AMDGCN_LOC_PATTERN = re.compile(
     r".*loc\s+(\d+)\s+(\d+)\s+(\d+)(?:\s+[^;]*)?;\s*(.+?):(\d+):(\d+)"
 )
 
+# the definition of the SASS source mapping pattern.
+# Example: //## File "/path/to/source.py", line 188
+SASS_LOC_PATTERN = re.compile(r'//## File "([^"]+)", line (\d+)')
+
 
 # alias loc definitions in TTGIR/TTIR
 # Example: #loc16 = loc("pid"(#loc2))
@@ -208,6 +212,61 @@ def extract_loc_definitions(ir_content: str) -> Dict[str, Dict[str, Any]]:
     return locations
 
 
+def extract_sass_mappings(sass_content: str) -> Dict[str, Dict[str, Any]]:
+    """
+    Extract source mappings from SASS content.
+
+    SASS format:
+        Function:kernel_name
+                //## File "/path/to/source.py", line 188
+                //## File ".nv_debug_ptx_txt", line 19    # Skip this line
+                        /*0000*/                   MOV R1, c[0x0][0x28] ;
+
+    Args:
+        sass_content (str): The content of the SASS file as a string.
+
+    Returns:
+        Dict[str, Dict[str, Any]]: A dictionary mapping line numbers to their corresponding
+        source file, line numbers, and column numbers.
+    """
+    mappings = {}
+    current_source_info = None
+
+    lines = sass_content.split("\n")
+
+    for line_num, line in enumerate(lines, 1):
+        # Skip lines related to .nv_debug_ptx_txt - these cannot be mapped to Python source
+        if ".nv_debug_ptx_txt" in line:
+            continue
+
+        # Check if this is a source location comment
+        match = SASS_LOC_PATTERN.match(line.strip())
+        if match:
+            file_path, source_line = match.groups()
+            current_source_info = {
+                "file": file_path,
+                "line": int(source_line),
+                "column": 0,  # SASS comments don't include column info
+            }
+            # Add the comment line itself to mappings so it can be highlighted
+            mappings[str(line_num)] = {
+                "file": file_path,
+                "line": int(source_line),
+                "column": 0,
+                "sass_line": line_num,
+            }
+        # Check if this is a SASS instruction line (contains /*address*/ format)
+        elif current_source_info and re.match(r".*\/\*[0-9a-fA-F]+\*\/.*", line):
+            mappings[str(line_num)] = {
+                "file": current_source_info["file"],
+                "line": current_source_info["line"],
+                "column": current_source_info["column"],
+                "sass_line": line_num,
+            }
+
+    return mappings
+
+
 def extract_code_locations(ir_content: str) -> Dict[int, str]:
     """
     Extracts code location mappings from the given IR content.
@@ -236,7 +295,7 @@ def extract_code_locations(ir_content: str) -> Dict[int, str]:
 
 
 def extract_ptx_amdgcn_mappings(
-    content: str, other_mappings: List[Any] = None, ir_type: str = "ptx"
+    content: str, other_mappings: List[Any] | None = None, ir_type: str = "ptx"
 ) -> Dict[str, Dict[str, Any]]:
     """
     Extract mappings from PTX code where `.loc` directives provide source file and line info.

--- a/tritonparse/parse/trace_processor.py
+++ b/tritonparse/parse/trace_processor.py
@@ -22,7 +22,7 @@ logger = get_logger("SourceMapping")
 
 
 def generate_source_mappings(
-    ir_content: str, ir_type: str, other_mappings: List[Any] = None
+    ir_content: str, ir_type: str, other_mappings: List[Any] | None = None
 ) -> Dict[str, Dict[str, Any]]:
     """
     Generate source mappings from intermediate representation (IR) content to the source file.
@@ -52,6 +52,10 @@ def generate_source_mappings(
         other_mappings = []
     if ir_type == "ptx" or ir_type == "amdgcn":
         return extract_ptx_amdgcn_mappings(ir_content, other_mappings, ir_type)
+    elif ir_type == "sass":
+        from .ir_parser import extract_sass_mappings
+
+        return extract_sass_mappings(ir_content)
 
     loc_defs = extract_loc_definitions(ir_content)
     logger.debug(f"Found {len(loc_defs)} #loc definitions")
@@ -116,7 +120,7 @@ def process_ir(
     key: str,
     file_content: Dict[str, str],
     file_path: Dict[str, str],
-    other_mappings: List[Any] = None,
+    other_mappings: List[Any] | None = None,
 ):
     ir_content = load_ir_contents(key, file_content, file_path)
     if not ir_content:
@@ -151,18 +155,20 @@ def parse_single_trace_content(trace_content: str) -> str:
         ttgir_key = next((k for k in file_content if k.endswith(".ttgir")), None)
         ptx_key = next((k for k in file_content if k.endswith(".ptx")), None)
         amdgcn_key = next((k for k in file_content if k.endswith(".amdgcn")), None)
+        sass_key = next((k for k in file_content if k.endswith(".sass")), None)
         # Skip if no IR files found
-        if not (ttir_key or ttgir_key or ptx_key or amdgcn_key):
+        if not (ttir_key or ttgir_key or ptx_key or amdgcn_key or sass_key):
             logger.warning("No IR files found in the payload.")
             return trace_content
 
-        # generate ttir->source, ttgir->source, ptx->source
+        # generate ttir->source, ttgir->source, ptx->source, sass->source
         ttir_map = process_ir(ttir_key, file_content, file_path)
         ttgir_map = process_ir(ttgir_key, file_content, file_path)
         ptx_map = process_ir(ptx_key, file_content, file_path, [ttir_map, ttgir_map])
         amdgcn_map = process_ir(
             amdgcn_key, file_content, file_path, [ttir_map, ttgir_map]
         )
+        sass_map = process_ir(sass_key, file_content, file_path, [ttir_map, ttgir_map])
 
         # Create bidirectional mappings between all IR types
         ir_maps = {
@@ -170,6 +176,7 @@ def parse_single_trace_content(trace_content: str) -> str:
             "ttgir": ttgir_map,
             "ptx": ptx_map,
             "amdgcn": amdgcn_map,
+            "sass": sass_map,
         }
 
         # Create mappings between all pairs of IR types
@@ -199,6 +206,7 @@ def parse_single_trace_content(trace_content: str) -> str:
                 (ttgir_key, ttgir_map),
                 (ptx_key, ptx_map),
                 (amdgcn_key, amdgcn_map),
+                (sass_key, sass_map),
             ]
 
             for key, mapping in ir_keys_and_maps:
@@ -213,6 +221,7 @@ def parse_single_trace_content(trace_content: str) -> str:
             "ttgir": ttgir_map,
             **({"ptx": ptx_map} if ptx_map else {}),
             **({"amdgcn": amdgcn_map} if amdgcn_map else {}),
+            **({"sass": sass_map} if sass_map else {}),
             "python": py_map,
         }
     # NDJSON format requires a newline at the end of each line

--- a/website/src/components/CodeComparisonView.tsx
+++ b/website/src/components/CodeComparisonView.tsx
@@ -1,6 +1,6 @@
 // (c) Meta Platforms, Inc. and affiliates.
 
-import React, { useCallback, useMemo, useRef } from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import { Panel, Group, Separator } from "react-resizable-panels";
 import CodeViewer from "./CodeViewer";
 import CopyCodeButton from "./CopyCodeButton";
@@ -437,10 +437,66 @@ const CodeComparisonView: React.FC<CodeComparisonViewProps> = ({
         [handlePanelLineClick]
     );
 
+    // ==================== Scroll Tip State ====================
+
+    const [showScrollTip, setShowScrollTip] = useState(() => {
+        if (typeof window !== 'undefined') {
+            return localStorage.getItem('tritonparse_hideScrollTip') !== 'true';
+        }
+        return true;
+    });
+
+    const handleDismissScrollTip = useCallback(() => {
+        setShowScrollTip(false);
+        if (typeof window !== 'undefined') {
+            localStorage.setItem('tritonparse_hideScrollTip', 'true');
+        }
+    }, []);
+
     // ==================== Render ====================
 
     return (
-        <Group orientation="horizontal" style={{ height: '100%' }}>
+        <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+            {showScrollTip && (
+                <div style={{
+                    backgroundColor: '#e7f3ff',
+                    borderBottom: '1px solid #b3d7ff',
+                    padding: '6px 16px',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    fontSize: '13px',
+                    color: '#0066cc',
+                    flexShrink: 0
+                }}>
+                    <span>
+                        💡 Tip: Use <kbd style={{
+                            backgroundColor: '#f0f0f0',
+                            border: '1px solid #ccc',
+                            borderRadius: '3px',
+                            padding: '2px 6px',
+                            fontFamily: 'monospace',
+                            fontSize: '12px',
+                            margin: '0 2px'
+                        }}>Shift</kbd> + Mouse Wheel to scroll horizontally
+                    </span>
+                    <button
+                        onClick={handleDismissScrollTip}
+                        style={{
+                            background: 'none',
+                            border: 'none',
+                            cursor: 'pointer',
+                            fontSize: '16px',
+                            color: '#666',
+                            padding: '0 4px'
+                        }}
+                        title="Dismiss tip"
+                    >
+                        ✕
+                    </button>
+                </div>
+            )}
+            <Group orientation="horizontal" style={{ flex: 1, minHeight: 0 }}>
             {/* Left Panel */}
             <Panel defaultSize={33} minSize={20}>
                 <div style={{
@@ -570,6 +626,7 @@ const CodeComparisonView: React.FC<CodeComparisonViewProps> = ({
                 </>
             )}
         </Group>
+        </div>
     );
 };
 

--- a/website/src/components/CodeComparisonView.tsx
+++ b/website/src/components/CodeComparisonView.tsx
@@ -250,7 +250,8 @@ const CodeComparisonView: React.FC<CodeComparisonViewProps> = ({
                 { type: "ttir", property: "ttir_lines" },
                 { type: "ptx", property: "ptx_lines" },
                 { type: "llir", property: "llir_lines" },
-                { type: "amdgcn", property: "amdgcn_lines" }
+                { type: "amdgcn", property: "amdgcn_lines" },
+                { type: "sass", property: "sass_lines" }
             ];
 
             for (const { type, property } of irTypesToCheck) {

--- a/website/src/components/CodeViewer.tsx
+++ b/website/src/components/CodeViewer.tsx
@@ -179,6 +179,8 @@ export const mapLanguageToHighlighter = (language: string): string => {
     return 'ptx';
   } else if (lowerCaseLanguage.endsWith("amdgcn")) {
     return 'amdgcn';
+  } else if (lowerCaseLanguage.endsWith("sass")) {
+    return 'asm';  // SASS is NVIDIA assembly, use generic asm highlighting
   } else if (lowerCaseLanguage === "python") {
     return 'python';
   }

--- a/website/src/utils/dataLoader.ts
+++ b/website/src/utils/dataLoader.ts
@@ -12,11 +12,13 @@ export interface SourceMapping {
     ptx_line?: number;
     amdgcn_line?: number;
     llir_line?: number;
+    sass_line?: number;
     ptx_lines?: number[]; // Array of corresponding PTX lines
     ttir_lines?: number[]; // Array of corresponding TTIR lines
     ttgir_lines?: number[]; // Array of corresponding TTGIR lines
     llir_lines?: number[]; // Array of corresponding LLIR lines
     amdgcn_lines?: number[]; // Array of corresponding AMDGCN lines
+    sass_lines?: number[]; // Array of corresponding SASS lines
     // New fields for location alias support
     type?: string; // Type of mapping entry, e.g., "loc_def" for loc definition lines
     kind?: string; // Deprecated alias for type, kept for backward compatibility

--- a/website/src/utils/irLanguage.ts
+++ b/website/src/utils/irLanguage.ts
@@ -24,6 +24,8 @@ export const getDisplayLanguage = (irType: string): string => {
     return "JSON";
   } else if (irType.toLowerCase().endsWith("amdgcn")) {
     return "AMDGCN (AMD GCN Assembly)";
+  } else if (irType.toLowerCase().endsWith("sass")) {
+    return "SASS (NVIDIA Shader Assembly)";
   } else {
     return irType;
   }


### PR DESCRIPTION
Summary:
Code panels displaying IR content (TTIR, TTGIR, PTX, SASS, etc.) may contain long lines that extend beyond the visible viewport. Since horizontal scrollbars appear at the bottom of the content (which could be thousands of lines down), users may not realize they can scroll horizontally.

This change adds a dismissible tip banner at the top of the code comparison view that informs users they can use Shift + Mouse Wheel to scroll horizontally. The tip:
- Appears by default on first visit
- Can be dismissed by clicking the close button
- Remembers the user's preference in localStorage (key: `tritonparse_hideScrollTip`)
- Uses a non-intrusive light blue design that matches the existing UI

This is a simple UX improvement that helps users discover the horizontal scroll functionality without requiring complex changes to the scroll container architecture.

Differential Revision: D90263088
