### PR TITLE
Add unit tests for commit_detector.py (Test-PR-02)

### DIFF
--- a/tests/cpu/test_bisect_commit_detector.py
+++ b/tests/cpu/test_bisect_commit_detector.py
@@ -1,0 +1,195 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Unit tests for tritonparse.bisect.commit_detector module.
+
+Tests cover:
+- LLVMBumpInfo dataclass
+- _extract_hash_from_content() pure logic
+- CommitDetector with mocked ShellExecutor
+"""
+
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from tritonparse.bisect.commit_detector import (
+    CommitDetector,
+    CommitDetectorError,
+    LLVMBumpInfo,
+)
+
+
+class LLVMBumpInfoTest(unittest.TestCase):
+    """Tests for LLVMBumpInfo dataclass."""
+
+    def test_default_fields_are_none(self) -> None:
+        info = LLVMBumpInfo(is_llvm_bump=False)
+        self.assertFalse(info.is_llvm_bump)
+        self.assertIsNone(info.old_hash)
+        self.assertIsNone(info.new_hash)
+        self.assertIsNone(info.triton_commit)
+
+    def test_all_fields_populated(self) -> None:
+        info = LLVMBumpInfo(
+            is_llvm_bump=True,
+            old_hash="abc1234",
+            new_hash="def5678",
+            triton_commit="commit123",
+        )
+        self.assertTrue(info.is_llvm_bump)
+        self.assertEqual(info.old_hash, "abc1234")
+        self.assertEqual(info.new_hash, "def5678")
+        self.assertEqual(info.triton_commit, "commit123")
+
+
+class ExtractHashTest(unittest.TestCase):
+    """Tests for CommitDetector._extract_hash_from_content() pure logic."""
+
+    def setUp(self) -> None:
+        mock_logger = MagicMock()
+        mock_executor = MagicMock()
+        self.detector = CommitDetector(
+            triton_dir=Path("/fake/triton"),
+            executor=mock_executor,
+            logger=mock_logger,
+        )
+
+    def test_simple_hash(self) -> None:
+        content = "abc1234def5678901234567890123456789012"
+        result = self.detector._extract_hash_from_content(content)
+        self.assertEqual(result, "abc1234def5678901234567890123456789012")
+
+    def test_hash_with_whitespace(self) -> None:
+        content = "  abc1234def5678901234567890123456789012  \n"
+        result = self.detector._extract_hash_from_content(content)
+        self.assertEqual(result, "abc1234def5678901234567890123456789012")
+
+    def test_hash_with_newlines(self) -> None:
+        content = "\n\nabc1234def5678901234567890123456789012\n\n"
+        result = self.detector._extract_hash_from_content(content)
+        self.assertEqual(result, "abc1234def5678901234567890123456789012")
+
+    def test_hash_with_comment_lines(self) -> None:
+        content = "# This is a comment\nabc1234def5678\n# Another comment"
+        result = self.detector._extract_hash_from_content(content)
+        self.assertEqual(result, "abc1234def5678")
+
+    def test_short_hash_7_chars(self) -> None:
+        content = "abc1234"
+        result = self.detector._extract_hash_from_content(content)
+        self.assertEqual(result, "abc1234")
+
+    def test_full_40_char_hash(self) -> None:
+        content = "1234567890abcdef1234567890abcdef12345678"
+        result = self.detector._extract_hash_from_content(content)
+        self.assertEqual(result, "1234567890abcdef1234567890abcdef12345678")
+
+    def test_invalid_content_raises_error(self) -> None:
+        with self.assertRaises(CommitDetectorError):
+            self.detector._extract_hash_from_content("not a valid hash!")
+
+    def test_too_short_hash_raises_error(self) -> None:
+        with self.assertRaises(CommitDetectorError):
+            self.detector._extract_hash_from_content("abc123")
+
+    def test_empty_content_raises_error(self) -> None:
+        with self.assertRaises(CommitDetectorError):
+            self.detector._extract_hash_from_content("")
+
+    def test_only_comments_raises_error(self) -> None:
+        with self.assertRaises(CommitDetectorError):
+            self.detector._extract_hash_from_content("# Comment only\n# Another")
+
+
+class CommitDetectorTest(unittest.TestCase):
+    """Tests for CommitDetector with mocked git interactions."""
+
+    def setUp(self) -> None:
+        self.mock_logger = MagicMock()
+        self.mock_executor = MagicMock()
+        self.detector = CommitDetector(
+            triton_dir=Path("/fake/triton"),
+            executor=self.mock_executor,
+            logger=self.mock_logger,
+        )
+
+    def _make_result(
+        self, success: bool, stdout: str = "", stderr: str = ""
+    ) -> MagicMock:
+        result = MagicMock()
+        result.success = success
+        result.stdout = stdout
+        result.stderr = stderr
+        return result
+
+    def test_detect_non_llvm_bump(self) -> None:
+        self.mock_executor.run_command.return_value = self._make_result(
+            success=True, stdout="src/file1.py\nsrc/file2.py\n"
+        )
+
+        info = self.detector.detect("abc1234567890123456789012345678901234567")
+
+        self.assertFalse(info.is_llvm_bump)
+        self.assertEqual(info.triton_commit, "abc1234567890123456789012345678901234567")
+        self.assertIsNone(info.old_hash)
+        self.assertIsNone(info.new_hash)
+
+    def test_detect_llvm_bump(self) -> None:
+        old_hash = "0000000000000000000000000000000000000001"
+        new_hash = "0000000000000000000000000000000000000002"
+
+        def side_effect(cmd: list, cwd: str) -> MagicMock:
+            if cmd[1] == "diff":
+                return self._make_result(
+                    success=True, stdout="cmake/llvm-hash.txt\nsrc/other.py\n"
+                )
+            elif "~1:cmake/llvm-hash.txt" in cmd[2]:
+                return self._make_result(success=True, stdout=old_hash)
+            else:
+                return self._make_result(success=True, stdout=new_hash)
+
+        self.mock_executor.run_command.side_effect = side_effect
+
+        info = self.detector.detect("abc1234567890123456789012345678901234567")
+
+        self.assertTrue(info.is_llvm_bump)
+        self.assertEqual(info.old_hash, old_hash)
+        self.assertEqual(info.new_hash, new_hash)
+
+    def test_get_llvm_hash_at_commit_success(self) -> None:
+        self.mock_executor.run_command.return_value = self._make_result(
+            success=True, stdout="abc1234567890123456789012345678901234567\n"
+        )
+
+        result = self.detector.get_llvm_hash_at_commit("commit123")
+
+        self.assertEqual(result, "abc1234567890123456789012345678901234567")
+
+    def test_get_llvm_hash_at_commit_failure(self) -> None:
+        self.mock_executor.run_command.return_value = self._make_result(
+            success=False, stderr="fatal: not a git repository"
+        )
+
+        with self.assertRaises(CommitDetectorError):
+            self.detector.get_llvm_hash_at_commit("commit123")
+
+    def test_fallback_detection_when_diff_fails(self) -> None:
+        hash_at_commit = "aaaaaaa1234567890123456789012345678901"
+        hash_at_parent = "bbbbbbb1234567890123456789012345678901"
+        call_count = [0]
+
+        def side_effect(cmd: list, cwd: str) -> MagicMock:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return self._make_result(success=False, stderr="diff failed")
+            elif call_count[0] == 2:
+                return self._make_result(success=True, stdout=hash_at_commit)
+            else:
+                return self._make_result(success=True, stdout=hash_at_parent)
+
+        self.mock_executor.run_command.side_effect = side_effect
+
+        is_bump = self.detector._is_llvm_bump_commit("abc123")
+
+        self.assertTrue(is_bump)

--- a/tests/cpu/test_bisect_state.py
+++ b/tests/cpu/test_bisect_state.py
@@ -1,0 +1,288 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Tests for bisect state module (CPU-only, no GPU required)."""
+
+import shutil
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from tritonparse.bisect import BisectPhase, BisectState, StateManager
+
+
+class BisectPhaseTest(unittest.TestCase):
+    """Tests for BisectPhase enum."""
+
+    def test_phase_values(self):
+        """Test that all phases have expected string values."""
+        self.assertEqual(BisectPhase.TRITON_BISECT.value, "triton_bisect")
+        self.assertEqual(BisectPhase.TYPE_CHECK.value, "type_check")
+        self.assertEqual(BisectPhase.PAIR_TEST.value, "pair_test")
+        self.assertEqual(BisectPhase.LLVM_BISECT.value, "llvm_bisect")
+        self.assertEqual(BisectPhase.COMPLETED.value, "completed")
+        self.assertEqual(BisectPhase.FAILED.value, "failed")
+
+    def test_phase_from_string(self):
+        """Test creating phase from string value."""
+        self.assertEqual(BisectPhase("triton_bisect"), BisectPhase.TRITON_BISECT)
+        self.assertEqual(BisectPhase("completed"), BisectPhase.COMPLETED)
+        with self.assertRaises(ValueError):
+            BisectPhase("invalid_phase")
+
+
+class BisectStateTest(unittest.TestCase):
+    """Tests for BisectState dataclass."""
+
+    def test_default_values(self):
+        """Test default values are set correctly."""
+        state = BisectState(
+            triton_dir="/path",
+            test_script="/test.py",
+            good_commit="v1",
+            bad_commit="v2",
+        )
+        self.assertEqual(state.phase, BisectPhase.TRITON_BISECT)
+        self.assertEqual(state.conda_env, "triton_bisect")
+        self.assertEqual(state.log_dir, "./bisect_logs")
+        self.assertIsNone(state.triton_culprit)
+        self.assertIsNone(state.is_llvm_bump)
+
+    def test_to_dict_serializes_phase_as_string(self):
+        """Test to_dict converts BisectPhase enum to string."""
+        state = BisectState(
+            triton_dir="/path",
+            test_script="/test.py",
+            good_commit="v1",
+            bad_commit="v2",
+            phase=BisectPhase.TYPE_CHECK,
+        )
+        data = state.to_dict()
+        self.assertEqual(data["phase"], "type_check")
+        self.assertIsInstance(data["phase"], str)
+
+    def test_from_dict_parses_phase_string(self):
+        """Test from_dict converts string back to BisectPhase."""
+        data = {
+            "triton_dir": "/path",
+            "test_script": "/test.py",
+            "good_commit": "v1",
+            "bad_commit": "v2",
+            "phase": "llvm_bisect",
+            "commits_csv": None,
+            "conda_env": "triton_bisect",
+            "log_dir": "./bisect_logs",
+            "build_command": None,
+            "session_name": None,
+            "started_at": None,
+            "updated_at": None,
+            "triton_culprit": None,
+            "is_llvm_bump": None,
+            "old_llvm_hash": None,
+            "new_llvm_hash": None,
+            "failing_pair_index": None,
+            "good_llvm": None,
+            "bad_llvm": None,
+            "triton_commit_for_llvm": None,
+            "llvm_culprit": None,
+            "error_message": None,
+        }
+        state = BisectState.from_dict(data)
+        self.assertEqual(state.phase, BisectPhase.LLVM_BISECT)
+        self.assertIsInstance(state.phase, BisectPhase)
+
+    def test_round_trip_serialization(self):
+        """Test state survives to_dict -> from_dict round trip."""
+        original = BisectState(
+            triton_dir="/path/to/triton",
+            test_script="/path/to/test.py",
+            good_commit="abc123",
+            bad_commit="def456",
+            commits_csv="/path/to/commits.csv",
+            conda_env="my_env",
+            phase=BisectPhase.PAIR_TEST,
+            triton_culprit="culprit123",
+            is_llvm_bump=True,
+            old_llvm_hash="old_hash",
+            new_llvm_hash="new_hash",
+        )
+        data = original.to_dict()
+        restored = BisectState.from_dict(data)
+        self.assertEqual(restored.triton_dir, original.triton_dir)
+        self.assertEqual(restored.phase, original.phase)
+        self.assertEqual(restored.triton_culprit, original.triton_culprit)
+        self.assertEqual(restored.is_llvm_bump, original.is_llvm_bump)
+
+    def test_to_report_includes_llvm_info_when_bump(self):
+        """Test report includes LLVM details when is_llvm_bump=True."""
+        state = BisectState(
+            triton_dir="/path",
+            test_script="/test.py",
+            good_commit="v1",
+            bad_commit="v2",
+            phase=BisectPhase.COMPLETED,
+            triton_culprit="abc123",
+            is_llvm_bump=True,
+            old_llvm_hash="old_llvm",
+            new_llvm_hash="new_llvm",
+            good_llvm="good_llvm",
+            bad_llvm="bad_llvm",
+            llvm_culprit="llvm_culprit_hash",
+            failing_pair_index=5,
+        )
+        report = state.to_report()
+        self.assertTrue(report["is_llvm_bump"])
+        self.assertEqual(report["llvm_culprit"], "llvm_culprit_hash")
+        self.assertIn("llvm_bump", report)
+        self.assertEqual(report["llvm_bump"]["old"], "old_llvm")
+        self.assertIn("llvm_range", report)
+
+    def test_to_report_excludes_llvm_info_when_not_bump(self):
+        """Test report excludes LLVM details when is_llvm_bump=False."""
+        state = BisectState(
+            triton_dir="/path",
+            test_script="/test.py",
+            good_commit="v1",
+            bad_commit="v2",
+            phase=BisectPhase.COMPLETED,
+            triton_culprit="abc123",
+            is_llvm_bump=False,
+        )
+        report = state.to_report()
+        self.assertFalse(report["is_llvm_bump"])
+        self.assertNotIn("llvm_culprit", report)
+        self.assertNotIn("llvm_bump", report)
+
+    def test_to_report_includes_error_when_failed(self):
+        """Test report includes error message when workflow failed."""
+        state = BisectState(
+            triton_dir="/path",
+            test_script="/test.py",
+            good_commit="v1",
+            bad_commit="v2",
+            phase=BisectPhase.FAILED,
+            error_message="Something went wrong",
+        )
+        report = state.to_report()
+        self.assertEqual(report["status"], "failed")
+        self.assertIn("error", report)
+        self.assertEqual(report["error"], "Something went wrong")
+
+
+class StateManagerTest(unittest.TestCase):
+    """Tests for StateManager class."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        shutil.rmtree(self.temp_dir)
+
+    def test_get_state_path_format(self):
+        """Test state path follows {session_name}_state.json pattern."""
+        path = StateManager.get_state_path(self.temp_dir, "test_session")
+        self.assertEqual(path.name, "test_session_state.json")
+        self.assertEqual(path.parent, Path(self.temp_dir))
+
+    def test_save_creates_directory_if_not_exists(self):
+        """Test save creates parent directories."""
+        nested_dir = Path(self.temp_dir) / "nested" / "logs"
+        state = BisectState(
+            triton_dir="/path",
+            test_script="/test.py",
+            good_commit="v1",
+            bad_commit="v2",
+            log_dir=str(nested_dir),
+        )
+        path = StateManager.save(state, session_name="test_session")
+        self.assertTrue(path.exists())
+        self.assertTrue(nested_dir.exists())
+
+    def test_save_updates_timestamps(self):
+        """Test save sets started_at and updated_at."""
+        state = BisectState(
+            triton_dir="/path",
+            test_script="/test.py",
+            good_commit="v1",
+            bad_commit="v2",
+            log_dir=self.temp_dir,
+        )
+        self.assertIsNone(state.started_at)
+        self.assertIsNone(state.updated_at)
+        StateManager.save(state, session_name="test_session")
+        self.assertIsNotNone(state.started_at)
+        self.assertIsNotNone(state.updated_at)
+
+    def test_load_reads_saved_state(self):
+        """Test load correctly reads state saved by save."""
+        original = BisectState(
+            triton_dir="/path/to/triton",
+            test_script="/test.py",
+            good_commit="v1",
+            bad_commit="v2",
+            log_dir=self.temp_dir,
+            phase=BisectPhase.PAIR_TEST,
+            triton_culprit="abc123",
+        )
+        path = StateManager.save(original, session_name="test_session")
+        loaded = StateManager.load(str(path))
+        self.assertEqual(loaded.triton_dir, original.triton_dir)
+        self.assertEqual(loaded.phase, original.phase)
+        self.assertEqual(loaded.triton_culprit, original.triton_culprit)
+
+    def test_load_raises_file_not_found(self):
+        """Test load raises FileNotFoundError for missing file."""
+        with self.assertRaises(FileNotFoundError):
+            StateManager.load("/nonexistent/path/state.json")
+
+    def test_exists_returns_correct_boolean(self):
+        """Test exists returns True for existing file, False otherwise."""
+        state = BisectState(
+            triton_dir="/path",
+            test_script="/test.py",
+            good_commit="v1",
+            bad_commit="v2",
+            log_dir=self.temp_dir,
+        )
+        path = StateManager.save(state, session_name="test_session")
+        self.assertTrue(StateManager.exists(str(path)))
+        self.assertFalse(StateManager.exists("/nonexistent/path.json"))
+
+    def test_find_latest_state_returns_most_recent(self):
+        """Test find_latest_state returns file with latest mtime."""
+        # Create first state
+        state1 = BisectState(
+            triton_dir="/path1",
+            test_script="/test.py",
+            good_commit="v1",
+            bad_commit="v2",
+            log_dir=self.temp_dir,
+        )
+        StateManager.save(state1, session_name="session_old")
+        time.sleep(0.1)  # Ensure different mtime
+        # Create second state
+        state2 = BisectState(
+            triton_dir="/path2",
+            test_script="/test.py",
+            good_commit="v1",
+            bad_commit="v2",
+            log_dir=self.temp_dir,
+        )
+        StateManager.save(state2, session_name="session_new")
+        # Find latest
+        latest = StateManager.find_latest_state(self.temp_dir)
+        self.assertIsNotNone(latest)
+        self.assertIn("session_new", str(latest))
+
+    def test_find_latest_state_returns_none_for_empty_dir(self):
+        """Test find_latest_state returns None when no state files."""
+        empty_dir = Path(self.temp_dir) / "empty"
+        empty_dir.mkdir()
+        result = StateManager.find_latest_state(str(empty_dir))
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tritonparse/bisect/cli.py
+++ b/tritonparse/bisect/cli.py
@@ -1,0 +1,158 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+CLI implementation for the bisect subcommand.
+
+This module provides the command-line interface for bisecting Triton and LLVM
+commits to find regression-causing changes.
+
+Usage Examples:
+    # Default: Triton bisect only
+    tritonparseoss bisect --triton-dir /path/to/triton --test-script test.py \\
+        --good v2.0.0 --bad HEAD
+
+    # Full workflow (Triton -> detect LLVM bump -> LLVM bisect if needed)
+    tritonparseoss bisect --triton-dir /path/to/triton --test-script test.py \\
+        --good v2.0.0 --bad HEAD --commits-csv pairs.csv
+
+    # LLVM-only bisect (uses current HEAD of triton repo if --triton-commit not specified)
+    tritonparseoss bisect --llvm-only --triton-dir /path/to/triton \\
+        --test-script test.py --good-llvm def456 --bad-llvm 789abc
+
+    # LLVM-only bisect with explicit triton commit
+    tritonparseoss bisect --llvm-only --triton-dir /path/to/triton \\
+        --test-script test.py --triton-commit abc123 \\
+        --good-llvm def456 --bad-llvm 789abc
+
+    # Resume from saved state
+    tritonparseoss bisect --resume --state ./bisect_logs/state.json
+
+    # Check status
+    tritonparseoss bisect --status
+"""
+
+import argparse
+
+
+def _add_bisect_args(parser: argparse.ArgumentParser) -> None:
+    """
+    Add arguments for the bisect subcommand.
+
+    This implements smart defaults with switches:
+    - Default (no special flags) = Triton bisect only
+    - --commits-csv = Full workflow (Triton -> detect LLVM bump -> LLVM bisect if needed)
+    - --llvm-only = LLVM bisect only
+    - --resume = Resume from saved state
+    - --status = Show bisect status
+    """
+    # Mode switches (mutually exclusive)
+    mode_group = parser.add_mutually_exclusive_group()
+    mode_group.add_argument(
+        "--llvm-only",
+        action="store_true",
+        help="Only bisect LLVM commits (requires --triton-commit, --good-llvm, --bad-llvm)",
+    )
+    mode_group.add_argument(
+        "--pair-test",
+        action="store_true",
+        help="Test (Triton, LLVM) commit pairs from CSV to find LLVM bisect range "
+        "(requires --commits-csv, --good-llvm, --bad-llvm)",
+    )
+    mode_group.add_argument(
+        "--resume",
+        action="store_true",
+        help="Resume bisect from saved state file",
+    )
+    mode_group.add_argument(
+        "--status",
+        action="store_true",
+        help="Show current bisect status",
+    )
+
+    # Common arguments
+    parser.add_argument(
+        "--triton-dir",
+        type=str,
+        help="Path to Triton repository",
+    )
+    parser.add_argument(
+        "--test-script",
+        type=str,
+        help="Path to test script that determines pass/fail",
+    )
+    parser.add_argument(
+        "--conda-env",
+        type=str,
+        default="triton_bisect",
+        help="Conda environment name (default: triton_bisect)",
+    )
+    parser.add_argument(
+        "--log-dir",
+        type=str,
+        default="./bisect_logs",
+        help="Directory for log files (default: ./bisect_logs)",
+    )
+    parser.add_argument(
+        "--build-command",
+        type=str,
+        default=None,
+        help="Custom build command (default: 'pip install -e .' for Triton)",
+    )
+
+    # Triton bisect arguments
+    parser.add_argument(
+        "--good",
+        type=str,
+        help="Known good commit (test passes)",
+    )
+    parser.add_argument(
+        "--bad",
+        type=str,
+        help="Known bad commit (test fails)",
+    )
+
+    # Full workflow argument
+    parser.add_argument(
+        "--commits-csv",
+        type=str,
+        help="CSV file with (triton_commit, llvm_commit) pairs for full workflow",
+    )
+
+    # LLVM-only arguments
+    parser.add_argument(
+        "--triton-commit",
+        type=str,
+        help="Fixed Triton commit for LLVM bisect (default: current HEAD of triton-dir)",
+    )
+    parser.add_argument(
+        "--good-llvm",
+        type=str,
+        help="Known good LLVM commit (required with --llvm-only)",
+    )
+    parser.add_argument(
+        "--bad-llvm",
+        type=str,
+        help="Known bad LLVM commit (required with --llvm-only)",
+    )
+
+    # Resume/status arguments
+    parser.add_argument(
+        "--state",
+        type=str,
+        help="Path to state file (for --resume or --status)",
+    )
+
+    # TUI control
+    parser.add_argument(
+        "--tui",
+        action="store_true",
+        default=True,
+        dest="tui",
+        help="Enable Rich TUI interface (default: enabled if available)",
+    )
+    parser.add_argument(
+        "--no-tui",
+        action="store_false",
+        dest="tui",
+        help="Disable Rich TUI, use plain text output",
+    )

--- a/tritonparse/bisect/cli.py
+++ b/tritonparse/bisect/cli.py
@@ -429,3 +429,99 @@ def _handle_triton_bisect(args: argparse.Namespace) -> int:
     )
 
     return 0 if culprit else 1
+
+
+def _handle_llvm_only(args: argparse.Namespace) -> int:
+    """
+    Handle --llvm-only mode: bisect only LLVM commits.
+
+    This function performs LLVM bisect without first running Triton bisect.
+    It's useful when you already know the Triton commit to use and want to
+    find the culprit LLVM commit directly.
+
+    Args:
+        args: Parsed arguments including triton_dir, test_script,
+              triton_commit (optional), good_llvm, bad_llvm, etc.
+
+    Returns:
+        0 on success, 1 on failure.
+    """
+    from .llvm_bisector import LLVMBisectError, LLVMBisector
+    from .ui import BisectUI, print_final_summary, SummaryMode
+
+    # Initialize TUI first
+    ui = BisectUI(enabled=args.tui)
+
+    # Variables to store results for summary after TUI exits
+    culprit = None
+    error_msg = None
+    logger = None
+
+    # Use context manager to start/stop TUI - entire workflow inside
+    with ui:
+        try:
+            # Create logger inside TUI context
+            logger = _create_logger(args.log_dir)
+
+            # Configure logger for TUI mode (redirect output to TUI)
+            if ui.is_tui_enabled:
+                logger.configure_for_tui(ui.create_output_callback())
+
+            ui.append_output(ui.get_tui_status_message())
+
+            # Set initial progress: LLVM only mode has 1 phase
+            ui.update_progress(
+                phase="LLVM Bisect",
+                phase_number=1,
+                total_phases=1,
+                log_dir=str(logger.log_dir),
+                log_file=logger.module_log_path.name,
+                command_log=logger.command_log_path.name,
+            )
+
+            # Create bisector (its logs will go to TUI)
+            bisector = LLVMBisector(
+                triton_dir=args.triton_dir,
+                test_script=args.test_script,
+                conda_env=args.conda_env,
+                logger=logger,
+            )
+
+            # Run bisect
+            culprit = bisector.run(
+                triton_commit=args.triton_commit,
+                good_llvm=args.good_llvm,
+                bad_llvm=args.bad_llvm,
+                output_callback=ui.create_output_callback(),
+            )
+
+            # Show result in TUI
+            ui.append_output("")
+            ui.append_output("=" * 60)
+            ui.append_output("LLVM Bisect Result")
+            ui.append_output("=" * 60)
+            ui.append_output(f"Culprit LLVM commit: {culprit}")
+            ui.append_output(f"Log directory: {args.log_dir}")
+            ui.append_output("=" * 60)
+
+        except LLVMBisectError as e:
+            error_msg = str(e)
+            ui.append_output(f"\nLLVM bisect failed: {e}")
+        except Exception as e:
+            error_msg = str(e)
+            ui.append_output(f"\nUnexpected error: {e}")
+
+    # TUI has exited, print final summary
+    print_final_summary(
+        mode=SummaryMode.LLVM_BISECT,
+        culprits={"llvm": culprit} if culprit else None,
+        llvm_bump_info=None,
+        error_msg=error_msg,
+        log_dir=args.log_dir,
+        log_file=str(logger.module_log_path) if logger else None,
+        command_log=str(logger.command_log_path) if logger else None,
+        elapsed_time=ui.progress.elapsed_seconds,
+        logger=logger,
+    )
+
+    return 0 if culprit else 1

--- a/tritonparse/bisect/cli.py
+++ b/tritonparse/bisect/cli.py
@@ -156,3 +156,73 @@ def _add_bisect_args(parser: argparse.ArgumentParser) -> None:
         dest="tui",
         help="Disable Rich TUI, use plain text output",
     )
+
+
+def _validate_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
+    """
+    Validate argument combinations based on the selected mode.
+
+    Args:
+        args: Parsed arguments.
+        parser: ArgumentParser for error reporting.
+    """
+    if args.status:
+        # Status mode: no required args (will use default state path if not specified)
+        return
+
+    if args.resume:
+        # Resume mode: --state is optional (will use default if not specified)
+        return
+
+    if args.llvm_only:
+        # LLVM-only mode: requires specific arguments
+        missing = []
+        if not args.triton_dir:
+            missing.append("--triton-dir")
+        if not args.test_script:
+            missing.append("--test-script")
+        # --triton-commit is optional, defaults to current HEAD of triton_dir
+        if not args.good_llvm:
+            missing.append("--good-llvm")
+        if not args.bad_llvm:
+            missing.append("--bad-llvm")
+
+        if missing:
+            parser.error(
+                f"--llvm-only requires the following arguments: {', '.join(missing)}"
+            )
+        return
+
+    if args.pair_test:
+        # Pair test mode: requires CSV and LLVM range
+        missing = []
+        if not args.triton_dir:
+            missing.append("--triton-dir")
+        if not args.test_script:
+            missing.append("--test-script")
+        if not args.commits_csv:
+            missing.append("--commits-csv")
+        if not args.good_llvm:
+            missing.append("--good-llvm")
+        if not args.bad_llvm:
+            missing.append("--bad-llvm")
+
+        if missing:
+            parser.error(
+                f"--pair-test requires the following arguments: {', '.join(missing)}"
+            )
+        return
+
+    # Default mode (Triton bisect) or full workflow (with --commits-csv)
+    missing = []
+    if not args.triton_dir:
+        missing.append("--triton-dir")
+    if not args.test_script:
+        missing.append("--test-script")
+    if not args.good:
+        missing.append("--good")
+    if not args.bad:
+        missing.append("--bad")
+
+    if missing:
+        parser.error(f"The following arguments are required: {', '.join(missing)}")

--- a/tritonparse/bisect/cli.py
+++ b/tritonparse/bisect/cli.py
@@ -799,6 +799,48 @@ def _handle_triton_bisect(args: argparse.Namespace) -> int:
     return 0 if culprit else 1
 
 
+def bisect_command(args: argparse.Namespace) -> int:
+    """
+    Execute the bisect command based on parsed arguments.
+
+    This is the main entry point for the bisect subcommand. It routes
+    to the appropriate handler based on the mode flags.
+
+    Mode priority (checked in order):
+    1. --status: Show current bisect status
+    2. --resume: Resume from saved state
+    3. --llvm-only: LLVM-only bisect
+    4. --pair-test: Test commit pairs from CSV
+    5. Default: Triton bisect (or full workflow with --commits-csv)
+
+    The mode flags are mutually exclusive (enforced by argparse).
+
+    Args:
+        args: Parsed command-line arguments from _add_bisect_args().
+
+    Returns:
+        Exit code (0 for success, non-zero for failure).
+    """
+    # Handle --status mode
+    if args.status:
+        return _handle_status(args)
+
+    # Handle --resume mode
+    if args.resume:
+        return _handle_resume(args)
+
+    # Handle --llvm-only mode
+    if args.llvm_only:
+        return _handle_llvm_only(args)
+
+    # Handle --pair-test mode
+    if args.pair_test:
+        return _handle_pair_test(args)
+
+    # Default mode: Triton bisect (or full workflow if --commits-csv provided)
+    return _handle_triton_bisect(args)
+
+
 def _handle_pair_test(args: argparse.Namespace) -> int:
     """
     Handle --pair-test mode: test commit pairs to find LLVM bisect range.


### PR DESCRIPTION
Summary:
Add comprehensive unit tests for the bisect commit_detector module.

This diff adds test coverage for:
- LLVMBumpInfo dataclass: default field values and full field population
- _extract_hash_from_content() pure logic: hash parsing with whitespace, comments, validation (7-40 char hex), and error cases
- CommitDetector with mocked ShellExecutor: LLVM bump detection, non-bump detection, fallback detection when git diff fails, and error handling

The tests follow the same patterns as Test-PR-01 (using MagicMock for isolated testing) and add 17 new test scenarios across 3 test classes.

This is part of the unit test extension plan (Test-PR-02) to improve test coverage for the bisect module.

Differential Revision: D91052220


