### PR TITLE
Add --embed-context flag for standalone reproducer scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,10 +52,6 @@ jobs:
               run: |
                   make format-check || (echo "❌ Format check failed. Please run 'make format' to fix formatting issues, then commit the changes." && echo "📖 For detailed formatting guide, see: https://github.com/meta-pytorch/tritonparse/wiki/05.-Code-Formatting" && exit 1)
 
-            - name: Check linting
-              run: |
-                  make lint-check || (echo "❌ Linting failed. Please run 'make format' to fix formatting issues, then commit the changes." && echo "📖 For detailed formatting guide, see: https://github.com/meta-pytorch/tritonparse/wiki/05.-Code-Formatting" && exit 1)
-
     # GPU tests - runs on GPU runner with full Triton from source
     # Note: CPU tests (tests/cpu/) are run as part of GPU jobs with TEST_TYPE=all
     test-from-source:

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,12 @@
 # Makefile for tritonparse project
 
-.PHONY: help format format-check lint lint-check test test-cuda clean install-dev website-install website-lint website-build website-build-single website-dev
+.PHONY: help format format-check test test-cuda clean install-dev website-install website-lint website-build website-build-single website-dev
 
 # Default target
 help:
 	@echo "Available targets:"
 	@echo "  format           - Format all Python files"
 	@echo "  format-check     - Check formatting without making changes"
-	@echo "  lint             - Run all linters"
-	@echo "  lint-check       - Check linting without making changes"
 	@echo "  test             - Run tests (CPU only)"
 	@echo "  test-cuda        - Run tests (including CUDA tests)"
 	@echo "  clean            - Clean up cache files"
@@ -29,17 +27,6 @@ format:
 format-check:
 	@echo "Checking formatting..."
 	python -m tritonparse.tools.format_fix --check-only --verbose
-
-# Linting targets
-lint:
-	@echo "Running linters..."
-	ruff check .
-	black --check .
-
-lint-check:
-	@echo "Checking linting..."
-	ruff check --diff .
-	black --check --diff .
 
 # Testing targets
 test:
@@ -62,7 +49,7 @@ clean:
 
 install-dev:
 	@echo "Installing development dependencies..."
-	pip install -U black usort ruff coverage
+	pip install -e ".[dev]"
 
 # Website targets
 website-install:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,17 +25,24 @@ pytorch-triton = [
 test = [
     "coverage>=7.0.0",
 ]
+dev = [
+    "ufmt==2.9.0",
+    "usort==1.1.0",
+    "ruff-api==0.2.0",
+    "ruff>=0.4.0",
+    "coverage>=7.0.0",
+]
 
 [tool.setuptools.packages.find]
 include = ["tritonparse*"]
 
-[tool.black]
-line-length = 88
-target-version = ["py310"]
-
 [tool.ufmt]
-formatter = "black"
+formatter = "ruff-api"
 sorter = "usort"
+
+[tool.ruff]
+line-length = 88
+target-version = "py310"
 
 [tool.usort]
 first_party_detection = false

--- a/tests/gpu/test_reproducer_e2e.py
+++ b/tests/gpu/test_reproducer_e2e.py
@@ -19,7 +19,7 @@ from pathlib import Path
 import torch
 import triton  # @manual=//triton:triton
 import tritonparse.structured_logging
-from tests.test_utils import GPUTestBase, skip_in_fbcode
+from tests.test_utils import GPUTestBase
 from tritonparse.reproducer.orchestrator import reproduce
 from tritonparse.shared_vars import TEST_KEEP_OUTPUT
 from tritonparse.tools.prettify_ndjson import load_ndjson
@@ -28,7 +28,6 @@ from tritonparse.tools.prettify_ndjson import load_ndjson
 class TestReproducerE2E(GPUTestBase):
     """End-to-end tests for reproducer functionality."""
 
-    @skip_in_fbcode
     def test_reproducer_end_to_end(self):
         """End-to-end test for reproducer: generate logs, build script, run it."""
 

--- a/tests/gpu/test_reproducer_e2e.py
+++ b/tests/gpu/test_reproducer_e2e.py
@@ -28,39 +28,43 @@ from tritonparse.tools.prettify_ndjson import load_ndjson
 class TestReproducerE2E(GPUTestBase):
     """End-to-end tests for reproducer functionality."""
 
-    def test_reproducer_end_to_end(self):
-        """End-to-end test for reproducer: generate logs, build script, run it."""
+    # Kernel source code used by all tests
+    KERNEL_SRC = (
+        "import triton\n"
+        "import triton.language as tl\n"
+        "import torch\n"
+        "\n"
+        "@triton.jit\n"
+        "def add_kernel(x_ptr, y_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):\n"
+        "    pid = tl.program_id(axis=0)\n"
+        "    block_start = pid * BLOCK_SIZE\n"
+        "    offsets = block_start + tl.arange(0, BLOCK_SIZE)\n"
+        "    mask = offsets < n_elements\n"
+        "    x = tl.load(x_ptr + offsets, mask=mask)\n"
+        "    y = tl.load(y_ptr + offsets, mask=mask)\n"
+        "    tl.store(out_ptr + offsets, x + y, mask=mask)\n"
+    )
 
-        # 1) Prepare temp dirs
+    def _setup_temp_dirs(self):
+        """Create temporary directory structure for tests."""
         temp_dir = tempfile.mkdtemp()
         logs_dir = os.path.join(temp_dir, "logs")
         out_dir = os.path.join(temp_dir, "repro_output")
+        kernel_dir = os.path.join(temp_dir, "kernels")
         os.makedirs(logs_dir, exist_ok=True)
         os.makedirs(out_dir, exist_ok=True)
-
-        # 2) Write a simple module-level Triton kernel to a temp file
-        kernel_dir = os.path.join(temp_dir, "kernels")
         os.makedirs(kernel_dir, exist_ok=True)
-        kernel_file = os.path.join(kernel_dir, "simple_kernel.py")
-        kernel_src = (
-            "import triton\n"
-            "import triton.language as tl\n"
-            "import torch\n"
-            "\n"
-            "@triton.jit\n"
-            "def add_kernel(x_ptr, y_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):\n"
-            "    pid = tl.program_id(axis=0)\n"
-            "    block_start = pid * BLOCK_SIZE\n"
-            "    offsets = block_start + tl.arange(0, BLOCK_SIZE)\n"
-            "    mask = offsets < n_elements\n"
-            "    x = tl.load(x_ptr + offsets, mask=mask)\n"
-            "    y = tl.load(y_ptr + offsets, mask=mask)\n"
-            "    tl.store(out_ptr + offsets, x + y, mask=mask)\n"
-        )
-        with open(kernel_file, "w", encoding="utf-8") as f:
-            f.write(kernel_src)
+        return temp_dir, logs_dir, out_dir, kernel_dir
 
-        # 3) Generate logs by running the kernel once
+    def _write_kernel_file(self, kernel_dir):
+        """Write the test kernel to a file."""
+        kernel_file = os.path.join(kernel_dir, "simple_kernel.py")
+        with open(kernel_file, "w", encoding="utf-8") as f:
+            f.write(self.KERNEL_SRC)
+        return kernel_file
+
+    def _run_kernel_with_logging(self, logs_dir, kernel_dir):
+        """Run the kernel with structured logging enabled."""
         tritonparse.structured_logging.init(
             logs_dir, enable_trace_launch=True, enable_more_tensor_information=True
         )
@@ -69,6 +73,7 @@ class TestReproducerE2E(GPUTestBase):
                 sys.path.insert(0, kernel_dir)
 
             mod = importlib.import_module("simple_kernel")
+            mod = importlib.reload(mod)
             device = torch.device("cuda:0")
             torch.manual_seed(0)
             n = 256
@@ -82,7 +87,8 @@ class TestReproducerE2E(GPUTestBase):
         finally:
             tritonparse.structured_logging.clear_logging_config()
 
-        # 4) Find the NDJSON and compute launch event index
+    def _find_launch_event(self, logs_dir):
+        """Find the NDJSON file and return (ndjson_path, line_index)."""
         ndjson_files = [
             os.path.join(logs_dir, f)
             for f in os.listdir(logs_dir)
@@ -96,45 +102,113 @@ class TestReproducerE2E(GPUTestBase):
             i for i, ev in enumerate(events) if ev.get("event_type") == "launch"
         ]
         assert launch_indices, "No launch event found in ndjson"
-        line_index = launch_indices[0]
+        return ndjson_path, launch_indices[0]
 
-        # 5) Build reproducer
-        reproduce(
-            input_path=ndjson_path,
-            line_index=line_index,
-            out_dir=out_dir,
-            template="example",
-        )
-
-        # 6) Locate generated script and context under out_dir/add_kernel/
-        kernel_out_dir = os.path.join(out_dir, "add_kernel")
-        assert os.path.isdir(kernel_out_dir), (
-            f"Kernel output dir not found: {kernel_out_dir}"
-        )
-        gen_scripts = [f for f in os.listdir(kernel_out_dir) if f.endswith(".py")]
-        gen_jsons = [f for f in os.listdir(kernel_out_dir) if f.endswith(".json")]
-        assert gen_scripts, f"No generated script in {kernel_out_dir}"
-        assert gen_jsons, f"No generated context json in {kernel_out_dir}"
-        script_path = os.path.join(kernel_out_dir, sorted(gen_scripts)[-1])
-
-        # 7) Execute generated script and assert success output
-        proc = subprocess.run(
-            [
-                sys.executable,
-                script_path,
-            ],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-        self.assertIn("Kernel execution finished.", proc.stdout)
-
-        # Cleanup
+    def _cleanup(self, temp_dir):
+        """Clean up temporary directory."""
         if TEST_KEEP_OUTPUT:
             print(f"✓ Preserving temporary directory (TEST_KEEP_OUTPUT=1): {temp_dir}")
         else:
             shutil.rmtree(temp_dir)
             print("✓ Cleaned up temporary directory")
+
+    def _generate_kernel_logs(self):
+        """
+        Set up temp dirs, write kernel, run it, and find launch event.
+
+        Returns:
+            Tuple of (ndjson_path, line_index, out_dir, temp_dir)
+        """
+        temp_dir, logs_dir, out_dir, kernel_dir = self._setup_temp_dirs()
+        self._write_kernel_file(kernel_dir)
+        self._run_kernel_with_logging(logs_dir, kernel_dir)
+        ndjson_path, line_index = self._find_launch_event(logs_dir)
+        return ndjson_path, line_index, out_dir, temp_dir
+
+    def test_reproducer_end_to_end(self):
+        """End-to-end test for reproducer: generate logs, build script, run it."""
+        ndjson_path, line_index, out_dir, temp_dir = self._generate_kernel_logs()
+
+        try:
+            # Build reproducer
+            reproduce(
+                input_path=ndjson_path,
+                line_index=line_index,
+                out_dir=out_dir,
+                template="example",
+            )
+
+            # Locate generated script and context under out_dir/add_kernel/
+            kernel_out_dir = os.path.join(out_dir, "add_kernel")
+            assert os.path.isdir(kernel_out_dir), (
+                f"Kernel output dir not found: {kernel_out_dir}"
+            )
+            gen_scripts = [f for f in os.listdir(kernel_out_dir) if f.endswith(".py")]
+            gen_jsons = [f for f in os.listdir(kernel_out_dir) if f.endswith(".json")]
+            assert gen_scripts, f"No generated script in {kernel_out_dir}"
+            assert gen_jsons, f"No generated context json in {kernel_out_dir}"
+            script_path = os.path.join(kernel_out_dir, sorted(gen_scripts)[-1])
+
+            # Execute generated script and assert success output
+            proc = subprocess.run(
+                [sys.executable, script_path],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertIn("Kernel execution finished.", proc.stdout)
+        finally:
+            self._cleanup(temp_dir)
+
+    def test_reproducer_embed_context(self):
+        """Test reproducer with embed_context=True generates standalone script."""
+        ndjson_path, line_index, out_dir, temp_dir = self._generate_kernel_logs()
+
+        try:
+            # Build reproducer with embed_context=True
+            result = reproduce(
+                input_path=ndjson_path,
+                line_index=line_index,
+                out_dir=out_dir,
+                template="example",
+                embed_context=True,
+            )
+
+            # Verify repro_context is None when embedding
+            self.assertIsNone(result["repro_context"])
+
+            # Locate generated script under out_dir/add_kernel/
+            kernel_out_dir = os.path.join(out_dir, "add_kernel")
+            assert os.path.isdir(kernel_out_dir), (
+                f"Kernel output dir not found: {kernel_out_dir}"
+            )
+            gen_scripts = [f for f in os.listdir(kernel_out_dir) if f.endswith(".py")]
+            # Verify NO JSON file was created
+            gen_jsons = [f for f in os.listdir(kernel_out_dir) if f.endswith(".json")]
+            self.assertEqual(
+                len(gen_jsons), 0, f"Expected no JSON files, found: {gen_jsons}"
+            )
+            assert gen_scripts, f"No generated script in {kernel_out_dir}"
+            script_path = os.path.join(kernel_out_dir, sorted(gen_scripts)[-1])
+
+            # Verify script contains embedded JSON
+            with open(script_path, "r", encoding="utf-8") as f:
+                script_content = f.read()
+            self.assertIn('CONTEXT_JSON = r"""', script_content)
+            self.assertIn("json.loads(CONTEXT_JSON)", script_content)
+            # Should NOT contain file-based loading
+            self.assertNotIn("create_args_from_json_file", script_content)
+
+            # Execute generated script and assert success output
+            proc = subprocess.run(
+                [sys.executable, script_path],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertIn("Kernel execution finished.", proc.stdout)
+        finally:
+            self._cleanup(temp_dir)
 
 
 if __name__ == "__main__":

--- a/tritonparse/bisect/scripts/__init__.py
+++ b/tritonparse/bisect/scripts/__init__.py
@@ -54,7 +54,7 @@ def get_script_path(script_name: str) -> Path:
         return script_path.resolve()
 
     raise FileNotFoundError(
-        f"Script not found: {script_name}. " f"Searched in: {scripts_dir}"
+        f"Script not found: {script_name}. Searched in: {scripts_dir}"
     )
 
 

--- a/tritonparse/cli.py
+++ b/tritonparse/cli.py
@@ -107,6 +107,7 @@ def main():
             kernel_import=args.kernel_import,
             replacer=replacer,
             skip_logger=True,  # Already logged above
+            embed_context=args.embed_context,
         )
     elif args.func == "info":
         info_command(

--- a/tritonparse/reproducer/cli.py
+++ b/tritonparse/reproducer/cli.py
@@ -70,3 +70,12 @@ def _add_reproducer_args(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help=("Use fbcode to setup repro environment."),
     )
+    parser.add_argument(
+        "--embed-context",
+        action="store_true",
+        default=False,
+        help=(
+            "Embed JSON context directly in the Python script for a standalone reproducer. "
+            "Default: False (generates separate JSON file)."
+        ),
+    )

--- a/tritonparse/reproducer/function_extractor.py
+++ b/tritonparse/reproducer/function_extractor.py
@@ -11,12 +11,17 @@ import ast
 from pathlib import Path
 
 
-def extract_utility_functions() -> str:
+def extract_utility_functions(embed_context: bool = False) -> str:
     """
     Extract all utility functions needed for the reproducer template.
 
     Uses AST parsing to extract functions and constants from source files
     without importing them (avoiding potential side effects).
+
+    Args:
+        embed_context: If True, exclude file-based loading functions
+            (create_args_from_json_file) since the context is embedded
+            directly in the script. Default: False.
 
     Returns:
         str: Complete Python code including imports and all utility functions.
@@ -31,15 +36,20 @@ def extract_utility_functions() -> str:
     load_tensor_tree, load_tensor_lines = _parse_source_file(load_tensor_path)
 
     # Define what to extract (in dependency order)
+    # When embed_context=True, we don't need create_args_from_json_file
+    # since the JSON is embedded directly in the script
     utils_function_names = [
         "_get_triton_tensor_types",
-        "create_args_from_json_file",
         "create_args_from_json",
         "_apply_stride_and_offset",
         "_create_base_tensor",
         "_create_tensor",
         "_create_arg_from_info",
     ]
+
+    # Only include file-based loading function when not embedding context
+    if not embed_context:
+        utils_function_names.insert(1, "create_args_from_json_file")
 
     load_tensor_function_names = [
         "load_tensor",

--- a/tritonparse/reproducer/templates/example.py
+++ b/tritonparse/reproducer/templates/example.py
@@ -11,11 +11,13 @@ logger = logging.getLogger(__name__)
 
 # {{IR_OVERRIDE_SETUP_PLACEHOLDER}}
 
+# {{UTILITY_FUNCTIONS_PLACEHOLDER}}
+
+# isort: off
 # {{KERNEL_SYSPATH_PLACEHOLDER}}
 
 # {{KERNEL_IMPORT_PLACEHOLDER}}
-
-# {{UTILITY_FUNCTIONS_PLACEHOLDER}}
+# isort: on
 
 
 def launch_kernel():

--- a/tritonparse/reproducer/templates/example.py
+++ b/tritonparse/reproducer/templates/example.py
@@ -9,6 +9,10 @@ import torch
 
 logger = logging.getLogger(__name__)
 
+# {{CONTEXT_JSON_PLACEHOLDER}}
+
+# {{COMPILATION_JSON_PLACEHOLDER}}
+
 # {{IR_OVERRIDE_SETUP_PLACEHOLDER}}
 
 # {{UTILITY_FUNCTIONS_PLACEHOLDER}}
@@ -21,14 +25,12 @@ logger = logging.getLogger(__name__)
 
 
 def launch_kernel():
-    script_dir = Path(__file__).resolve().parent  # noqa: F821
-    json_file = script_dir / "{{JSON_FILE_NAME_PLACEHOLDER}}"
-    grid, args_dict = create_args_from_json_file(str(json_file))  # noqa: F821
+    # {{LAUNCH_KERNEL_BODY_PLACEHOLDER}}
 
     print("Generated kernel arguments dictionary:")
-    for name, arg in args_dict.items():
+    for name, arg in args_dict.items():  # noqa: F821
         print(f"  {name}: {arg}")
-    print(f"Grid: {grid}")
+    print(f"Grid: {grid}")  # noqa: F821
 
     # {{KERNEL_INVOCATION_PLACEHOLDER}}
 

--- a/tritonparse/reproducer/templates/tritonbench.py
+++ b/tritonparse/reproducer/templates/tritonbench.py
@@ -18,11 +18,13 @@ imported_kernel_function: Optional[Callable[[Tuple[int], Dict[str, Any]], None]]
 
 # {{IR_OVERRIDE_SETUP_PLACEHOLDER}}
 
+# {{UTILITY_FUNCTIONS_PLACEHOLDER}}
+
+# isort: off
 # {{KERNEL_SYSPATH_PLACEHOLDER}}
 
 # {{KERNEL_IMPORT_PLACEHOLDER}}
-
-# {{UTILITY_FUNCTIONS_PLACEHOLDER}}
+# isort: on
 
 assert imported_kernel_function is not None, "imported_kernel_function is missing"
 

--- a/tritonparse/reproducer/templates/tritonbench.py
+++ b/tritonparse/reproducer/templates/tritonbench.py
@@ -1,7 +1,6 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 import logging
-from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Tuple
 
 import torch
@@ -16,6 +15,10 @@ logger = logging.getLogger(__name__)
 
 imported_kernel_function: Optional[Callable[[Tuple[int], Dict[str, Any]], None]] = None
 
+# {{CONTEXT_JSON_PLACEHOLDER}}
+
+# {{COMPILATION_JSON_PLACEHOLDER}}
+
 # {{IR_OVERRIDE_SETUP_PLACEHOLDER}}
 
 # {{UTILITY_FUNCTIONS_PLACEHOLDER}}
@@ -29,14 +32,10 @@ imported_kernel_function: Optional[Callable[[Tuple[int], Dict[str, Any]], None]]
 assert imported_kernel_function is not None, "imported_kernel_function is missing"
 
 KERNEL_NAME = "{{KERNEL_NAME_PLACEHOLDER}}"
-REPRO_CONTEXT_FILE_NAME = "{{JSON_FILE_NAME_PLACEHOLDER}}"
 
 
 def _get_launch_kernel_args() -> Tuple[Tuple[int], Dict[str, Any]]:
-    script_dir = Path(__file__).resolve().parent  # noqa: F821
-    json_file = script_dir / REPRO_CONTEXT_FILE_NAME
-
-    grid, args_dict = create_args_from_json_file(json_file)  # noqa: F821, F841
+    # {{LAUNCH_KERNEL_BODY_PLACEHOLDER}}
 
     print("Recorded kernel arguments dictionary:")
     for name, arg in args_dict.items():

--- a/tritonparse/reproducer/utils.py
+++ b/tritonparse/reproducer/utils.py
@@ -412,9 +412,13 @@ def _generate_import_statements(kernel_info) -> tuple[str, str]:
         raise ValueError("Kernel file path or function name missing from context.")
 
     # Always add the file's parent directory to sys.path
+    # Note: `import sys` is already included in the utility functions imports,
+    # so we don't need to include it here. This code block is protected by
+    # `# isort: off` to prevent the kernel import from being moved to the top.
     sys_stmt = (
-        "import sys; p = r'" + str(file_path.parent) + "';\n"
-        "if p not in sys.path: sys.path.insert(0, p)"
+        "p = r'" + str(file_path.parent) + "'\n"
+        "if p not in sys.path:\n"
+        "    sys.path.insert(0, p)"
     )
 
     module_name = file_path.with_suffix("").name

--- a/tritonparse/tools/format_fix.py
+++ b/tritonparse/tools/format_fix.py
@@ -5,9 +5,8 @@
 Format fix script for tritonparse project.
 
 This script runs all linter tools to format and fix code issues:
-- usort: Import sorting
+- ufmt: Unified formatting (reads formatter/sorter config from pyproject.toml)
 - ruff: Linting only
-- black: Code formatting
 
 Usage:
     python -m tritonparse.tools.format_fix [options]
@@ -50,9 +49,9 @@ def run_command(cmd: list[str], verbose: bool = False) -> bool:
         return False
 
 
-def run_usort(check_only: bool = False, verbose: bool = False) -> bool:
-    """Run usort for import sorting."""
-    cmd = ["usort"]
+def run_ufmt(check_only: bool = False, verbose: bool = False) -> bool:
+    """Run ufmt for unified formatting (sorter + formatter from pyproject.toml)."""
+    cmd = ["ufmt"]
 
     if check_only:
         cmd.extend(["check", "."])
@@ -70,18 +69,6 @@ def run_ruff_check(check_only: bool = False, verbose: bool = False) -> bool:
         cmd.append("--diff")
     else:
         cmd.append("--fix")
-
-    return run_command(cmd, verbose)
-
-
-def run_black(check_only: bool = False, verbose: bool = False) -> bool:
-    """Run black for code formatting."""
-    cmd = ["black"]
-
-    if check_only:
-        cmd.extend(["--check", "--diff", "."])
-    else:
-        cmd.append(".")
 
     return run_command(cmd, verbose)
 
@@ -115,13 +102,14 @@ Examples:
     # Run formatters on the entire project
     success = True
 
-    # 1. Run usort for import sorting
-    print("Running usort for import sorting...")
-    if not run_usort(args.check_only, args.verbose):
-        print("❌ usort failed")
+    # 1. Run ufmt for unified formatting (sorter + formatter)
+    # ufmt reads configuration from pyproject.toml [tool.ufmt] section
+    print("Running ufmt for formatting (sorter + formatter from pyproject.toml)...")
+    if not run_ufmt(args.check_only, args.verbose):
+        print("❌ ufmt failed")
         success = False
     else:
-        print("✅ usort completed")
+        print("✅ ufmt completed")
 
     # 2. Run ruff for linting only
     print("Running ruff for linting...")
@@ -130,14 +118,6 @@ Examples:
         success = False
     else:
         print("✅ ruff linting completed")
-
-    # 3. Run black for code formatting
-    print("Running black for code formatting...")
-    if not run_black(args.check_only, args.verbose):
-        print("❌ black failed")
-        success = False
-    else:
-        print("✅ black completed")
 
     if success:
         print("\n🎉 All formatting tools completed successfully!")


### PR DESCRIPTION
Summary:
Add a new `--embed-context` CLI flag to the reproducer that embeds the JSON context directly into the generated Python script, creating a fully standalone single-file reproducer.

**Motivation:**
Currently, the reproducer generates two files: a Python script and a separate JSON context file. A single-file reproducer is more convenient for:
- Sharing with others (single file to send)
- Bug reports (easier to attach)
- Archiving (no missing dependencies)

**Changes:**
- Added `--embed-context` CLI argument (default: False for backward compatibility)
- Added `embed_context` parameter to `reproduce()` function
- Added new template placeholders: `CONTEXT_JSON_PLACEHOLDER`, `COMPILATION_JSON_PLACEHOLDER`, `LAUNCH_KERNEL_BODY_PLACEHOLDER`
- Implemented placeholder handlers for embedded JSON mode
- Added warnings for external `blob_path` dependencies and large JSON sizes (>50KB)
- Updated templates to support both file-based and embedded modes
- When `embed_context=True`, `repro_context` returns `None` instead of a file path

**Usage:**
```bash
# Default: Two-file output (backward compatible)
tritonparse reproduce -i trace.ndjson -l 0 -o ./output -t example

# New: Single-file standalone output
tritonparse reproduce -i trace.ndjson -l 0 -o ./output -t example --embed-context
```

Differential Revision: D90353365


