### PR TITLE
Add URL normalization for Manifold Explorer and tritonparse URLs

### DIFF
--- a/website/src/components/DataSourceSelector.tsx
+++ b/website/src/components/DataSourceSelector.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { PaperClipIcon, LinkIcon } from "./icons";
+import { normalizeDataUrl } from "../utils/urlUtils";
 
 interface DataSourceSelectorProps {
   onFileSelected: (file: File) => void;
@@ -60,10 +61,11 @@ const DataSourceSelector: React.FC<DataSourceSelectorProps> = ({
     }
 
     try {
+      const normalizedUrl = normalizeDataUrl(url);
       // Basic URL validation
-      new URL(url);
+      new URL(normalizedUrl);
       setError(null);
-      onUrlSelected(url);
+      onUrlSelected(normalizedUrl);
     } catch {
       setError("Please enter a valid URL");
     }

--- a/website/src/pages/FileDiffView.tsx
+++ b/website/src/pages/FileDiffView.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import DiffComparisonView from "../components/DiffComparisonView";
 import { useFileDiffSession } from "../context/FileDiffSession";
 import { ProcessedKernel, loadLogData, loadLogDataFromFile, processKernelData, getIRType } from "../utils/dataLoader";
+import { normalizeDataUrl } from "../utils/urlUtils";
 import "../types/global.d.ts";
 
 type DiffMode = "single" | "all";
@@ -395,7 +396,7 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
   const handleLoadRight = async () => {
     if (!pendingUrl) return;
     setRightLoadedFromLocal(false);
-    setRightLoadedUrl(pendingUrl);
+    setRightLoadedUrl(normalizeDataUrl(pendingUrl));
   };
 
   const handleLoadRightLocal = async (file: File | null) => {
@@ -428,7 +429,7 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
   const handleLoadLeft = async () => {
     if (!leftPendingUrlLocal) return;
     setLeftLoadedFromLocal(false);
-    setLeftLoadedUrlLocal(leftPendingUrlLocal);
+    setLeftLoadedUrlLocal(normalizeDataUrl(leftPendingUrlLocal));
   };
   const handleLoadLeftLocal = async (file: File | null) => {
     if (!file) return;

--- a/website/src/utils/urlUtils.ts
+++ b/website/src/utils/urlUtils.ts
@@ -1,0 +1,67 @@
+/**
+ * URL normalization utilities for handling various Meta-internal URL formats
+ */
+
+const MANIFOLD_EXPLORER_PREFIX = 'https://www.internalfb.com/manifold/explorer/';
+const INTERNCACHE_MANIFOLD_PREFIX = 'https://interncache-all.fbcdn.net/manifold/';
+
+/**
+ * Extract json_url parameter from a tritonparse website URL
+ * 
+ * Example input:
+ *   https://interncache-all.fbcdn.net/manifold/tritonparse/tree/index.html?json_url=https%3A%2F%2F...&view=ir_code_comparison
+ * 
+ * Example output:
+ *   https://interncache-all.fbcdn.net/manifold/tlparse_reports/tree/logs/...
+ */
+function extractJsonUrlParam(url: string): string {
+  try {
+    const urlObj = new URL(url);
+    const jsonUrl = urlObj.searchParams.get('json_url');
+    if (jsonUrl) {
+      return jsonUrl; // URLSearchParams automatically decodes the value
+    }
+  } catch {
+    // Not a valid URL, return as-is
+  }
+  return url;
+}
+
+/**
+ * Convert Manifold Explorer URL to interncache URL
+ * 
+ * Example input:
+ *   https://www.internalfb.com/manifold/explorer/tlparse_reports/tree/logs/tmpy6uh65b8/file.ndjson.gz
+ * 
+ * Example output:
+ *   https://interncache-all.fbcdn.net/manifold/tlparse_reports/tree/logs/tmpy6uh65b8/file.ndjson.gz
+ */
+function convertManifoldExplorerUrl(url: string): string {
+  if (url.startsWith(MANIFOLD_EXPLORER_PREFIX)) {
+    const path = url.substring(MANIFOLD_EXPLORER_PREFIX.length);
+    return INTERNCACHE_MANIFOLD_PREFIX + path;
+  }
+  return url;
+}
+
+/**
+ * Normalize a data URL to a format that can be directly fetched.
+ * 
+ * Handles:
+ * 1. tritonparse website URLs with json_url parameter - extracts the actual data URL
+ * 2. Manifold Explorer URLs - converts to interncache format
+ * 
+ * The order matters: first extract json_url (which may itself be a Manifold Explorer URL),
+ * then convert if needed.
+ */
+export function normalizeDataUrl(inputUrl: string): string {
+  let url = inputUrl.trim();
+  
+  // Step 1: Extract json_url parameter if present
+  url = extractJsonUrlParam(url);
+  
+  // Step 2: Convert Manifold Explorer URL to interncache
+  url = convertManifoldExplorerUrl(url);
+  
+  return url;
+}


### PR DESCRIPTION
Summary:
Fix https://github.com/meta-pytorch/tritonparse/issues/323

Add URL normalization utilities to handle special URL formats when loading data:

1. Extract `json_url` parameter from tritonparse website URLs (e.g., when users copy a full tritonparse link with `?json_url=...&view=...`)
2. Convert Manifold Explorer URLs (`https://www.internalfb.com/manifold/explorer/...`) to interncache format (`https://interncache-all.fbcdn.net/manifold/...`)

This improves UX by allowing users to paste various URL formats directly without manual conversion. The normalized URL is displayed in the UI after loading.

Differential Revision: D91740498


