### PR TITLE
feat: Add `clp-ffi-js` to support loading CLP archives in the log viewer.

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -11,7 +11,7 @@
         "@heroicons/react": "^2.2.0",
         "@monaco-editor/react": "^4.7.0",
         "@types/react-syntax-highlighter": "^15.5.13",
-        "clp-ffi-js": "^0.7.0-beta.2",
+        "clp-ffi-js": "^0.7.0-beta.3",
         "monaco-editor": "^0.55.1",
         "prismjs": "^1.30.0",
         "react": "^19.2.5",
@@ -29,7 +29,7 @@
         "@vitejs/plugin-react": "^6.0.1",
         "autoprefixer": "^10.4.27",
         "eslint": "^10.2.0",
-        "eslint-plugin-react-hooks": "*",
+        "eslint-plugin-react-hooks": "canary",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
         "postcss": "^8.5.9",
@@ -1715,9 +1715,9 @@
       }
     },
     "node_modules/clp-ffi-js": {
-      "version": "0.7.0-beta.2",
-      "resolved": "https://registry.npmjs.org/clp-ffi-js/-/clp-ffi-js-0.7.0-beta.2.tgz",
-      "integrity": "sha512-pUzwlcZERuaij/4t/oIx54cMsWwBjjg91GbJhGzIjKJcXC1r+BYbOYLfmij3oDexkhUfYa/dNkYf+NoeGNIrNQ==",
+      "version": "0.7.0-beta.3",
+      "resolved": "https://registry.npmjs.org/clp-ffi-js/-/clp-ffi-js-0.7.0-beta.3.tgz",
+      "integrity": "sha512-5IzqidXR4dNy77tbaruQwjwkn4A0rmcU28z+pKjyK8O4pc3X9QDptmqUgZEuJDpUsWujU2ev/hfYUOC+lxhDMA==",
       "license": "Apache-2.0"
     },
     "node_modules/comma-separated-tokens": {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -11,6 +11,7 @@
         "@heroicons/react": "^2.2.0",
         "@monaco-editor/react": "^4.7.0",
         "@types/react-syntax-highlighter": "^15.5.13",
+        "clp-ffi-js": "^0.7.0-beta.2",
         "monaco-editor": "^0.55.1",
         "prismjs": "^1.30.0",
         "react": "^19.2.5",
@@ -1712,6 +1713,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/clp-ffi-js": {
+      "version": "0.7.0-beta.2",
+      "resolved": "https://registry.npmjs.org/clp-ffi-js/-/clp-ffi-js-0.7.0-beta.2.tgz",
+      "integrity": "sha512-pUzwlcZERuaij/4t/oIx54cMsWwBjjg91GbJhGzIjKJcXC1r+BYbOYLfmij3oDexkhUfYa/dNkYf+NoeGNIrNQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",

--- a/website/package.json
+++ b/website/package.json
@@ -14,6 +14,7 @@
     "@heroicons/react": "^2.2.0",
     "@monaco-editor/react": "^4.7.0",
     "@types/react-syntax-highlighter": "^15.5.13",
+    "clp-ffi-js": "^0.7.0-beta.2",
     "monaco-editor": "^0.55.1",
     "prismjs": "^1.30.0",
     "react": "^19.2.5",

--- a/website/package.json
+++ b/website/package.json
@@ -14,7 +14,7 @@
     "@heroicons/react": "^2.2.0",
     "@monaco-editor/react": "^4.7.0",
     "@types/react-syntax-highlighter": "^15.5.13",
-    "clp-ffi-js": "^0.7.0-beta.2",
+    "clp-ffi-js": "^0.7.0-beta.3",
     "monaco-editor": "^0.55.1",
     "prismjs": "^1.30.0",
     "react": "^19.2.5",

--- a/website/src/components/DataSourceSelector.tsx
+++ b/website/src/components/DataSourceSelector.tsx
@@ -39,16 +39,19 @@ const DataSourceSelector: React.FC<DataSourceSelectorProps> = ({
     if (files && files.length > 0) {
       const file = files[0];
 
-      // Support NDJSON and compressed files only
+      // Support NDJSON, gzip-compressed files, or CLP archives only
       const fileName = file.name.toLowerCase();
       const isValidFile =
-        fileName.endsWith(".ndjson") || fileName.endsWith(".gz") || file.type === "application/x-ndjson";
+        fileName.endsWith(".ndjson") ||
+        fileName.endsWith(".gz") ||
+        fileName.endsWith(".clp") ||
+        file.type === "application/x-ndjson";
 
       if (isValidFile) {
         setError(null);
         onFileSelected(file);
       } else {
-        setError("Please select an NDJSON or compressed file");
+        setError("Please select an NDJSON, gzip-compressed file, or CLP archive.");
       }
     }
   };
@@ -88,7 +91,7 @@ const DataSourceSelector: React.FC<DataSourceSelectorProps> = ({
           <input
             type="file"
             id="fileInput"
-            accept=".ndjson,.gz,application/x-ndjson,application/gzip"
+            accept=".clp,.gz,.ndjson,application/gzip,application/x-ndjson"
             onChange={handleFileChange}
             disabled={isLoading}
             className="hidden"
@@ -117,7 +120,7 @@ const DataSourceSelector: React.FC<DataSourceSelectorProps> = ({
               type="url"
               value={url}
               onChange={(e) => setUrl(e.target.value)}
-              placeholder="Enter NDJSON file URL"
+              placeholder="Enter NDJSON, .gz, .clp URL"
               className="flex-1 p-2 border border-gray-300 rounded-l-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
               disabled={isLoading}
             />

--- a/website/src/components/WelcomeScreen.tsx
+++ b/website/src/components/WelcomeScreen.tsx
@@ -19,9 +19,12 @@ const WelcomeScreen: React.FC<WelcomeScreenProps> = ({ loadDefaultData, handleFi
     if (files && files.length > 0) {
       const file = files[0];
 
-      // Support NDJSON and compressed files only
+      // Support NDJSON, gzip-compressed, or CLP files only
       const fileName = file.name.toLowerCase();
-      const isValidFile = fileName.endsWith(".ndjson") || fileName.endsWith(".gz");
+      const isValidFile =
+        fileName.endsWith(".ndjson") ||
+        fileName.endsWith(".gz") ||
+        fileName.endsWith(".clp");
 
       if (isValidFile) {
         handleFileSelected(file);
@@ -51,9 +54,12 @@ const WelcomeScreen: React.FC<WelcomeScreenProps> = ({ loadDefaultData, handleFi
     if (files && files.length > 0) {
       const file = files[0];
 
-      // Support NDJSON and compressed files only
+      // Support NDJSON, gzip-compressed files, or CLP archives only
       const fileName = file.name.toLowerCase();
-      const isValidFile = fileName.endsWith(".ndjson") || fileName.endsWith(".gz");
+      const isValidFile =
+        fileName.endsWith(".ndjson") ||
+        fileName.endsWith(".gz") ||
+        fileName.endsWith(".clp");
 
       if (isValidFile) {
         handleFileSelected(file);
@@ -65,8 +71,8 @@ const WelcomeScreen: React.FC<WelcomeScreenProps> = ({ loadDefaultData, handleFi
     <div className="flex flex-col items-center justify-center px-4 py-16 max-w-4xl mx-auto text-center">
       <h2 className="text-2xl font-bold text-gray-800 mb-6">Welcome to TritonParse</h2>
       <p className="mb-8 text-gray-600">
-        Load a Triton log file to analyze compiled kernels and their IR representations. Supports NDJSON and compressed
-        (.gz) files.
+        Load a Triton log file to analyze compiled kernels and their IR representations. Supports NDJSON,
+        gzip-compressed files, or CLP archives.
       </p>
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-8 w-full max-w-4xl mb-10">
@@ -96,13 +102,13 @@ const WelcomeScreen: React.FC<WelcomeScreenProps> = ({ loadDefaultData, handleFi
           </div>
           <h3 className="text-lg font-medium text-gray-800 mb-2">Local File</h3>
           <p className="text-sm text-gray-600 mb-4">
-            {isDragOver ? 'Drop Triton log file here' : 'Open or drag a Triton log file (NDJSON or .gz)'}
+            {isDragOver ? 'Drop Triton log file here' : 'Open or drag a Triton log file (NDJSON, .gz or .clp)'}
           </p>
           <label htmlFor="welcomeFileInput" className="absolute inset-0 cursor-pointer" aria-label="Open local file" />
           <input
             type="file"
             id="welcomeFileInput"
-            accept=".ndjson,.gz,application/x-ndjson,application/gzip"
+            accept=".clp,.gz,.ndjson,application/gzip,application/x-ndjson"
             onChange={handleFileChange}
             className="hidden"
           />

--- a/website/src/pages/FileDiffView.tsx
+++ b/website/src/pages/FileDiffView.tsx
@@ -475,7 +475,7 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
             <div className="flex items-center gap-2 mb-1">
               <input
                 type="file"
-                accept=".ndjson,.ndjson.gz,.gz,.jsonl"
+                accept=".ndjson,.ndjson.gz,.gz,.jsonl,.clp"
                 className="block w-full text-sm text-gray-700"
                 onChange={(e) => handleLoadLeftLocal(e.target.files?.[0] || null)}
                 disabled={loadingLeft}
@@ -530,7 +530,7 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
             <div className="flex items-center gap-2 mb-1">
               <input
                 type="file"
-                accept=".ndjson,.ndjson.gz,.gz,.jsonl"
+                accept=".ndjson,.ndjson.gz,.gz,.jsonl,.clp"
                 className="block w-full text-sm text-gray-700"
                 onChange={(e) => handleLoadRightLocal(e.target.files?.[0] || null)}
                 disabled={loadingRight}

--- a/website/src/utils/dataLoader.ts
+++ b/website/src/utils/dataLoader.ts
@@ -1,4 +1,4 @@
-import { ClpArchiveReader } from "clp-ffi-js/sfa";
+import { ClpArchiveReader, isClpFile } from "clp-ffi-js/sfa";
 
 /**
  * Source mapping information that connects lines in IR code to source code
@@ -410,23 +410,6 @@ function isGzipFile(buffer: ArrayBuffer): boolean {
     // Check for gzip magic number (first two bytes should be 0x1F, 0x8B)
     const header = new Uint8Array(buffer.slice(0, 2));
     return header[0] === 0x1F && header[1] === 0x8B;
-}
-
-/**
- * Detects if a file is in CLP JSON single-file archive (SFA) format by checking
- * its header bytes.
- * @param buffer - ArrayBuffer containing the file data
- * @returns Boolean indicating if the file is a clp-json single-file archive
- */
-function isClpFile(buffer: ArrayBuffer): boolean {
-    // Check for CLP JSON SFA magic number: 0xFD 0x2F 0xC5 0x30
-    const header = new Uint8Array(buffer.slice(0, 4));
-    return (
-        header[0] === 0xFD &&
-        header[1] === 0x2F &&
-        header[2] === 0xC5 &&
-        header[3] === 0x30
-    );
 }
 
 /**

--- a/website/src/utils/dataLoader.ts
+++ b/website/src/utils/dataLoader.ts
@@ -566,15 +566,17 @@ export async function loadLogData(url: string): Promise<LogEntry[]> {
  * @param file - The File object to load
  * @returns Promise resolving to an array of LogEntry objects
  */
-export function loadLogDataFromFile(file: File): Promise<LogEntry[]> {
+export async function loadLogDataFromFile(file: File): Promise<LogEntry[]> {
     // For large files, we should use streaming to avoid memory issues
     const LARGE_FILE_THRESHOLD = 100 * 1024 * 1024; // 100 MB
-    if (file.size > LARGE_FILE_THRESHOLD) {
-        console.log(`File size (${file.size} bytes) exceeds threshold, using streaming.`);
-        // Note: This does not handle gzipped files selected locally, as we can't
-        // easily detect gzip from a stream without reading parts of it first.
-        // The assumption is that very large local files are not gzipped or
-        // have already been decompressed.
+    const header = await file.slice(0, 4).arrayBuffer();
+    if (file.size > LARGE_FILE_THRESHOLD && false === isGzipFile(header) && false === isClpFile(header)) {
+        // For large files, use streaming to avoid high memory usage. We read a
+        // small header upfront to detect known compression formats (gzip or
+        // CLP). Streaming is only used for files that exceed the size threshold
+        // and are not detected as compressed, since compressed streams require
+        // different handling.
+        console.log(`NDJSON file size (${file.size} bytes) exceeds threshold, using streaming.`);
         return parseLogDataFromStream(file.stream() as ReadableStream<Uint8Array>);
     }
 

--- a/website/src/utils/dataLoader.ts
+++ b/website/src/utils/dataLoader.ts
@@ -568,15 +568,14 @@ export async function loadLogData(url: string): Promise<LogEntry[]> {
  * @returns Promise resolving to an array of LogEntry objects
  */
 export async function loadLogDataFromFile(file: File): Promise<LogEntry[]> {
-    // For large files, we should use streaming to avoid memory issues
+    // For large NDJSON files, we should use streaming to avoid memory issues.
+    // We read a small header upfront to detect known compression formats (gzip
+    // or CLP). Streaming is only used for files that exceed the size threshold
+    // and are not detected as compressed, since compressed streams require
+    // different handling inside `processArrayBuffer`.
     const LARGE_FILE_THRESHOLD = 100 * 1024 * 1024; // 100 MB
     const header = await file.slice(0, 4).arrayBuffer();
     if (file.size > LARGE_FILE_THRESHOLD && false === isGzipFile(header) && false === isClpFile(header)) {
-        // For large files, use streaming to avoid high memory usage. We read a
-        // small header upfront to detect known compression formats (gzip or
-        // CLP). Streaming is only used for files that exceed the size threshold
-        // and are not detected as compressed, since compressed streams require
-        // different handling.
         console.log(`NDJSON file size (${file.size} bytes) exceeds threshold, using streaming.`);
         return parseLogDataFromStream(file.stream() as ReadableStream<Uint8Array>);
     }

--- a/website/src/utils/dataLoader.ts
+++ b/website/src/utils/dataLoader.ts
@@ -563,7 +563,7 @@ export async function loadLogData(url: string): Promise<LogEntry[]> {
 
 
 /**
- * Loads log data from a local file using FileReader
+ * Loads log data from a local file using Blob arrayBuffer
  * @param file - The File object to load
  * @returns Promise resolving to an array of LogEntry objects
  */
@@ -575,39 +575,18 @@ export async function loadLogDataFromFile(file: File): Promise<LogEntry[]> {
     // different handling inside `processArrayBuffer`.
     const LARGE_FILE_THRESHOLD = 100 * 1024 * 1024; // 100 MB
     const header = await file.slice(0, 4).arrayBuffer();
-    if (file.size > LARGE_FILE_THRESHOLD && false === isGzipFile(header) && false === isClpFile(header)) {
+    if (file.size > LARGE_FILE_THRESHOLD && !isGzipFile(header) && !isClpFile(header)) {
         console.log(`NDJSON file size (${file.size} bytes) exceeds threshold, using streaming.`);
         return parseLogDataFromStream(file.stream() as ReadableStream<Uint8Array>);
     }
 
     // For smaller files, reading into memory is faster and simpler.
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-
-        reader.onload = async (event) => {
-            try {
-                if (!event.target || !event.target.result) {
-                    throw new Error("Failed to read file");
-                }
-
-                const result = event.target.result;
-                if (!(result instanceof ArrayBuffer)) {
-                    throw new Error("Expected ArrayBuffer from FileReader");
-                }
-
-                resolve(await processArrayBuffer(result));
-            } catch (error) {
-                console.error("Error parsing data from file:", error);
-                reject(error);
-            }
-        };
-
-        reader.onerror = () => {
-            reject(new Error("Error reading file"));
-        };
-
-        reader.readAsArrayBuffer(file);
-    });
+    try {
+        return await processArrayBuffer(await file.arrayBuffer());
+    } catch (error) {
+        console.error("Error parsing data from file:", error);
+        throw error;
+    }
 }
 
 /**

--- a/website/src/utils/dataLoader.ts
+++ b/website/src/utils/dataLoader.ts
@@ -1,3 +1,5 @@
+import { ClpArchiveReader } from "clp-ffi-js/sfa";
+
 /**
  * Source mapping information that connects lines in IR code to source code
  */
@@ -411,6 +413,22 @@ function isGzipFile(buffer: ArrayBuffer): boolean {
 }
 
 /**
+ * Detects if a file is in clp-json single-file archive format by checking its header bytes.
+ * @param buffer - ArrayBuffer containing the file data
+ * @returns Boolean indicating if the file is a clp-json single-file archive
+ */
+function isClpFile(buffer: ArrayBuffer): boolean {
+    // Check for clp-s sfa magic number: 0xFD 0x2F 0xC5 0x30
+    const header = new Uint8Array(buffer.slice(0, 4));
+    return (
+        header[0] === 0xFD &&
+        header[1] === 0x2F &&
+        header[2] === 0xC5 &&
+        header[3] === 0x30
+    );
+}
+
+/**
  * Parses log data from a stream, handling line-by-line NDJSON parsing.
  * This is memory-efficient and suitable for very large files.
  * @param stream - A ReadableStream of Uint8Array (e.g., from a decompressed file)
@@ -470,8 +488,38 @@ async function parseLogDataFromStream(stream: ReadableStream<Uint8Array>): Promi
  * @returns Promise resolving to an array of LogEntry objects
  */
 export async function processArrayBuffer(buffer: ArrayBuffer): Promise<LogEntry[]> {
-    // Check if file is gzip compressed
-    if (isGzipFile(buffer)) {
+    if (isClpFile(buffer)) {
+        const entries: LogEntry[] = [];
+        let reader: ClpArchiveReader | null = null;
+        try {
+            reader = await ClpArchiveReader.create(new Uint8Array(buffer));
+
+            for (const event of reader.decodeAll()) {
+                try {
+                    const parsedLine: LogEntry = JSON.parse(event.message);
+                    if (parsedLine && typeof parsedLine === 'object') {
+                        entries.push(parsedLine);
+                    }
+                } catch {
+                    console.warn(`Failed to parse line as JSON: ${event.message.substring(0, 100)}...`);
+                    continue;
+                }
+            }
+        } catch (error) {
+            console.error('Error decompressing or parsing clp stream:', error);
+            const message = error instanceof Error ? error.message : String(error);
+            throw new Error(`Failed to process clp stream: ${message}`, { cause: error });
+        } finally {
+            reader?.close();
+        }
+
+        if (entries.length === 0) {
+            console.error("No valid JSON entries found in CLP archive");
+            throw new Error("No valid JSON entries found in CLP archive");
+        }
+
+        return entries;
+    } else if (isGzipFile(buffer)) {
         try {
             if (!('DecompressionStream' in window)) {
                 throw new Error('DecompressionStream API is not supported in this browser');

--- a/website/src/utils/dataLoader.ts
+++ b/website/src/utils/dataLoader.ts
@@ -413,12 +413,13 @@ function isGzipFile(buffer: ArrayBuffer): boolean {
 }
 
 /**
- * Detects if a file is in clp-json single-file archive format by checking its header bytes.
+ * Detects if a file is in CLP JSON single-file archive (SFA) format by checking
+ * its header bytes.
  * @param buffer - ArrayBuffer containing the file data
  * @returns Boolean indicating if the file is a clp-json single-file archive
  */
 function isClpFile(buffer: ArrayBuffer): boolean {
-    // Check for clp-s sfa magic number: 0xFD 0x2F 0xC5 0x30
+    // Check for CLP JSON SFA magic number: 0xFD 0x2F 0xC5 0x30
     const header = new Uint8Array(buffer.slice(0, 4));
     return (
         header[0] === 0xFD &&

--- a/website/src/utils/dataLoader.ts
+++ b/website/src/utils/dataLoader.ts
@@ -484,7 +484,8 @@ async function parseLogDataFromStream(stream: ReadableStream<Uint8Array>): Promi
 
 
 /**
- * Processes ArrayBuffer data, handling gzip decompression and parsing if needed
+ * Processes ArrayBuffer data, handling decompression and parsing as needed for
+ * supported compression formats
  * @param buffer - ArrayBuffer containing the data
  * @returns Promise resolving to an array of LogEntry objects
  */


### PR DESCRIPTION
Continuation of https://github.com/meta-pytorch/tritonparse/pull/326.
Now that structured logging can emit CLP archives, this PR adds UI support for loading and parsing CLP archives in the log viewer.
This PR closes #369. The current PR is the formal version that passed internal review at YScope.