### PR TITLE
Add vertical resize capability to IR Code View panels

### DIFF
--- a/website/src/pages/CodeView.tsx
+++ b/website/src/pages/CodeView.tsx
@@ -167,7 +167,7 @@ const CodeViewInner: React.FC<{
 
       {/* Side-by-side comparison of selected IR files */}
       {leftIR && rightIR ? (
-        <div className="h-[calc(100vh-20rem)] bg-white rounded-lg overflow-hidden shadow-sm border border-gray-200">
+        <div className="h-[calc(100vh-20rem)] bg-white rounded-lg overflow-auto resize-y min-h-48 shadow-sm border border-gray-200">
           <CodeComparisonView
             leftPanel={{
               code: {


### PR DESCRIPTION
Summary:
Enable users to resize the height of the IR Code View panels by dragging the resize handle in the bottom-right corner, similar to the Compilation Stack Trace component.

This improves usability when users need more or less vertical space for the code comparison panels based on their screen size or preference.

Changes:
- Add `resize-y` CSS class to enable vertical resizing
- Change `overflow-hidden` to `overflow-auto` (required for CSS resize to work)
- Add `min-h-48` to set minimum height constraint (192px)

 {F1984497985}

Differential Revision: D90400186


