### PR TITLE
[bisect] Support UV as bisect env

### DIFF
--- a/tritonparse/bisect/scripts/bisect_triton.sh
+++ b/tritonparse/bisect/scripts/bisect_triton.sh
@@ -75,9 +75,14 @@ TRITON_DIR=${TRITON_DIR:-""}
 TEST_SCRIPT=${TEST_SCRIPT:-""}
 CONDA_ENV=${CONDA_ENV:-triton_bisect}
 CONDA_DIR=${CONDA_DIR:-$HOME/miniconda3}
+USE_UV=${USE_UV:-0}
 LOG_DIR=${LOG_DIR:-./bisect_logs}
 TEST_ARGS=${TEST_ARGS:-""}
-BUILD_COMMAND=${BUILD_COMMAND:-"pip install -e ."}
+if [[ "$USE_UV" == "1" ]]; then
+  BUILD_COMMAND=${BUILD_COMMAND:-"uv pip install -e ."}
+else
+  BUILD_COMMAND=${BUILD_COMMAND:-"pip install -e ."}
+fi
 PER_COMMIT_LOG=${PER_COMMIT_LOG:-1}  # Set to 0 to disable per-commit log files
 
 # ============ Validation ============
@@ -159,19 +164,20 @@ echo "Updating git submodules..." | log_output
 git submodule update --init --recursive 2>&1 | log_output
 echo "" | log_output
 
-# Activate conda
-echo "Activating conda environment: $CONDA_ENV" | log_output
-
+# Activate conda or uv (if enabled)
 source ${CONDA_DIR}/bin/activate
 if [ $? -ne 0 ]; then
-  echo "ERROR: Cannot activate conda" | log_output
+  echo "ERROR: Cannot activate conda or uv" | log_output
   exit 128
 fi
 
-conda activate "$CONDA_ENV"
-if [ $? -ne 0 ]; then
-  echo "ERROR: Failed to activate conda environment: $CONDA_ENV" | log_output
-  exit 128
+if [ "$USE_UV" == "0" ]; then
+  echo "Activating conda environment: $CONDA_ENV" | log_output
+  conda activate "$CONDA_ENV"
+  if [ $? -ne 0 ]; then
+    echo "ERROR: Failed to activate conda environment: $CONDA_ENV" | log_output
+    exit 128
+  fi
 fi
 
 echo "" | log_output

--- a/tritonparse/bisect/triton_bisector.py
+++ b/tritonparse/bisect/triton_bisector.py
@@ -7,6 +7,7 @@ This module implements Phase 1 of the bisect workflow: bisecting Triton
 commits to find the first bad commit that causes a test to fail.
 """
 
+import os
 from pathlib import Path
 from typing import Callable, Dict, Optional, Union
 
@@ -51,6 +52,8 @@ class TritonBisector(BaseBisector):
     @property
     def default_build_command(self) -> str:
         """Default build command for Triton."""
+        if os.environ.get("USE_UV", None):
+            return "uv pip install -e ."
         return "pip install -e ."
 
     @property


### PR DESCRIPTION
Support UV as bisect env

Test command:

USE_UV=1 CONDA_ENV=py312 CONDA_DIR=$HOME/local/uv_venvs/py312 REPRO_CMDLINE="python run.py --op ragged_attention --only hstu --metrics tflops --simple-output" tritonparseoss bisect --triton-dir $HOME/triton --test-script ./.ci/bisect/bisect-script.sh --good 96e075c65e2d92800598a130d5d2d1ab2f9cdf74 --bad d3a4c78cb231c69f652a8fbfe6a087908881206f