### PR TITLE
Add Dependabot configuration for website npm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule:
+      interval: "monthly"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+
+    # Group all updates into a single PR to reduce "PR bombing"
+    groups:
+      website-all:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
+
+    # Limit the number of open PRs at a time (optional)
+    open-pull-requests-limit: 1


### PR DESCRIPTION
Summary:
Add `.github/dependabot.yml` to automatically manage npm dependency updates for the website.

Configuration:
- Monitors `/website` directory for npm package updates
- Runs monthly at 09:00 Pacific time
- Groups all dependency updates (major, minor, patch) into a single PR to reduce PR noise
- Limits concurrent open PRs to 1

This helps keep the website dependencies up-to-date with security patches and bug fixes while minimizing maintenance overhead.

Differential Revision: D90649498


