### PR TITLE
Add PairTester data classes (PR-24)

### DIFF
--- a/tritonparse/bisect/__init__.py
+++ b/tritonparse/bisect/__init__.py
@@ -7,7 +7,11 @@ This module provides tools for bisecting Triton and LLVM regressions.
 """
 
 from tritonparse.bisect.base_bisector import BaseBisector, BisectError
-from tritonparse.bisect.commit_detector import CommitDetector, CommitDetectorError
+from tritonparse.bisect.commit_detector import (
+    CommitDetector,
+    CommitDetectorError,
+    LLVMBumpInfo,
+)
 from tritonparse.bisect.executor import CommandResult, ShellExecutor
 from tritonparse.bisect.llvm_bisector import LLVMBisectError, LLVMBisector
 from tritonparse.bisect.logger import BisectLogger
@@ -22,6 +26,7 @@ __all__ = [
     "CommitDetectorError",
     "LLVMBisectError",
     "LLVMBisector",
+    "LLVMBumpInfo",
     "ShellExecutor",
     "TritonBisectError",
     "TritonBisector",

--- a/tritonparse/bisect/__init__.py
+++ b/tritonparse/bisect/__init__.py
@@ -7,6 +7,7 @@ This module provides tools for bisecting Triton and LLVM regressions.
 """
 
 from tritonparse.bisect.base_bisector import BaseBisector, BisectError
+from tritonparse.bisect.commit_detector import CommitDetector, CommitDetectorError
 from tritonparse.bisect.executor import CommandResult, ShellExecutor
 from tritonparse.bisect.llvm_bisector import LLVMBisectError, LLVMBisector
 from tritonparse.bisect.logger import BisectLogger
@@ -17,6 +18,8 @@ __all__ = [
     "BisectError",
     "BisectLogger",
     "CommandResult",
+    "CommitDetector",
+    "CommitDetectorError",
     "LLVMBisectError",
     "LLVMBisector",
     "ShellExecutor",

--- a/tritonparse/bisect/__init__.py
+++ b/tritonparse/bisect/__init__.py
@@ -15,6 +15,7 @@ from tritonparse.bisect.commit_detector import (
 from tritonparse.bisect.executor import CommandResult, ShellExecutor
 from tritonparse.bisect.llvm_bisector import LLVMBisectError, LLVMBisector
 from tritonparse.bisect.logger import BisectLogger
+from tritonparse.bisect.pair_tester import CommitPair, PairTesterError, PairTestResult
 from tritonparse.bisect.triton_bisector import TritonBisectError, TritonBisector
 
 __all__ = [
@@ -24,9 +25,12 @@ __all__ = [
     "CommandResult",
     "CommitDetector",
     "CommitDetectorError",
+    "CommitPair",
     "LLVMBisectError",
     "LLVMBisector",
     "LLVMBumpInfo",
+    "PairTesterError",
+    "PairTestResult",
     "ShellExecutor",
     "TritonBisectError",
     "TritonBisector",

--- a/tritonparse/bisect/commit_detector.py
+++ b/tritonparse/bisect/commit_detector.py
@@ -1,0 +1,98 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Commit type detector for Triton bisect workflow.
+
+This module provides the CommitDetector class which implements Phase 2 of the
+Triton/LLVM bisect workflow. It detects whether a given Triton commit is an
+LLVM bump by checking if the cmake/llvm-hash.txt file was modified.
+"""
+
+from pathlib import Path
+
+from tritonparse.bisect.executor import ShellExecutor
+from tritonparse.bisect.logger import BisectLogger
+
+
+class CommitDetectorError(Exception):
+    """Exception raised for commit detection errors."""
+
+    pass
+
+
+class CommitDetector:
+    """
+    Detects the type of a Triton commit.
+
+    This class implements Phase 2 of the bisect workflow - determining whether
+    a Triton commit is an LLVM bump by checking if cmake/llvm-hash.txt was
+    modified in the commit.
+
+    Example:
+        >>> logger = BisectLogger("./logs")
+        >>> executor = ShellExecutor(logger)
+        >>> detector = CommitDetector(
+        ...     triton_dir=Path("/path/to/triton"),
+        ...     executor=executor,
+        ...     logger=logger,
+        ... )
+        >>> is_bump = detector.is_llvm_bump(commit="abc123")
+        >>> if is_bump:
+        ...     print("This commit is an LLVM bump!")
+    """
+
+    LLVM_HASH_FILE = "cmake/llvm-hash.txt"
+
+    def __init__(
+        self,
+        triton_dir: Path,
+        executor: ShellExecutor,
+        logger: BisectLogger,
+    ) -> None:
+        """
+        Initialize the commit detector.
+
+        Args:
+            triton_dir: Path to the Triton repository.
+            executor: ShellExecutor instance for running git commands.
+            logger: BisectLogger instance for logging.
+        """
+        self.triton_dir = triton_dir
+        self.executor = executor
+        self.logger = logger
+
+    def is_llvm_bump(self, commit: str) -> bool:
+        """
+        Check if a commit is an LLVM bump.
+
+        A commit is considered an LLVM bump if it modifies the
+        cmake/llvm-hash.txt file.
+
+        Args:
+            commit: The Triton commit hash to check.
+
+        Returns:
+            True if the commit modifies LLVM hash, False otherwise.
+        """
+        self.logger.info(f"Checking if commit is LLVM bump: {commit}")
+
+        result = self.executor.run_command(
+            ["git", "diff", "--name-only", f"{commit}~1", commit],
+            cwd=str(self.triton_dir),
+        )
+
+        if not result.success:
+            self.logger.warning(
+                f"Failed to get changed files for {commit}: {result.stderr}"
+            )
+            return False
+
+        changed_files = result.stdout.strip().split("\n")
+        is_bump = self.LLVM_HASH_FILE in changed_files
+
+        if is_bump:
+            self.logger.info(f"Commit {commit[:7]} IS an LLVM bump")
+        else:
+            self.logger.info(f"Commit {commit[:7]} is NOT an LLVM bump")
+
+        return is_bump

--- a/tritonparse/bisect/pair_tester.py
+++ b/tritonparse/bisect/pair_tester.py
@@ -1,0 +1,60 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Pair tester for Triton/LLVM commit pairs.
+
+This module provides the PairTester class which implements Phase 3 of the
+Triton/LLVM bisect workflow. It tests (Triton, LLVM) commit pairs sequentially
+to find the first failing pair.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+class PairTesterError(Exception):
+    """Exception raised for pair testing errors."""
+
+    pass
+
+
+@dataclass
+class CommitPair:
+    """
+    A (Triton, LLVM) commit pair.
+
+    Attributes:
+        triton_commit: The Triton commit hash.
+        llvm_commit: The LLVM commit hash.
+        index: The pair index (0-based) in the CSV file.
+    """
+
+    triton_commit: str
+    llvm_commit: str
+    index: int
+
+
+@dataclass
+class PairTestResult:
+    """
+    Result of pair testing.
+
+    Attributes:
+        found_failing: Whether a failing pair was found.
+        failing_index: Index of the first failing pair (0-based), or -1 if none.
+        good_llvm: LLVM commit from the last passing pair (for bisect).
+        bad_llvm: LLVM commit from the first failing pair (for bisect).
+        triton_commit: Triton commit of the failing pair.
+        total_pairs: Total number of pairs tested.
+        all_passed: True if all pairs passed (no failing pair found).
+        error_message: Error message if testing failed.
+    """
+
+    found_failing: bool
+    failing_index: int = -1
+    good_llvm: Optional[str] = None
+    bad_llvm: Optional[str] = None
+    triton_commit: Optional[str] = None
+    total_pairs: int = 0
+    all_passed: bool = False
+    error_message: Optional[str] = None


### PR DESCRIPTION
Summary:
Add data classes for pair testing module which implements Phase 3 of the
Triton/LLVM bisect workflow.

Components added:
- PairTesterError: Exception class for pair testing errors
- CommitPair: Dataclass representing a (Triton, LLVM) commit pair with
  triton_commit, llvm_commit, and index fields
- PairTestResult: Dataclass for pair testing results containing
  found_failing, failing_index, good_llvm, bad_llvm, triton_commit,
  total_pairs, all_passed, and error_message fields

These data classes will be used by the PairTester class (PR-25~27) to
store and return pair testing information.

Differential Revision: D90621841


