### PR TITLE
Add index prefix to kernel selector

### DIFF
--- a/website/src/pages/CodeView.tsx
+++ b/website/src/pages/CodeView.tsx
@@ -47,7 +47,8 @@ const CodeViewInner: React.FC<{
   kernel: ProcessedKernel;
   irFiles: string[];
   defaultIRFiles: { left: string; right: string };
-}> = ({ kernel, irFiles, defaultIRFiles }) => {
+  selectedKernel: number;
+}> = ({ kernel, irFiles, defaultIRFiles, selectedKernel }) => {
   // States to track selected IR files for left and right panels
   // Initialize with defaults - component remounts when kernel changes
   const [leftIR, setLeftIR] = useState<string>(defaultIRFiles.left);
@@ -61,7 +62,7 @@ const CodeViewInner: React.FC<{
   return (
     <div className="p-6">
       <h1 className="text-2xl font-bold text-gray-800 mb-4">
-        Code Comparison: {kernel.name}
+        Code Comparison: [{selectedKernel}] {kernel.name}
       </h1>
 
       {/* IR file selector controls */}
@@ -256,6 +257,7 @@ const CodeView: React.FC<CodeViewProps> = ({ kernels, selectedKernel = 0 }) => {
       kernel={kernel}
       irFiles={irFiles}
       defaultIRFiles={defaultIRFiles}
+      selectedKernel={selectedKernel}
     />
   );
 };

--- a/website/src/pages/FileDiffView.tsx
+++ b/website/src/pages/FileDiffView.tsx
@@ -589,7 +589,7 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
             >
               {leftArrayResolved.map((k, i) => (
                 <option key={`l-${i}`} value={i}>
-                  {k.name} {(k.metadata?.hash || "").slice(0, 8)}
+                  [{i}] {k.name} {(k.metadata?.hash || "").slice(0, 8)}
                 </option>
               ))}
             </select>
@@ -604,7 +604,7 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
             >
               {kernelsRight.map((k, i) => (
                 <option key={`r-${i}`} value={i}>
-                  {k.name} {(k.metadata?.hash || "").slice(0, 8)}
+                  [{i}] {k.name} {(k.metadata?.hash || "").slice(0, 8)}
                 </option>
               ))}
             </select>

--- a/website/src/pages/IRAnalysis.tsx
+++ b/website/src/pages/IRAnalysis.tsx
@@ -76,7 +76,7 @@ const IRAnalysis: React.FC<IRAnalysisProps> = ({ kernels, selectedKernel }) => {
 
       <div className="bg-white rounded-lg p-4 mb-4 shadow-sm border border-gray-200">
         <h2 className="text-xl font-semibold mb-4 text-gray-800">
-          Kernel: {kernel.name}
+          Kernel: [{selectedKernel}] {kernel.name}
         </h2>
 
         {io_counts && (ttgir_info || amdgcn_info) && (

--- a/website/src/pages/KernelOverview.tsx
+++ b/website/src/pages/KernelOverview.tsx
@@ -199,7 +199,7 @@ const KernelOverview: React.FC<KernelOverviewProps> = ({
                 >
                   {kernels.map((k, index) => (
                     <option key={index} value={index}>
-                      {k.name}
+                      [{index}] {k.name}
                     </option>
                   ))}
                 </select>
@@ -232,7 +232,7 @@ const KernelOverview: React.FC<KernelOverviewProps> = ({
                 }`}
                 onClick={() => onSelectKernel(index)}
               >
-                <div className="font-medium">{k.name}</div>
+                <div className="font-medium">[{index}] {k.name}</div>
               </button>
             ))}
           </div>
@@ -242,7 +242,7 @@ const KernelOverview: React.FC<KernelOverviewProps> = ({
       {/* Kernel Details */}
       <div className="bg-white rounded-lg p-4 mb-4 shadow-sm border border-gray-200">
         <h2 className="text-xl font-semibold mb-4 text-gray-800">
-          Kernel Details: {kernel.name}
+          Kernel Details: [{selectedKernel}] {kernel.name}
         </h2>
 
         {/* Metadata Section */}


### PR DESCRIPTION
Summary:
When multiple kernels have the same name (e.g., different autotune configurations), it was difficult to distinguish between them in the kernel selector. Adding a numeric index prefix (e.g., [0], [1], [2]) allows users to quickly identify and reference specific kernels within the same trace file.

The index is stable for a given trace file since kernels are processed in the order they appear in the log.

Fix https://github.com/meta-pytorch/tritonparse/issues/269

Differential Revision: D90798117


