### PR TITLE
Add line_index to reproducer filename for better identification

### DIFF
--- a/tritonparse/reproducer/orchestrator.py
+++ b/tritonparse/reproducer/orchestrator.py
@@ -87,7 +87,7 @@ def reproduce(
         f"Built context bundle for kernel: {context_bundle.kernel_info.function_name}"
     )
     out_py_path, temp_json_path = determine_output_paths(
-        out_dir, context_bundle.kernel_info.function_name, template
+        out_dir, context_bundle.kernel_info.function_name, template, line_index
     )
 
     # Save context JSON only if not embedding

--- a/tritonparse/reproducer/utils.py
+++ b/tritonparse/reproducer/utils.py
@@ -362,7 +362,9 @@ def _create_arg_from_info(arg_info):
         return None
 
 
-def determine_output_paths(out_dir: str, kernel_name: str, template: str):
+def determine_output_paths(
+    out_dir: str, kernel_name: str, template: str, line_index: int
+):
     """
     Determine output file paths for reproducer script and context data.
 
@@ -370,6 +372,7 @@ def determine_output_paths(out_dir: str, kernel_name: str, template: str):
         out_dir: Output directory path. If empty, uses default location.
         kernel_name: Name of the kernel for default directory naming.
         template: Template name or path. If a path, extracts the filename.
+        line_index: 0-based line index of the launch event in the NDJSON file.
 
     Returns:
         Tuple of (python_script_path, json_context_path) as Path objects.
@@ -383,13 +386,15 @@ def determine_output_paths(out_dir: str, kernel_name: str, template: str):
         Path(template).stem if "/" in template or "\\" in template else template
     )
 
-    filename_parts = ["repro"]
+    filename_parts = ["repro", f"line{line_index}"]
     if template != "example":
         filename_parts.append(template_name)
     filename_parts.append(timestamp)
     filename = "_".join(filename_parts) + ".py"
     out_py_path = output_directory / filename
-    temp_json_path = output_directory / f"repro_context_{timestamp}.json"
+    temp_json_path = (
+        output_directory / f"repro_line{line_index}_context_{timestamp}.json"
+    )
 
     return out_py_path, temp_json_path
 


### PR DESCRIPTION
Summary:
Fix https://github.com/meta-pytorch/tritonparse/issues/271

Previously, reproducer scripts were named with only a timestamp (e.g., `repro_20260120173000.py`), making it difficult to identify which launch event the script corresponds to.

This change adds the line index to the filename, resulting in names like:
- `repro_line42_20260120173000.py`
- `repro_line42_context_20260120173000.json`

Benefits:
- Users can easily see which line from the NDJSON file was used
- The filename directly indicates the `--line N` parameter needed to reproduce
- Works consistently whether users specify `--line N` or `--kernel xxx --launch-id M`

Differential Revision: D91047612


