### PR TITLE
Add PairTester parsing methods (PR-27)

### DIFF
--- a/tritonparse/bisect/__init__.py
+++ b/tritonparse/bisect/__init__.py
@@ -7,7 +7,11 @@ This module provides tools for bisecting Triton and LLVM regressions.
 """
 
 from tritonparse.bisect.base_bisector import BaseBisector, BisectError
-from tritonparse.bisect.commit_detector import CommitDetector, CommitDetectorError
+from tritonparse.bisect.commit_detector import (
+    CommitDetector,
+    CommitDetectorError,
+    LLVMBumpInfo,
+)
 from tritonparse.bisect.executor import CommandResult, ShellExecutor
 from tritonparse.bisect.llvm_bisector import LLVMBisectError, LLVMBisector
 from tritonparse.bisect.logger import BisectLogger
@@ -22,6 +26,7 @@ __all__ = [
     "CommitDetectorError",
     "LLVMBisectError",
     "LLVMBisector",
+    "LLVMBumpInfo",
     "ShellExecutor",
     "TritonBisectError",
     "TritonBisector",

--- a/tritonparse/bisect/__init__.py
+++ b/tritonparse/bisect/__init__.py
@@ -15,7 +15,12 @@ from tritonparse.bisect.commit_detector import (
 from tritonparse.bisect.executor import CommandResult, ShellExecutor
 from tritonparse.bisect.llvm_bisector import LLVMBisectError, LLVMBisector
 from tritonparse.bisect.logger import BisectLogger
-from tritonparse.bisect.pair_tester import CommitPair, PairTesterError, PairTestResult
+from tritonparse.bisect.pair_tester import (
+    CommitPair,
+    PairTester,
+    PairTesterError,
+    PairTestResult,
+)
 from tritonparse.bisect.triton_bisector import TritonBisectError, TritonBisector
 
 __all__ = [
@@ -29,6 +34,7 @@ __all__ = [
     "LLVMBisectError",
     "LLVMBisector",
     "LLVMBumpInfo",
+    "PairTester",
     "PairTesterError",
     "PairTestResult",
     "ShellExecutor",

--- a/tritonparse/bisect/__init__.py
+++ b/tritonparse/bisect/__init__.py
@@ -7,6 +7,7 @@ This module provides tools for bisecting Triton and LLVM regressions.
 """
 
 from tritonparse.bisect.base_bisector import BaseBisector, BisectError
+from tritonparse.bisect.commit_detector import CommitDetector, CommitDetectorError
 from tritonparse.bisect.executor import CommandResult, ShellExecutor
 from tritonparse.bisect.llvm_bisector import LLVMBisectError, LLVMBisector
 from tritonparse.bisect.logger import BisectLogger
@@ -17,6 +18,8 @@ __all__ = [
     "BisectError",
     "BisectLogger",
     "CommandResult",
+    "CommitDetector",
+    "CommitDetectorError",
     "LLVMBisectError",
     "LLVMBisector",
     "ShellExecutor",

--- a/tritonparse/bisect/__init__.py
+++ b/tritonparse/bisect/__init__.py
@@ -15,6 +15,7 @@ from tritonparse.bisect.commit_detector import (
 from tritonparse.bisect.executor import CommandResult, ShellExecutor
 from tritonparse.bisect.llvm_bisector import LLVMBisectError, LLVMBisector
 from tritonparse.bisect.logger import BisectLogger
+from tritonparse.bisect.pair_tester import CommitPair, PairTesterError, PairTestResult
 from tritonparse.bisect.triton_bisector import TritonBisectError, TritonBisector
 
 __all__ = [
@@ -24,9 +25,12 @@ __all__ = [
     "CommandResult",
     "CommitDetector",
     "CommitDetectorError",
+    "CommitPair",
     "LLVMBisectError",
     "LLVMBisector",
     "LLVMBumpInfo",
+    "PairTesterError",
+    "PairTestResult",
     "ShellExecutor",
     "TritonBisectError",
     "TritonBisector",

--- a/tritonparse/bisect/commit_detector.py
+++ b/tritonparse/bisect/commit_detector.py
@@ -1,0 +1,98 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Commit type detector for Triton bisect workflow.
+
+This module provides the CommitDetector class which implements Phase 2 of the
+Triton/LLVM bisect workflow. It detects whether a given Triton commit is an
+LLVM bump by checking if the cmake/llvm-hash.txt file was modified.
+"""
+
+from pathlib import Path
+
+from tritonparse.bisect.executor import ShellExecutor
+from tritonparse.bisect.logger import BisectLogger
+
+
+class CommitDetectorError(Exception):
+    """Exception raised for commit detection errors."""
+
+    pass
+
+
+class CommitDetector:
+    """
+    Detects the type of a Triton commit.
+
+    This class implements Phase 2 of the bisect workflow - determining whether
+    a Triton commit is an LLVM bump by checking if cmake/llvm-hash.txt was
+    modified in the commit.
+
+    Example:
+        >>> logger = BisectLogger("./logs")
+        >>> executor = ShellExecutor(logger)
+        >>> detector = CommitDetector(
+        ...     triton_dir=Path("/path/to/triton"),
+        ...     executor=executor,
+        ...     logger=logger,
+        ... )
+        >>> is_bump = detector.is_llvm_bump(commit="abc123")
+        >>> if is_bump:
+        ...     print("This commit is an LLVM bump!")
+    """
+
+    LLVM_HASH_FILE = "cmake/llvm-hash.txt"
+
+    def __init__(
+        self,
+        triton_dir: Path,
+        executor: ShellExecutor,
+        logger: BisectLogger,
+    ) -> None:
+        """
+        Initialize the commit detector.
+
+        Args:
+            triton_dir: Path to the Triton repository.
+            executor: ShellExecutor instance for running git commands.
+            logger: BisectLogger instance for logging.
+        """
+        self.triton_dir = triton_dir
+        self.executor = executor
+        self.logger = logger
+
+    def is_llvm_bump(self, commit: str) -> bool:
+        """
+        Check if a commit is an LLVM bump.
+
+        A commit is considered an LLVM bump if it modifies the
+        cmake/llvm-hash.txt file.
+
+        Args:
+            commit: The Triton commit hash to check.
+
+        Returns:
+            True if the commit modifies LLVM hash, False otherwise.
+        """
+        self.logger.info(f"Checking if commit is LLVM bump: {commit}")
+
+        result = self.executor.run_command(
+            ["git", "diff", "--name-only", f"{commit}~1", commit],
+            cwd=str(self.triton_dir),
+        )
+
+        if not result.success:
+            self.logger.warning(
+                f"Failed to get changed files for {commit}: {result.stderr}"
+            )
+            return False
+
+        changed_files = result.stdout.strip().split("\n")
+        is_bump = self.LLVM_HASH_FILE in changed_files
+
+        if is_bump:
+            self.logger.info(f"Commit {commit[:7]} IS an LLVM bump")
+        else:
+            self.logger.info(f"Commit {commit[:7]} is NOT an LLVM bump")
+
+        return is_bump

--- a/tritonparse/bisect/pair_tester.py
+++ b/tritonparse/bisect/pair_tester.py
@@ -1,0 +1,60 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Pair tester for Triton/LLVM commit pairs.
+
+This module provides the PairTester class which implements Phase 3 of the
+Triton/LLVM bisect workflow. It tests (Triton, LLVM) commit pairs sequentially
+to find the first failing pair.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+class PairTesterError(Exception):
+    """Exception raised for pair testing errors."""
+
+    pass
+
+
+@dataclass
+class CommitPair:
+    """
+    A (Triton, LLVM) commit pair.
+
+    Attributes:
+        triton_commit: The Triton commit hash.
+        llvm_commit: The LLVM commit hash.
+        index: The pair index (0-based) in the CSV file.
+    """
+
+    triton_commit: str
+    llvm_commit: str
+    index: int
+
+
+@dataclass
+class PairTestResult:
+    """
+    Result of pair testing.
+
+    Attributes:
+        found_failing: Whether a failing pair was found.
+        failing_index: Index of the first failing pair (0-based), or -1 if none.
+        good_llvm: LLVM commit from the last passing pair (for bisect).
+        bad_llvm: LLVM commit from the first failing pair (for bisect).
+        triton_commit: Triton commit of the failing pair.
+        total_pairs: Total number of pairs tested.
+        all_passed: True if all pairs passed (no failing pair found).
+        error_message: Error message if testing failed.
+    """
+
+    found_failing: bool
+    failing_index: int = -1
+    good_llvm: Optional[str] = None
+    bad_llvm: Optional[str] = None
+    triton_commit: Optional[str] = None
+    total_pairs: int = 0
+    all_passed: bool = False
+    error_message: Optional[str] = None

--- a/tritonparse/bisect/pair_tester.py
+++ b/tritonparse/bisect/pair_tester.py
@@ -8,8 +8,13 @@ Triton/LLVM bisect workflow. It tests (Triton, LLVM) commit pairs sequentially
 to find the first failing pair.
 """
 
+import csv
 from dataclasses import dataclass
-from typing import Optional
+from pathlib import Path
+from typing import List, Optional
+
+from tritonparse.bisect.executor import ShellExecutor
+from tritonparse.bisect.logger import BisectLogger
 
 
 class PairTesterError(Exception):
@@ -58,3 +63,142 @@ class PairTestResult:
     total_pairs: int = 0
     all_passed: bool = False
     error_message: Optional[str] = None
+
+
+class PairTester:
+    """
+    Tests (Triton, LLVM) commit pairs to find the first failing pair.
+
+    This class implements Phase 3 of the bisect workflow - testing commit pairs
+    sequentially to find the first pair that causes test failure. This is used
+    when Triton bisect identifies an LLVM bump commit.
+
+    Example:
+        >>> logger = BisectLogger("./logs")
+        >>> executor = ShellExecutor(logger)
+        >>> tester = PairTester(
+        ...     triton_dir=Path("/path/to/triton"),
+        ...     test_script=Path("/path/to/test.py"),
+        ...     executor=executor,
+        ...     logger=logger,
+        ... )
+        >>> result = tester.test_from_csv(csv_path=Path("commits.csv"))
+        >>> if result.found_failing:
+        ...     print(f"First failing pair at index {result.failing_index}")
+        ...     print(f"LLVM bisect range: {result.good_llvm} -> {result.bad_llvm}")
+    """
+
+    def __init__(
+        self,
+        triton_dir: Path,
+        test_script: Path,
+        executor: ShellExecutor,
+        logger: BisectLogger,
+        conda_env: str = "triton_bisect",
+        build_command: Optional[str] = None,
+    ) -> None:
+        """
+        Initialize the pair tester.
+
+        Args:
+            triton_dir: Path to the Triton repository.
+            test_script: Path to the test script.
+            executor: ShellExecutor instance for running commands.
+            logger: BisectLogger instance for logging.
+            conda_env: Conda environment name for testing.
+            build_command: Custom build command template. Use {TRITON_COMMIT}
+                and {LLVM_COMMIT} as placeholders.
+        """
+        self.triton_dir = triton_dir
+        self.test_script = test_script
+        self.executor = executor
+        self.logger = logger
+        self.conda_env = conda_env
+        self.build_command = build_command
+
+    def _load_pairs_from_csv(self, csv_path: Path) -> List[CommitPair]:
+        """
+        Load commit pairs from a CSV file.
+
+        The CSV file format:
+        - Two columns: triton_commit, llvm_commit
+        - Optional header row (auto-detected and skipped)
+        - Empty lines are ignored
+        - Comment lines starting with # are ignored
+
+        Args:
+            csv_path: Path to the CSV file.
+
+        Returns:
+            List of CommitPair objects.
+
+        Raises:
+            PairTesterError: If CSV file cannot be read.
+        """
+        if not csv_path.exists():
+            raise PairTesterError(f"CSV file not found: {csv_path}")
+
+        pairs: List[CommitPair] = []
+        index = 0
+
+        try:
+            with open(csv_path, "r") as f:
+                # Read all lines and filter out comments for header detection
+                all_lines = f.readlines()
+                non_comment_lines = [
+                    line for line in all_lines if not line.strip().startswith("#")
+                ]
+
+                # Use first few non-comment lines for header detection
+                sample = "".join(non_comment_lines[:10])
+                has_header = False
+                if sample.strip():
+                    try:
+                        has_header = csv.Sniffer().has_header(sample)
+                    except csv.Error:
+                        # Sniffer failed, assume no header
+                        has_header = False
+
+                # Reset and read with csv reader
+                f.seek(0)
+                reader = csv.reader(f)
+
+                header_skipped = False
+
+                for row in reader:
+                    if len(row) < 2:
+                        continue
+
+                    triton_commit = row[0].strip().strip('"')
+                    llvm_commit = row[1].strip().strip('"')
+
+                    # Skip empty rows
+                    if not triton_commit or not llvm_commit:
+                        continue
+
+                    # Skip comment lines (starting with #)
+                    if triton_commit.startswith("#"):
+                        continue
+
+                    # Skip header row (only once)
+                    if triton_commit.lower() in ("triton", "triton_commit"):
+                        continue
+
+                    # Skip detected header (first non-comment data row if has_header)
+                    if has_header and not header_skipped:
+                        header_skipped = True
+                        continue
+
+                    pairs.append(
+                        CommitPair(
+                            triton_commit=triton_commit,
+                            llvm_commit=llvm_commit,
+                            index=index,
+                        )
+                    )
+                    index += 1
+
+        except Exception as e:
+            raise PairTesterError(f"Failed to read CSV file {csv_path}: {e}")
+
+        return pairs


### PR DESCRIPTION
Summary:
Complete the PairTester implementation with full parsing methods:

1. _filter_pairs_by_llvm_range() - Full implementation
   - Validates good_llvm and bad_llvm exist in pairs list
   - Supports prefix matching for short commit hashes
   - Validates ordering (good must come before bad)
   - Stores filter indices for reference
   - Returns original list (filtering done by shell script)

2. _parse_test_output() - Full implementation
   - Handles exit code 0 (all passed or test failure found)
   - Handles exit code 1 (build failure or critical error)
   - Uses regex to parse output for:
     * Build failures: 'Status: Build Failed.*Position: Pair N of M'
     * Test failures: 'TEST FAILED.*Position: Pair N of M'
     * Commit info: 'Triton Commit:', 'LLVM Commit:'
   - Determines good_llvm from previous pair
   - Falls back to _parse_result_file() if parsing fails

3. _parse_result_file() - New method
   - Fallback when output parsing fails
   - Looks for 'Result file: *.txt' in output
   - Parses result file content for commit info
   - Extracts position and commit hashes

Added import: re (for regex parsing)

Differential Revision: D90621840


