### PR TITLE
Align OSS formatting with internal pyfmt config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,10 +52,6 @@ jobs:
               run: |
                   make format-check || (echo "❌ Format check failed. Please run 'make format' to fix formatting issues, then commit the changes." && echo "📖 For detailed formatting guide, see: https://github.com/meta-pytorch/tritonparse/wiki/05.-Code-Formatting" && exit 1)
 
-            - name: Check linting
-              run: |
-                  make lint-check || (echo "❌ Linting failed. Please run 'make format' to fix formatting issues, then commit the changes." && echo "📖 For detailed formatting guide, see: https://github.com/meta-pytorch/tritonparse/wiki/05.-Code-Formatting" && exit 1)
-
     # GPU tests - runs on GPU runner with full Triton from source
     # Note: CPU tests (tests/cpu/) are run as part of GPU jobs with TEST_TYPE=all
     test-from-source:

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,12 @@
 # Makefile for tritonparse project
 
-.PHONY: help format format-check lint lint-check test test-cuda clean install-dev website-install website-lint website-build website-build-single website-dev
+.PHONY: help format format-check test test-cuda clean install-dev website-install website-lint website-build website-build-single website-dev
 
 # Default target
 help:
 	@echo "Available targets:"
 	@echo "  format           - Format all Python files"
 	@echo "  format-check     - Check formatting without making changes"
-	@echo "  lint             - Run all linters"
-	@echo "  lint-check       - Check linting without making changes"
 	@echo "  test             - Run tests (CPU only)"
 	@echo "  test-cuda        - Run tests (including CUDA tests)"
 	@echo "  clean            - Clean up cache files"
@@ -29,17 +27,6 @@ format:
 format-check:
 	@echo "Checking formatting..."
 	python -m tritonparse.tools.format_fix --check-only --verbose
-
-# Linting targets
-lint:
-	@echo "Running linters..."
-	ruff check .
-	black --check .
-
-lint-check:
-	@echo "Checking linting..."
-	ruff check --diff .
-	black --check --diff .
 
 # Testing targets
 test:
@@ -62,7 +49,7 @@ clean:
 
 install-dev:
 	@echo "Installing development dependencies..."
-	pip install -U black usort ruff coverage
+	pip install -e ".[dev]"
 
 # Website targets
 website-install:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,17 +25,24 @@ pytorch-triton = [
 test = [
     "coverage>=7.0.0",
 ]
+dev = [
+    "ufmt==2.9.0",
+    "usort==1.1.0",
+    "ruff-api==0.2.0",
+    "ruff>=0.4.0",
+    "coverage>=7.0.0",
+]
 
 [tool.setuptools.packages.find]
 include = ["tritonparse*"]
 
-[tool.black]
-line-length = 88
-target-version = ["py310"]
-
 [tool.ufmt]
-formatter = "black"
+formatter = "ruff-api"
 sorter = "usort"
+
+[tool.ruff]
+line-length = 88
+target-version = "py310"
 
 [tool.usort]
 first_party_detection = false

--- a/tritonparse/bisect/scripts/__init__.py
+++ b/tritonparse/bisect/scripts/__init__.py
@@ -54,7 +54,7 @@ def get_script_path(script_name: str) -> Path:
         return script_path.resolve()
 
     raise FileNotFoundError(
-        f"Script not found: {script_name}. " f"Searched in: {scripts_dir}"
+        f"Script not found: {script_name}. Searched in: {scripts_dir}"
     )
 
 

--- a/tritonparse/tools/format_fix.py
+++ b/tritonparse/tools/format_fix.py
@@ -5,9 +5,8 @@
 Format fix script for tritonparse project.
 
 This script runs all linter tools to format and fix code issues:
-- usort: Import sorting
+- ufmt: Unified formatting (reads formatter/sorter config from pyproject.toml)
 - ruff: Linting only
-- black: Code formatting
 
 Usage:
     python -m tritonparse.tools.format_fix [options]
@@ -50,9 +49,9 @@ def run_command(cmd: list[str], verbose: bool = False) -> bool:
         return False
 
 
-def run_usort(check_only: bool = False, verbose: bool = False) -> bool:
-    """Run usort for import sorting."""
-    cmd = ["usort"]
+def run_ufmt(check_only: bool = False, verbose: bool = False) -> bool:
+    """Run ufmt for unified formatting (sorter + formatter from pyproject.toml)."""
+    cmd = ["ufmt"]
 
     if check_only:
         cmd.extend(["check", "."])
@@ -70,18 +69,6 @@ def run_ruff_check(check_only: bool = False, verbose: bool = False) -> bool:
         cmd.append("--diff")
     else:
         cmd.append("--fix")
-
-    return run_command(cmd, verbose)
-
-
-def run_black(check_only: bool = False, verbose: bool = False) -> bool:
-    """Run black for code formatting."""
-    cmd = ["black"]
-
-    if check_only:
-        cmd.extend(["--check", "--diff", "."])
-    else:
-        cmd.append(".")
 
     return run_command(cmd, verbose)
 
@@ -115,13 +102,14 @@ Examples:
     # Run formatters on the entire project
     success = True
 
-    # 1. Run usort for import sorting
-    print("Running usort for import sorting...")
-    if not run_usort(args.check_only, args.verbose):
-        print("❌ usort failed")
+    # 1. Run ufmt for unified formatting (sorter + formatter)
+    # ufmt reads configuration from pyproject.toml [tool.ufmt] section
+    print("Running ufmt for formatting (sorter + formatter from pyproject.toml)...")
+    if not run_ufmt(args.check_only, args.verbose):
+        print("❌ ufmt failed")
         success = False
     else:
-        print("✅ usort completed")
+        print("✅ ufmt completed")
 
     # 2. Run ruff for linting only
     print("Running ruff for linting...")
@@ -130,14 +118,6 @@ Examples:
         success = False
     else:
         print("✅ ruff linting completed")
-
-    # 3. Run black for code formatting
-    print("Running black for code formatting...")
-    if not run_black(args.check_only, args.verbose):
-        print("❌ black failed")
-        success = False
-    else:
-        print("✅ black completed")
 
     if success:
         print("\n🎉 All formatting tools completed successfully!")


### PR DESCRIPTION
Summary:
This change aligns the tritonparse OSS formatting configuration with the internal pyfmt config used by `arc f`.

**Problem:**
There was a mismatch between:
- Internal `arc f`: uses `ruff-api` formatter (inherited from `["fbcode/pytorch"]` in pyfmt config)
- OSS `make format`: uses `black` formatter (via separate usort + black calls)

This caused formatting conflicts when syncing between fbcode and the open-source repository.

**Solution:**
1. Update `pyproject.toml` to use `ruff-api` as the formatter (matching internal config)
2. Update `format_fix.py` to use `ufmt` which reads configuration from `pyproject.toml`
3. Add `dev` optional dependencies with pinned versions matching internal pyfmt:
   - ufmt==2.9.0
   - usort==1.1.0
   - ruff-api==0.2.0
4. Update `Makefile` install-dev target with the same pinned versions

Now both `arc f` and `make format` use the same `ruff-api` formatter with consistent versions.

Reviewed By: bowiechen

Differential Revision: D90551420


