### PR TITLE
Make tensor blob saving count per compilation hash

### DIFF
--- a/tests/gpu/test_tensor_blob.py
+++ b/tests/gpu/test_tensor_blob.py
@@ -333,6 +333,47 @@ class TestTensorBlob(GPUTestBase):
             )
             print(f"✓ skip=1, max=2: {blobs_5b} blob(s) saved (runs 2 and 3 only)")
 
+        # Test 5c: max_runs=1 with different BLOCK_SIZE (different hash per config)
+        # Verifies per-hash counting: each unique compilation gets its own budget
+        print("\n--- Test 5c: max_runs=1 per hash ---")
+        temp_output_dir_5c = tempfile.mkdtemp()
+
+        with tritonparse.context_manager.TritonParseManager(
+            enable_trace_launch=True,
+            enable_tensor_blob_storage=True,
+            tensor_save_max_runs=1,
+            out=temp_output_dir_5c,
+        ) as manager:
+            # Run kernel with BLOCK_SIZE=256 twice — same hash, only 1st saves
+            for i in range(2):
+                x = torch.randn(
+                    (512,), device=self.cuda_device, dtype=torch.float32
+                ) * (i + 1)
+                run_kernel(x)
+            # Run kernel with BLOCK_SIZE=128 twice — different hash, only 1st saves
+            for i in range(2):
+                x = torch.randn(
+                    (512,), device=self.cuda_device, dtype=torch.float32
+                ) * (i + 1)
+                n_elements = x.numel()
+                output = torch.empty_like(x)
+                grid = (triton.cdiv(n_elements, 128),)
+                tensor_input_kernel[grid](x, output, n_elements, 128)
+            torch.cuda.synchronize()
+
+            blobs_5c = count_all_blobs(manager.dir_path)
+            print(f"  Blobs with max_runs=1, 2 hashes x 2 launches: {blobs_5c}")
+            # 2 unique hashes, each saves 1 run → 2 runs save blobs
+            # Each run has input + output = 2 blobs, but dedup may reduce
+            # Expect 2-4 blobs (1-2 per hash)
+            self.assertGreaterEqual(blobs_5c, 2, "Should save blobs from both hashes")
+            self.assertLessEqual(
+                blobs_5c,
+                4,
+                "Should save at most 4 blobs (input+output per hash)",
+            )
+            print(f"✓ max_runs=1 per hash: {blobs_5c} blob(s) from 2 hashes")
+
         # Clean up all test outputs
         try:
             if TEST_KEEP_OUTPUT:
@@ -343,7 +384,8 @@ class TestTensorBlob(GPUTestBase):
                     f"  Test 3: {temp_output_dir_3}\n"
                     f"  Test 4: {temp_output_dir_4}\n"
                     f"  Test 5a: {temp_output_dir_5a}\n"
-                    f"  Test 5b: {temp_output_dir_5b}"
+                    f"  Test 5b: {temp_output_dir_5b}\n"
+                    f"  Test 5c: {temp_output_dir_5c}"
                 )
             else:
                 for temp_dir in [
@@ -353,6 +395,7 @@ class TestTensorBlob(GPUTestBase):
                     temp_output_dir_4,
                     temp_output_dir_5a,
                     temp_output_dir_5b,
+                    temp_output_dir_5c,
                 ]:
                     if os.path.exists(temp_dir):
                         shutil.rmtree(temp_dir)

--- a/tritonparse/structured_logging.py
+++ b/tritonparse/structured_logging.py
@@ -89,8 +89,8 @@ TRITONPARSE_DUMP_SASS = os.getenv("TRITONPARSE_DUMP_SASS", None) in [
 
 # The flag to mark if launch is traced. It is used to avoid initilizing the launch hook twice.
 _trace_launch_enabled = False
-# Kernel run counter and per-launch blob save flag for skip/max runs gating
-_kernel_run_count = 0
+# Per-hash run counter and per-launch blob save flag for skip/max runs gating
+_kernel_run_counts_per_hash: dict[str, int] = {}
 _save_blobs_for_current_launch = True
 # Enable tensor blob storage
 TRITONPARSE_SAVE_TENSOR_BLOBS = os.getenv("TRITONPARSE_SAVE_TENSOR_BLOBS", "0") in [
@@ -1467,7 +1467,7 @@ def extract_arg_info(arg_dict):
 
 
 def add_launch_metadata(grid, metadata, arg_dict, inductor_args=None):
-    global _kernel_run_count, _save_blobs_for_current_launch
+    global _save_blobs_for_current_launch
 
     # Check if we're in CUDA graph capture mode - if so, skip detailed argument extraction
     # to avoid CUDA errors (cudaErrorStreamCaptureUnsupported)
@@ -1489,19 +1489,22 @@ def add_launch_metadata(grid, metadata, arg_dict, inductor_args=None):
             )
         }
 
-    # Gate tensor blob saving based on skip/max runs
+    # Gate tensor blob saving: always skip benchmark launches, then apply
+    # per-compilation-hash skip/max_runs so each autotuned config gets its
+    # own budget (e.g. max_runs=1 saves one set of blobs per config).
     if TRITONPARSE_SAVE_TENSOR_BLOBS:
         skip = TRITONPARSE_TENSOR_SAVE_SKIP_RUNS
         max_runs = TRITONPARSE_TENSOR_SAVE_MAX_RUNS
-        if skip > 0 or max_runs > 0:
-            # Only capture the stack when we actually need kernel run counting
-            from .parse.sourcemap_utils import _is_autotune_benchmark_launch
+        from .parse.sourcemap_utils import _is_autotune_benchmark_launch
 
-            if not _is_autotune_benchmark_launch(get_stack_trace()):
-                _kernel_run_count += 1
+        if _is_autotune_benchmark_launch(get_stack_trace()):
+            _save_blobs_for_current_launch = False
+        elif skip > 0 or max_runs > 0:
+            kernel_hash = metadata._asdict().get("hash", "")
+            count = _kernel_run_counts_per_hash.get(kernel_hash, 0) + 1
+            _kernel_run_counts_per_hash[kernel_hash] = count
             _save_blobs_for_current_launch = not (
-                _kernel_run_count <= skip
-                or (max_runs > 0 and _kernel_run_count > skip + max_runs)
+                count <= skip or (max_runs > 0 and count > skip + max_runs)
             )
         else:
             _save_blobs_for_current_launch = True
@@ -1850,7 +1853,7 @@ def clear_logging_config():
     global TRITON_TRACE_HANDLER, triton_trace_folder, _KERNEL_ALLOWLIST_PATTERNS
     global _trace_launch_enabled
     global TENSOR_BLOB_MANAGER
-    global _kernel_run_count, _save_blobs_for_current_launch
+    global _kernel_run_counts_per_hash, _save_blobs_for_current_launch
     # 1. Clean up the log handler
     if TRITON_TRACE_HANDLER is not None:
         if TRITON_TRACE_HANDLER in triton_trace_log.handlers:
@@ -1865,7 +1868,7 @@ def clear_logging_config():
 
     # 3. Reset tensor blob manager and related flags
     TENSOR_BLOB_MANAGER = None
-    _kernel_run_count = 0
+    _kernel_run_counts_per_hash = {}
     _save_blobs_for_current_launch = True
 
     # 4. Reset Triton knobs


### PR DESCRIPTION
Summary:
The skip/max_runs gating for tensor blob saving previously used a single
global counter. With max_runs=1, only the first autotuned winner launch
saved blobs — later configs got no blobs even though they have different
compiled binaries.

This changes the counter to per-compilation-hash (metadata.hash). Each
unique compiled kernel variant gets its own skip/max_runs budget. With
max_runs=1, each autotuned config saves exactly one set of blobs.

Also always skips benchmark launches (autotune timing runs) regardless
of skip/max_runs settings, since they're never useful for reproducers.

Reviewed By: FindHao

Differential Revision: D100015808


