### PR TITLE
Add preserve_autotune mode for reproducers

### DIFF
--- a/tests/cpu/test_function_extractor.py
+++ b/tests/cpu/test_function_extractor.py
@@ -1,0 +1,504 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+"""Tests for function extractor functionality."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from tritonparse.reproducer.function_extractor import (
+    extract_autotune_config_params,
+    extract_function_with_decorators,
+    is_constexpr_param,
+)
+
+
+class TestExtractAutotuneConfigParams(unittest.TestCase):
+    """Tests for extract_autotune_config_params function."""
+
+    def test_extract_simple_config(self):
+        """Test simple triton.Config patterns."""
+        source = """
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_M": 64, "BLOCK_N": 64}),
+        triton.Config({"BLOCK_M": 128, "BLOCK_N": 32}),
+    ],
+    key=["M", "N"]
+)
+@triton.jit
+def matmul_kernel(a_ptr, b_ptr, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
+    pass
+"""
+        params = extract_autotune_config_params(source)
+        self.assertEqual(params, {"BLOCK_M", "BLOCK_N"})
+
+    def test_extract_quoted_keys(self):
+        """Test quoted keys."""
+        source = """
+triton.Config({'BLOCK_SIZE': 128, 'NUM_WARPS': 4})
+"""
+        params = extract_autotune_config_params(source)
+        self.assertEqual(params, {"BLOCK_SIZE", "NUM_WARPS"})
+
+    def test_extract_unquoted_keys(self):
+        """Test unquoted keys."""
+        source = """
+triton.Config({BLOCK_SIZE: 128, NUM_STAGES: 2})
+"""
+        params = extract_autotune_config_params(source)
+        self.assertEqual(params, {"BLOCK_SIZE", "NUM_STAGES"})
+
+    def test_extract_multiple_configs(self):
+        """Test multiple Config instances."""
+        source = """
+configs = [
+    triton.Config({"BLOCK_M": 64, "BLOCK_K": 32}),
+    triton.Config({"BLOCK_M": 128, "BLOCK_K": 64, "BLOCK_N": 64}),
+]
+"""
+        params = extract_autotune_config_params(source)
+        self.assertEqual(params, {"BLOCK_M", "BLOCK_K", "BLOCK_N"})
+
+    def test_no_configs(self):
+        """Test source with no triton.Config."""
+        source = """
+@triton.jit
+def simple_kernel(a_ptr, n_elements):
+    pid = tl.program_id(0)
+"""
+        params = extract_autotune_config_params(source)
+        self.assertEqual(params, set())
+
+    def test_empty_source(self):
+        """Test empty source."""
+        params = extract_autotune_config_params("")
+        self.assertEqual(params, set())
+
+    def test_direct_config_import(self):
+        """Test Config imported directly."""
+        source = """
+from triton import Config
+
+configs = [
+    Config({"BLOCK_M": 64, "BLOCK_N": 32}),
+    Config({"BLOCK_M": 128, "BLOCK_N": 64}),
+]
+"""
+        params = extract_autotune_config_params(source)
+        self.assertEqual(params, {"BLOCK_M", "BLOCK_N"})
+
+    def test_config_with_keyword_args(self):
+        """Test Config with keyword arguments."""
+        source = """
+triton.Config({"BLOCK_M": 64}, BLOCK_N=32, BLOCK_K=16)
+"""
+        params = extract_autotune_config_params(source)
+        self.assertEqual(params, {"BLOCK_M", "BLOCK_N", "BLOCK_K"})
+
+    def test_config_filters_triton_specific_kwargs(self):
+        """Test triton-specific kwargs are filtered."""
+        source = """
+triton.Config(
+    {"BLOCK_M": 64, "BLOCK_N": 32},
+    num_warps=4,
+    num_stages=2,
+    num_ctas=1,
+)
+"""
+        params = extract_autotune_config_params(source)
+        self.assertEqual(params, {"BLOCK_M", "BLOCK_N"})
+        self.assertNotIn("num_warps", params)
+        self.assertNotIn("num_stages", params)
+        self.assertNotIn("num_ctas", params)
+
+    def test_config_filters_all_triton_kwargs(self):
+        """Test all triton kwargs are filtered."""
+        source = """
+triton.Config(
+    {"BLOCK_SIZE": 128},
+    num_warps=4,
+    num_stages=3,
+    num_ctas=2,
+    pre_hook=some_func,
+    minRegAutoWS=32,
+    maxRegAutoWS=64,
+    pingpongAutoWS=1,
+    maxnreg=128,
+)
+"""
+        params = extract_autotune_config_params(source)
+        self.assertEqual(params, {"BLOCK_SIZE"})
+
+    def test_syntax_error_handling(self):
+        """Test syntax errors return empty set."""
+        source = """
+def broken_function(
+    # Missing closing paren
+triton.Config({"BLOCK": 64})
+"""
+        params = extract_autotune_config_params(source)
+        self.assertEqual(params, set())
+
+    def test_mixed_dict_and_keyword_params(self):
+        """Test dict and keyword params combined."""
+        source = """
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_M": 64}, BLOCK_N=32, num_warps=4),
+        triton.Config({"BLOCK_M": 128}, BLOCK_N=64, BLOCK_K=32, num_stages=2),
+    ],
+    key=["M"]
+)
+@triton.jit
+def kernel():
+    pass
+"""
+        params = extract_autotune_config_params(source)
+        self.assertEqual(params, {"BLOCK_M", "BLOCK_N", "BLOCK_K"})
+
+    def test_config_only_keyword_args(self):
+        """Test Config with only keyword args."""
+        source = """
+triton.Config(BLOCK_M=64, BLOCK_N=32, num_warps=4)
+"""
+        params = extract_autotune_config_params(source)
+        self.assertEqual(params, {"BLOCK_M", "BLOCK_N"})
+
+    def test_module_level_config_list_with_direct_configs(self):
+        """Test module-level config list used in autotune decorator."""
+        source = """
+from triton import Config
+
+MATMUL_CONFIGS = [
+    Config(
+        {"BLOCK_M": 128, "BLOCK_N": 256, "BLOCK_K": 32, "SPLIT_K": 1},
+        num_stages=3,
+        num_warps=8,
+    ),
+    Config(
+        {"BLOCK_M": 256, "BLOCK_N": 128, "BLOCK_K": 32, "SPLIT_K": 1},
+        num_stages=3,
+        num_warps=8,
+    ),
+    Config(
+        {"BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 128, "SPLIT_K": 1},
+        num_stages=4,
+        num_warps=4,
+    ),
+]
+
+@triton.autotune(
+    configs=MATMUL_CONFIGS,
+    key=["M", "N", "K"],
+)
+@triton.jit
+def matmul_kernel(
+    a_ptr, b_ptr, c_ptr,
+    M, N, K,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    SPLIT_K: tl.constexpr,
+):
+    pass
+"""
+        params = extract_autotune_config_params(source)
+        self.assertEqual(params, {"BLOCK_M", "BLOCK_N", "BLOCK_K", "SPLIT_K"})
+
+    def test_function_returning_config_list(self):
+        """Test function that returns a list of configs."""
+        source = """
+from triton import Config
+
+def get_configs_io_bound():
+    configs = []
+    for num_stages in [2, 3, 4, 5, 6]:
+        for block_m in [16, 32]:
+            for block_k in [32, 64]:
+                for block_n in [32, 64, 128, 256]:
+                    num_warps = 2 if block_n <= 64 else 4
+                    configs.append(
+                        Config(
+                            {
+                                "BLOCK_M": block_m,
+                                "BLOCK_N": block_n,
+                                "BLOCK_K": block_k,
+                                "SPLIT_K": 1,
+                            },
+                            num_stages=num_stages,
+                            num_warps=num_warps,
+                        )
+                    )
+    return configs
+
+@triton.autotune(
+    configs=get_configs_io_bound(),
+    key=["M", "N", "K"],
+)
+@triton.jit
+def io_bound_kernel(BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr, SPLIT_K: tl.constexpr):
+    pass
+"""
+        params = extract_autotune_config_params(source)
+        self.assertEqual(params, {"BLOCK_M", "BLOCK_N", "BLOCK_K", "SPLIT_K"})
+
+    def test_list_comprehension_with_inline_config(self):
+        """Test list comprehension with Config."""
+        source = """
+configs = [
+    triton.Config({"BLOCK_M": bm, "BLOCK_N": bn}, num_warps=4)
+    for bm in [64, 128, 256]
+    for bn in [32, 64, 128]
+]
+
+@triton.autotune(configs=configs, key=["M", "N"])
+@triton.jit
+def kernel(BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
+    pass
+"""
+        params = extract_autotune_config_params(source)
+        self.assertEqual(params, {"BLOCK_M", "BLOCK_N"})
+
+    def test_helper_function_generates_config_with_dict_literal(self):
+        """Test helper function that builds config_kwargs dict."""
+        source = """
+def make_tile_config(BM, BN, occ, subtile, subtile_p, vectmul, add2reduce):
+    config_kwargs = {
+        "BLOCK_M": BM,
+        "BLOCK_N": BN,
+        "occupancy": occ,
+        "SUBTILING": subtile,
+        "SUBTILING_P": subtile_p,
+        "VECT_MUL": vectmul,
+        "FADD2_REDUCE": add2reduce,
+    }
+    extra_kwargs = {"pre_hook": _host_descriptor_pre_hook}
+    return triton.Config(config_kwargs, **extra_kwargs)
+
+TILE_CONFIGS = [
+    make_tile_config(128, 128, 2, True, False, True, True),
+    make_tile_config(128, 64, 3, True, False, True, True),
+]
+
+@triton.autotune(configs=TILE_CONFIGS, key=["seqlen_q", "seqlen_k"])
+@triton.jit
+def attention_kernel(
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    occupancy: tl.constexpr,
+    SUBTILING: tl.constexpr,
+    SUBTILING_P: tl.constexpr,
+    VECT_MUL: tl.constexpr,
+    FADD2_REDUCE: tl.constexpr,
+):
+    pass
+"""
+        params = extract_autotune_config_params(source)
+        self.assertEqual(
+            params,
+            {
+                "BLOCK_M",
+                "BLOCK_N",
+                "occupancy",
+                "SUBTILING",
+                "SUBTILING_P",
+                "VECT_MUL",
+                "FADD2_REDUCE",
+            },
+        )
+
+    def test_config_with_variable_dict_reference(self):
+        """Test Config with variable dict reference."""
+        source = """
+config_dict = {"BLOCK_M": 64, "BLOCK_N": 32, "BLOCK_K": 16}
+triton.Config(config_dict, num_warps=4)
+"""
+        params = extract_autotune_config_params(source)
+        self.assertEqual(params, {"BLOCK_M", "BLOCK_N", "BLOCK_K"})
+
+    def test_helper_with_standard_config_pattern(self):
+        """Test standard config helper pattern."""
+        source = """
+from triton import Config
+
+def make_standard_config(BM, BN, BK, num_stages, num_warps):
+    config = {
+        "BLOCK_M": BM,
+        "BLOCK_N": BN,
+        "BLOCK_K": BK,
+    }
+    return Config(config, num_stages=num_stages, num_warps=num_warps)
+
+configs = [
+    make_standard_config(128, 256, 32, 3, 8),
+    make_standard_config(64, 128, 64, 4, 4),
+]
+"""
+        params = extract_autotune_config_params(source)
+        self.assertEqual(params, {"BLOCK_M", "BLOCK_N", "BLOCK_K"})
+
+
+class TestIsConstexprParam(unittest.TestCase):
+    """Tests for is_constexpr_param function."""
+
+    def test_constexpr_with_spaces(self):
+        """Test constexpr with spaces."""
+        source = "def kernel(a_ptr, BLOCK_SIZE: tl.constexpr): pass"
+        self.assertTrue(is_constexpr_param("BLOCK_SIZE", source))
+
+    def test_constexpr_without_spaces(self):
+        """Test constexpr without spaces."""
+        source = "def kernel(a_ptr, BLOCK_SIZE:tl.constexpr): pass"
+        self.assertTrue(is_constexpr_param("BLOCK_SIZE", source))
+
+    def test_non_constexpr_param(self):
+        """Test non-constexpr params return False."""
+        source = "def kernel(a_ptr, BLOCK_SIZE: tl.constexpr): pass"
+        self.assertFalse(is_constexpr_param("a_ptr", source))
+
+    def test_param_not_in_source(self):
+        """Test params not in source return False."""
+        source = "def kernel(a_ptr, n_elements): pass"
+        self.assertFalse(is_constexpr_param("BLOCK_SIZE", source))
+
+    def test_multiline_signature(self):
+        """Test multiline function signature."""
+        source = """
+def matmul_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    M,
+    N,
+    K,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    pass
+"""
+        self.assertTrue(is_constexpr_param("BLOCK_M", source))
+        self.assertTrue(is_constexpr_param("BLOCK_N", source))
+        self.assertTrue(is_constexpr_param("BLOCK_K", source))
+        self.assertFalse(is_constexpr_param("M", source))
+        self.assertFalse(is_constexpr_param("a_ptr", source))
+
+
+class TestExtractFunctionWithDecorators(unittest.TestCase):
+    """Tests for extract_function_with_decorators function."""
+
+    def test_extract_simple_function(self):
+        """Test simple function without decorators."""
+        source = """
+def simple_function(x, y):
+    return x + y
+
+def other_function():
+    pass
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
+            tmp.write(source)
+            tmp.flush()
+
+            result = extract_function_with_decorators(tmp.name, "simple_function")
+
+            self.assertIsNotNone(result)
+            self.assertIn("def simple_function", result)
+            self.assertIn("return x + y", result)
+            # Should not include the other function
+            self.assertNotIn("other_function", result)
+
+            # Cleanup
+            Path(tmp.name).unlink()
+
+    def test_extract_function_with_decorator(self):
+        """Test function with decorators."""
+        source = """
+import triton
+import triton.language as tl
+
+@triton.autotune(
+    configs=[triton.Config({"BLOCK": 64})],
+    key=["n"]
+)
+@triton.jit
+def my_kernel(x_ptr, n, BLOCK: tl.constexpr):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK + tl.arange(0, BLOCK)
+    tl.store(x_ptr + offsets, 0)
+
+def helper_function():
+    pass
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
+            tmp.write(source)
+            tmp.flush()
+
+            result = extract_function_with_decorators(tmp.name, "my_kernel")
+
+            self.assertIsNotNone(result)
+            # Should include decorators
+            self.assertIn("@triton.autotune", result)
+            self.assertIn("@triton.jit", result)
+            # Should include function body
+            self.assertIn("def my_kernel", result)
+            self.assertIn("tl.program_id", result)
+            # Should not include other function
+            self.assertNotIn("helper_function", result)
+
+            # Cleanup
+            Path(tmp.name).unlink()
+
+    def test_extract_nonexistent_function(self):
+        """Test nonexistent function returns None."""
+        source = """
+def existing_function():
+    pass
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
+            tmp.write(source)
+            tmp.flush()
+
+            result = extract_function_with_decorators(tmp.name, "nonexistent_function")
+
+            self.assertIsNone(result)
+
+            # Cleanup
+            Path(tmp.name).unlink()
+
+    def test_extract_from_nonexistent_file(self):
+        """Test nonexistent file returns None."""
+        result = extract_function_with_decorators(
+            "/nonexistent/path/to/file.py", "some_function"
+        )
+        self.assertIsNone(result)
+
+    def test_extract_with_source_repo_dir(self):
+        """Test path resolution with source_repo_dir."""
+        source = """
+def target_function():
+    return 42
+"""
+        # Create a nested directory structure
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create file at tmpdir/subdir/kernel.py
+            subdir = Path(tmpdir) / "subdir"
+            subdir.mkdir()
+            kernel_file = subdir / "kernel.py"
+            kernel_file.write_text(source)
+
+            # Try to extract using a "production" path that doesn't exist
+            # but can be resolved using source_repo_dir
+            prod_path = "/some/prod/path/subdir/kernel.py"
+
+            result = extract_function_with_decorators(
+                prod_path, "target_function", source_repo_dir=tmpdir
+            )
+
+            self.assertIsNotNone(result)
+            self.assertIn("def target_function", result)
+            self.assertIn("return 42", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tritonparse/reproducer/function_extractor.py
+++ b/tritonparse/reproducer/function_extractor.py
@@ -5,10 +5,15 @@ Function extractor for reproducer utility functions.
 
 This module extracts utility functions from utils.py and load_tensor.py
 using AST parsing, and generates standalone code for reproducers.
+
+It also provides utilities for extracting kernel functions with their
+decorators (e.g., @triton.autotune) from source files.
 """
 
 import ast
 import importlib.resources
+from pathlib import Path
+from typing import Optional
 
 
 def _read_source_from_package(package: str, resource: str) -> str:
@@ -260,3 +265,235 @@ def _generate_imports() -> str:
         "import triton.language as tl",
     ]
     return "\n".join(imports)
+
+
+def extract_function_with_decorators(
+    file_path: str,
+    function_name: str,
+    source_repo_dir: Optional[str] = None,
+) -> Optional[str]:
+    """
+    Extract a function's source code including decorators from a file.
+
+    Resolves production paths to local repo paths if source_repo_dir is provided.
+
+    Args:
+        file_path: Path to the source file (may be a production path).
+        function_name: Name of the function to extract.
+        source_repo_dir: Optional repo directory for path resolution.
+
+    Returns:
+        Function source with decorators, or None if not found.
+    """
+    source_path = Path(file_path)
+
+    # Try to resolve the path if it doesn't exist
+    if not source_path.exists() and source_repo_dir:
+        source_repo_path = Path(source_repo_dir)
+        if source_repo_path.exists():
+            # Try progressively shorter path suffixes
+            for i in range(1, len(source_path.parts)):
+                new_path = source_repo_path / Path("/".join(source_path.parts[i:]))
+                if new_path.exists():
+                    source_path = new_path
+                    break
+
+    if not source_path.exists():
+        return None
+
+    try:
+        source_content = source_path.read_text()
+        tree, lines = _parse_source_code(source_content, str(source_path))
+        return _extract_function(tree, lines, function_name)
+    except Exception:
+        return None
+
+
+def extract_autotune_config_params(source_code: str) -> set[str]:
+    """
+    Extract parameter names provided by @triton.autotune configs.
+
+    Finds all triton.Config(...) calls in the source and extracts the dict keys,
+    which are the parameters the autotuner provides at runtime.
+
+    Handles patterns like:
+    - Direct dict literals: triton.Config({"BLOCK_M": 64, ...})
+    - Variable references: config_kwargs = {...}; triton.Config(config_kwargs, ...)
+
+    Args:
+        source_code: Kernel source including decorators and any config helpers.
+
+    Returns:
+        Set of autotune-provided parameter names, or empty set if none found.
+    """
+    params: set[str] = set()
+
+    try:
+        tree, _ = _parse_source_code(source_code)
+    except SyntaxError:
+        return params
+
+    # Build variable bindings for dict literals
+    var_bindings = _build_variable_bindings(tree)
+
+    for node in ast.walk(tree):
+        # Look for triton.Config(...) calls
+        if isinstance(node, ast.Call):
+            if _is_triton_config_call(node):
+                # Extract keys from dict argument (first positional or keyword args)
+                params.update(_extract_config_dict_keys(node, var_bindings))
+
+    return params
+
+
+def _build_variable_bindings(tree: ast.AST) -> dict[str, ast.Dict]:
+    """Build a mapping from variable names to dict literals.
+
+    Scans the AST for simple assignments like:
+        config_kwargs = {"BLOCK_M": 64, ...}
+
+    This enables resolving variable references in triton.Config(config_kwargs, ...).
+
+    Args:
+        tree: The parsed AST.
+
+    Returns:
+        Dict mapping variable names to their ast.Dict values.
+    """
+    bindings: dict[str, ast.Dict] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            # Handle: var = {...}
+            if (
+                len(node.targets) == 1
+                and isinstance(node.targets[0], ast.Name)
+                and isinstance(node.value, ast.Dict)
+            ):
+                bindings[node.targets[0].id] = node.value
+    return bindings
+
+
+def _is_triton_config_call(node: ast.Call) -> bool:
+    """Check if an AST Call node is a triton.Config(...) call."""
+    func = node.func
+    # Handle: triton.Config(...)
+    if isinstance(func, ast.Attribute) and func.attr == "Config":
+        if isinstance(func.value, ast.Name) and func.value.id == "triton":
+            return True
+    # Handle: Config(...) when imported directly
+    if isinstance(func, ast.Name) and func.id == "Config":
+        return True
+    return False
+
+
+# Triton.Config-specific kwargs that aren't kernel params
+# These are compile/runtime parameters that triton.Config accepts but are not
+# user-defined kernel config parameters.
+# Reference: triton.Config class in triton/runtime/autotuner.py
+# https://github.com/triton-lang/triton/blob/main/python/triton/runtime/autotuner.py
+from tritonparse.reproducer.utils import TRITON_COMPILE_PARAMS
+
+_TRITON_CONFIG_KWARGS = set(TRITON_COMPILE_PARAMS) | {
+    "pre_hook",
+    # Warp specialization parameters that may appear in some Triton versions
+    "minRegAutoWS",
+    "maxRegAutoWS",
+    "pingpongAutoWS",
+}
+
+
+def _extract_config_dict_keys(
+    node: ast.Call, var_bindings: dict[str, ast.Dict]
+) -> set[str]:
+    """Extract keys from the dict argument of a triton.Config call.
+
+    Handles direct dict literals and variable references to dict literals.
+
+    Args:
+        node: The AST Call node for triton.Config(...)
+        var_bindings: Mapping from variable names to their dict literal values.
+
+    Returns:
+        Set of config parameter names.
+    """
+    keys: set[str] = set()
+
+    # Check first positional argument
+    if node.args:
+        first_arg = node.args[0]
+        # Handle direct dict literal
+        if isinstance(first_arg, ast.Dict):
+            keys.update(_extract_dict_keys(first_arg))
+        # Handle variable reference to a dict
+        elif isinstance(first_arg, ast.Name) and first_arg.id in var_bindings:
+            keys.update(_extract_dict_keys(var_bindings[first_arg.id]))
+
+    # Also check keyword arguments passed directly to Config
+    for keyword in node.keywords:
+        if keyword.arg is not None:
+            # Skip triton.Config-specific kwargs that aren't kernel params
+            if keyword.arg not in _TRITON_CONFIG_KWARGS:
+                keys.add(keyword.arg)
+
+    return keys
+
+
+def _extract_dict_keys(dict_node: ast.Dict) -> set[str]:
+    """Extract keys from an AST Dict node.
+
+    Handles both quoted string keys ('BLOCK_SIZE') and unquoted identifier
+    keys (BLOCK_SIZE) which are valid Python dict syntax.
+    """
+    keys: set[str] = set()
+    for key in dict_node.keys:
+        if key is not None:
+            if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                keys.add(key.value)
+            elif isinstance(key, ast.Str):  # Python 3.7 compatibility
+                keys.add(key.s)
+            elif isinstance(key, ast.Name):
+                # Handle unquoted identifier keys like {BLOCK_SIZE: 128}
+                keys.add(key.id)
+    return keys
+
+
+def _is_constexpr_annotation(annotation: ast.expr) -> bool:
+    """Check if an annotation is tl.constexpr or triton.language.constexpr."""
+    if isinstance(annotation, ast.Attribute) and annotation.attr == "constexpr":
+        if isinstance(annotation.value, ast.Name):
+            return annotation.value.id in ("tl", "triton")
+        if isinstance(annotation.value, ast.Attribute):
+            return annotation.value.attr == "language"
+    return False
+
+
+def is_constexpr_param(param_name: str, source_code: str) -> bool:
+    """
+    Check if a parameter is annotated as tl.constexpr in the kernel signature.
+
+    Args:
+        param_name: Name of the parameter to check.
+        source_code: Kernel source code containing the function signature.
+
+    Returns:
+        True if the parameter has a `: tl.constexpr` annotation, False otherwise.
+
+    Example:
+        >>> source = "def kernel(a_ptr, BLOCK_SIZE: tl.constexpr): pass"
+        >>> is_constexpr_param("BLOCK_SIZE", source)
+        True
+        >>> is_constexpr_param("a_ptr", source)
+        False
+    """
+    try:
+        tree = ast.parse(source_code)
+    except SyntaxError:
+        return False
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            for arg in node.args.args:
+                if arg.arg == param_name and arg.annotation is not None:
+                    if _is_constexpr_annotation(arg.annotation):
+                        return True
+    return False


### PR DESCRIPTION
Summary:
This diff adds a `preserve_autotune` parameter to `DefaultPlaceholderReplacer` that allows reproducers to re-autotune rather than using captured configs.

**New Public APIs in function_extractor.py:**
- `extract_function_with_decorators(file_path, function_name, source_repo_dir)` - Extracts kernel source including all decorators (triton.autotune, triton.jit)
- `extract_autotune_config_params(source_code)` - Parses source to find triton.Config params
- `is_constexpr_param(param_name, source_code)` - Checks if param has tl.constexpr annotation

**New Public APIs in kernel_query.py:**
- `find_best_autotuned_launch_index(events, kernel_name)` - Finds the launch with best autotuned config (not benchmark runs)
- `_is_autotuning_benchmark_launch(event)` - Helper to detect benchmark vs production launches

**Changes to DefaultPlaceholderReplacer:**
- Added `preserve_autotune: bool = False` parameter
- When enabled: skips autotune-disabling code, re-extracts kernel with decorators, filters autotune-provided params

This enables downstream tools (like triton-mpp) to generate reproducers that can re-autotune fresh, potentially finding better configurations for given inputs.

Differential Revision: D91901077


