### PR TITLE
Fix ModuleNotFoundError for tritonparse.fb in atexit cleanup

### DIFF
--- a/tritonparse/structured_logging.py
+++ b/tritonparse/structured_logging.py
@@ -24,7 +24,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 from triton.knobs import JITHook, LaunchHook
 from tritonparse._json_compat import dumps, loads
 
-from .shared_vars import DEFAULT_TRACE_FILE_PREFIX
+from .shared_vars import DEFAULT_TRACE_FILE_PREFIX, is_fbcode
 
 
 log = logging.getLogger(__name__)
@@ -1163,6 +1163,7 @@ class TritonTraceHandler(logging.StreamHandler):
             self.close()
         if (
             TRITONPARSE_TRACE_MANIFOLD
+            and is_fbcode()
             and hasattr(self, "log_file_name")
             and self.log_file_name
             and os.path.exists(self.log_file_name)


### PR DESCRIPTION
## Summary

This PR fixes an OSS-only shutdown error in `TritonTraceHandler._cleanup()`.

When `TRITONPARSE_TRACE_MANIFOLD` is enabled, cleanup may try to import the fb-only uploader in OSS environments and print `ModuleNotFoundError: No module named 'tritonparse.fb'` during `atexit`, even though trace generation and parsing have already succeeded.

related issue：#373 

## Changes

- import `is_fbcode` from `shared_vars`
- gate the Manifold upload path in `_cleanup()` behind `is_fbcode()`

This keeps the existing internal upload behavior unchanged while skipping the fb-only uploader path in OSS.

## Testing
<img width="1369" height="425" alt="image" src="https://github.com/user-attachments/assets/82fa23a7-764b-47b9-bc58-ae6bf6115ccc" />
- ran `python /root/project/tritonparse/tests/test_add.py` in an OSS environment
- confirmed the script still generates trace and parsed output successfully
- confirmed the `atexit` cleanup no longer raises `ModuleNotFoundError` for `tritonparse.fb`