### PR TITLE
Implement log writing functions (PR-42)

### DIFF
--- a/tritonparse/bisect/__init__.py
+++ b/tritonparse/bisect/__init__.py
@@ -23,12 +23,14 @@ from tritonparse.bisect.pair_tester import (
 )
 from tritonparse.bisect.state import BisectPhase, BisectState, StateManager
 from tritonparse.bisect.triton_bisector import TritonBisectError, TritonBisector
+from tritonparse.bisect.ui import BisectProgress
 
 __all__ = [
     "BaseBisector",
     "BisectError",
     "BisectLogger",
     "BisectPhase",
+    "BisectProgress",
     "BisectState",
     "CommandResult",
     "CommitDetector",

--- a/tritonparse/bisect/__init__.py
+++ b/tritonparse/bisect/__init__.py
@@ -23,7 +23,7 @@ from tritonparse.bisect.pair_tester import (
 )
 from tritonparse.bisect.state import BisectPhase, BisectState, StateManager
 from tritonparse.bisect.triton_bisector import TritonBisectError, TritonBisector
-from tritonparse.bisect.ui import BisectProgress
+from tritonparse.bisect.ui import BisectProgress, BisectUI, RICH_AVAILABLE
 
 __all__ = [
     "BaseBisector",
@@ -32,6 +32,7 @@ __all__ = [
     "BisectPhase",
     "BisectProgress",
     "BisectState",
+    "BisectUI",
     "CommandResult",
     "CommitDetector",
     "CommitDetectorError",
@@ -42,6 +43,7 @@ __all__ = [
     "PairTester",
     "PairTesterError",
     "PairTestResult",
+    "RICH_AVAILABLE",
     "ShellExecutor",
     "StateManager",
     "TritonBisectError",

--- a/tritonparse/bisect/__init__.py
+++ b/tritonparse/bisect/__init__.py
@@ -23,7 +23,13 @@ from tritonparse.bisect.pair_tester import (
 )
 from tritonparse.bisect.state import BisectPhase, BisectState, StateManager
 from tritonparse.bisect.triton_bisector import TritonBisectError, TritonBisector
-from tritonparse.bisect.ui import BisectProgress, BisectUI, RICH_AVAILABLE
+from tritonparse.bisect.ui import (
+    BisectProgress,
+    BisectUI,
+    is_rich_available,
+    RICH_AVAILABLE,
+    SummaryMode,
+)
 
 __all__ = [
     "BaseBisector",
@@ -37,6 +43,7 @@ __all__ = [
     "CommitDetector",
     "CommitDetectorError",
     "CommitPair",
+    "is_rich_available",
     "LLVMBisectError",
     "LLVMBisector",
     "LLVMBumpInfo",
@@ -46,6 +53,7 @@ __all__ = [
     "RICH_AVAILABLE",
     "ShellExecutor",
     "StateManager",
+    "SummaryMode",
     "TritonBisectError",
     "TritonBisector",
 ]

--- a/tritonparse/bisect/__init__.py
+++ b/tritonparse/bisect/__init__.py
@@ -27,6 +27,7 @@ from tritonparse.bisect.ui import (
     BisectProgress,
     BisectUI,
     is_rich_available,
+    print_final_summary,
     RICH_AVAILABLE,
     SummaryMode,
 )
@@ -50,6 +51,7 @@ __all__ = [
     "PairTester",
     "PairTesterError",
     "PairTestResult",
+    "print_final_summary",
     "RICH_AVAILABLE",
     "ShellExecutor",
     "StateManager",

--- a/tritonparse/bisect/ui.py
+++ b/tritonparse/bisect/ui.py
@@ -8,8 +8,19 @@ and real-time command output. It gracefully falls back to plain text when
 Rich is not available or when running in non-TTY environments.
 """
 
+import sys
 from dataclasses import dataclass
-from typing import Optional
+from typing import List, Optional
+
+# Graceful fallback if rich not installed
+try:
+    from rich.console import Console
+    from rich.layout import Layout
+    from rich.live import Live
+
+    RICH_AVAILABLE = True
+except ImportError:
+    RICH_AVAILABLE = False
 
 
 @dataclass
@@ -50,3 +61,97 @@ class BisectProgress:
     command_log: Optional[str] = None
     # Pair test specific: track the starting index when range filter is applied
     range_start_index: Optional[int] = None
+
+
+class BisectUI:
+    """
+    Rich-based TUI for bisect operations.
+
+    Provides a split-screen interface with:
+    - Top panel: Progress information (phase, commit, progress, elapsed time)
+    - Bottom panel: Scrolling command output (build/test logs)
+
+    Automatically falls back to plain text output when:
+    - Rich library is not installed
+    - Running in non-TTY environment (CI, pipes)
+    - Explicitly disabled via enabled=False
+
+    Example:
+        >>> ui = BisectUI()
+        >>> with ui:
+        ...     ui.update_progress(phase="Triton Bisect", phase_number=1)
+        ...     ui.append_output("Building...")
+        ...     # ... do work ...
+        ...     ui.update_progress(commits_tested=5, total_commits=12)
+    """
+
+    def __init__(self, enabled: bool = True) -> None:
+        """
+        Initialize the TUI.
+
+        Args:
+            enabled: Whether to enable Rich TUI. If False or Rich unavailable,
+                    falls back to plain text output.
+        """
+        # Track why TUI was disabled for status message
+        self._disabled_reason: Optional[str] = None
+
+        # Check if we should use Rich TUI
+        if not enabled:
+            self._rich_enabled = False
+            self._disabled_reason = "disabled by --no-tui flag"
+        elif not RICH_AVAILABLE:
+            self._rich_enabled = False
+            self._disabled_reason = "rich library not installed (pip install rich)"
+        elif not sys.stdout.isatty() or not sys.stderr.isatty():
+            self._rich_enabled = False
+            self._disabled_reason = "not running in a TTY (e.g., piped output or CI)"
+        else:
+            self._rich_enabled = True
+
+        # Initialize progress state
+        self.progress = BisectProgress()
+        self.output_lines: List[str] = []
+        self.max_output_lines = 100
+        self.start_time: Optional[float] = None
+
+        # Initialize Rich components (only if enabled)
+        if self._rich_enabled:
+            self._console = Console()
+            self._layout = self._create_layout()
+            self._live: Optional[Live] = None
+        else:
+            self._console = None
+            self._layout = None
+            self._live = None
+
+    @property
+    def is_tui_enabled(self) -> bool:
+        """Check if Rich TUI is enabled."""
+        return self._rich_enabled
+
+    @property
+    def disabled_reason(self) -> Optional[str]:
+        """Get the reason TUI was disabled, or None if enabled."""
+        return self._disabled_reason
+
+    def get_tui_status_message(self) -> str:
+        """Get a human-readable message about TUI status."""
+        if self._rich_enabled:
+            return "Rich TUI enabled"
+        else:
+            return f"Rich TUI disabled: {self._disabled_reason}"
+
+    def _create_layout(self) -> "Layout":
+        """
+        Create the split-screen layout.
+
+        Returns:
+            Layout with progress panel (top) and output panel (bottom).
+        """
+        layout = Layout()
+        layout.split_column(
+            Layout(name="progress", size=6),
+            Layout(name="output"),
+        )
+        return layout

--- a/tritonparse/bisect/ui.py
+++ b/tritonparse/bisect/ui.py
@@ -12,6 +12,7 @@ import re
 import sys
 import time
 from dataclasses import dataclass
+from enum import Enum
 from typing import Callable, List, Optional
 
 # Graceful fallback if rich not installed
@@ -25,6 +26,34 @@ try:
     RICH_AVAILABLE = True
 except ImportError:
     RICH_AVAILABLE = False
+
+# GitHub commit URL mapping - for generating clickable links
+GITHUB_COMMIT_URLS = {
+    "triton": "https://github.com/triton-lang/triton/commit/",
+    "llvm": "https://github.com/llvm/llvm-project/commit/",
+}
+
+# Display order - from upper layer to lower layer (call stack order)
+CULPRIT_DISPLAY_ORDER = ["triton", "llvm"]
+
+# Display names for each component
+CULPRIT_DISPLAY_NAMES = {
+    "triton": "Triton",
+    "llvm": "LLVM",
+}
+
+
+class SummaryMode(Enum):
+    """
+    Mode for print_final_summary output.
+
+    Determines the title and structure of the summary panel.
+    """
+
+    TRITON_BISECT = "triton_bisect"
+    LLVM_BISECT = "llvm_bisect"
+    FULL_WORKFLOW = "full_workflow"
+    PAIR_TEST = "pair_test"
 
 
 def _format_elapsed(seconds: float) -> str:
@@ -542,3 +571,8 @@ class BisectUI:
         if match:
             steps_remaining = int(match.group(1))
             self.update_progress(steps_remaining=steps_remaining)
+
+
+def is_rich_available() -> bool:
+    """Check if Rich library is available."""
+    return RICH_AVAILABLE

--- a/tritonparse/bisect/ui.py
+++ b/tritonparse/bisect/ui.py
@@ -1,0 +1,52 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Rich TUI interface for bisect operations.
+
+This module provides a split-screen terminal UI for displaying bisect progress
+and real-time command output. It gracefully falls back to plain text when
+Rich is not available or when running in non-TTY environments.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class BisectProgress:
+    """
+    Bisect progress state for UI display.
+
+    Attributes:
+        phase: Current phase name (e.g., "Triton Bisect").
+        phase_number: Current phase number.
+        total_phases: Total number of phases (depends on mode).
+        current_commit: Currently testing commit hash.
+        commits_tested: Number of commits tested so far.
+        steps_remaining: Estimated steps remaining (from git bisect output).
+        elapsed_seconds: Time elapsed since start.
+        status_message: Additional status message.
+        is_building: Whether currently building.
+        is_testing: Whether currently running test.
+        log_dir: Directory containing log files.
+        log_file: Main log file name.
+        command_log: Command log file name.
+        range_start_index: Pair test specific - track the starting index
+            when range filter is applied.
+    """
+
+    phase: str = "Initializing"
+    phase_number: int = 1
+    total_phases: int = 1  # Default to 1, CLI will set correct value based on mode
+    current_commit: Optional[str] = None
+    commits_tested: int = 0
+    steps_remaining: Optional[int] = None
+    elapsed_seconds: float = 0.0
+    status_message: Optional[str] = None
+    is_building: bool = False
+    is_testing: bool = False
+    log_dir: Optional[str] = None
+    log_file: Optional[str] = None
+    command_log: Optional[str] = None
+    # Pair test specific: track the starting index when range filter is applied
+    range_start_index: Optional[int] = None


### PR DESCRIPTION
Summary:
Implement the log writing functions for final summary output,
providing the ability to write bisect results to log files.

Key components implemented:

1. _write_summary_to_log() - Rich Console export:
   - Uses Console.export_text() to extract plain text without ANSI codes
   - Writes FINAL SUMMARY header with "=" borders
   - Iterates through lines, skipping empty ones
   - Includes try-except for graceful error handling

2. _write_plain_summary_to_log() - Plain mode fallback:
   - Simplified signature (removed unused parameters)
   - Computes success and title internally
   - Writes culprits with GitHub links in CULPRIT_DISPLAY_ORDER
   - Shows LLVM bump info for Triton culprits
   - Includes elapsed time and log directory

3. _write_pair_test_summary_to_log() - Pair test logging:
   - Handles three result cases: error, all_passed, found_failing
   - Writes Triton commit and LLVM bisect range
   - Includes elapsed time and log directory

Also updated print_final_summary() to use the simplified
_write_plain_summary_to_log() signature.

This is the eleventh PR in Layer 6 (TUI), completing the summary
output functionality for logging bisect results.

Differential Revision: D90870313


