### PR TITLE
Add runtime accessibility test to website CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule:
+      interval: "monthly"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+
+    # Group all updates into a single PR to reduce "PR bombing"
+    groups:
+      website-all:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
+
+    # Limit the number of open PRs at a time (optional)
+    open-pull-requests-limit: 1

--- a/.github/workflows/website-build.yml
+++ b/.github/workflows/website-build.yml
@@ -61,3 +61,38 @@ jobs:
           fi
           echo "✅ Build successful: all expected files present"
           ls -la website/dist/
+
+      - name: Runtime accessibility test
+        working-directory: ./website
+        run: |
+          echo "Starting preview server..."
+          npm run preview &
+          SERVER_PID=$!
+
+          # Wait for server to start
+          echo "Waiting for server to start..."
+          sleep 5
+
+          # Test main page accessibility
+          echo "Testing main page accessibility..."
+          if curl --fail --silent --show-error http://localhost:4173/ > /dev/null; then
+            echo "✅ Main page is accessible"
+          else
+            echo "❌ Main page is not accessible"
+            kill $SERVER_PID 2>/dev/null || true
+            exit 1
+          fi
+
+          # Test standalone page accessibility
+          echo "Testing standalone page accessibility..."
+          if curl --fail --silent --show-error http://localhost:4173/standalone.html > /dev/null; then
+            echo "✅ Standalone page is accessible"
+          else
+            echo "❌ Standalone page is not accessible"
+            kill $SERVER_PID 2>/dev/null || true
+            exit 1
+          fi
+
+          # Cleanup
+          kill $SERVER_PID 2>/dev/null || true
+          echo "✅ Runtime accessibility test passed"


### PR DESCRIPTION
Summary:
Add a runtime accessibility test step to the website build workflow. This test starts the Vite preview server and verifies that both the main page and standalone page are accessible via HTTP requests.

This ensures that:
1. The built website can actually be served (not just built)
2. Both `index.html` and `standalone.html` return HTTP 200
3. Dependency updates (e.g., from Dependabot) don't break runtime functionality

The test uses `curl --fail` to verify page accessibility and properly cleans up the server process on success or failure.

Differential Revision: D90649754
