### PR TITLE
Add zstd compression support for trace file writing (#385)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tritonparse"
 dynamic = ["version"]
-dependencies = ["orjson>=3.9", "rich>=13.0"]
+dependencies = ["orjson>=3.9", "rich>=13.0", "zstandard>=0.19.0"]
 requires-python = ">=3.10"
 description = "TritonParse: A Compiler Tracer, Visualizer, and mini-Reproducer Generator for Triton Kernels"
 readme = "README.md"
@@ -24,6 +24,7 @@ pytorch-triton = [
 ]
 test = [
     "coverage>=7.0.0",
+    "parameterized>=0.9.0",
 ]
 dev = [
     "ufmt==2.9.0",

--- a/tests/cpu/test_compression.py
+++ b/tests/cpu/test_compression.py
@@ -1,0 +1,251 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+"""Tests for tritonparse.tools.compression module.
+
+Covers magic number detection, transparent reading of gzip/zstd/plain files,
+and the critical multi-frame zstd scenario (per-record frame concatenation).
+"""
+
+import gzip
+import tempfile
+import unittest
+from pathlib import Path
+
+import zstandard as zstd
+from tritonparse.tools.compression import (
+    detect_compression,
+    is_gzip_file,
+    is_zstd_file,
+    iter_lines,
+    open_compressed_file,
+)
+
+
+class DetectCompressionTest(unittest.TestCase):
+    """Tests for detect_compression() magic number detection."""
+
+    def test_detect_gzip(self):
+        with tempfile.NamedTemporaryFile(suffix=".gz", delete=False) as f:
+            path = f.name
+            with gzip.open(f, "wb") as gz:
+                gz.write(b"hello\n")
+        try:
+            self.assertEqual(detect_compression(path), "gzip")
+        finally:
+            Path(path).unlink()
+
+    def test_detect_zstd(self):
+        cctx = zstd.ZstdCompressor()
+        data = cctx.compress(b"hello\n")
+        with tempfile.NamedTemporaryFile(suffix=".zst", delete=False) as f:
+            path = f.name
+            f.write(data)
+        try:
+            self.assertEqual(detect_compression(path), "zstd")
+        finally:
+            Path(path).unlink()
+
+    def test_detect_plain_text(self):
+        with tempfile.NamedTemporaryFile(suffix=".ndjson", delete=False, mode="w") as f:
+            path = f.name
+            f.write('{"key": "value"}\n')
+        try:
+            self.assertEqual(detect_compression(path), "none")
+        finally:
+            Path(path).unlink()
+
+    def test_detect_nonexistent_file(self):
+        with self.assertRaises(FileNotFoundError):
+            detect_compression("/nonexistent/path/file.ndjson")
+
+
+class IsCompressedFileTest(unittest.TestCase):
+    """Tests for is_gzip_file() and is_zstd_file() helpers."""
+
+    def test_is_gzip_file(self):
+        with tempfile.NamedTemporaryFile(suffix=".gz", delete=False) as f:
+            path = f.name
+            with gzip.open(f, "wb") as gz:
+                gz.write(b"test\n")
+        try:
+            self.assertTrue(is_gzip_file(path))
+            self.assertFalse(is_zstd_file(path))
+        finally:
+            Path(path).unlink()
+
+    def test_is_zstd_file(self):
+        cctx = zstd.ZstdCompressor()
+        with tempfile.NamedTemporaryFile(suffix=".zst", delete=False) as f:
+            path = f.name
+            f.write(cctx.compress(b"test\n"))
+        try:
+            self.assertTrue(is_zstd_file(path))
+            self.assertFalse(is_gzip_file(path))
+        finally:
+            Path(path).unlink()
+
+    def test_nonexistent_returns_false(self):
+        self.assertFalse(is_gzip_file("/nonexistent"))
+        self.assertFalse(is_zstd_file("/nonexistent"))
+
+
+class OpenCompressedFileTest(unittest.TestCase):
+    """Tests for open_compressed_file() transparent reading."""
+
+    def test_read_plain_text(self):
+        with tempfile.NamedTemporaryFile(suffix=".ndjson", delete=False, mode="w") as f:
+            path = f.name
+            f.write('{"a": 1}\n{"a": 2}\n')
+        try:
+            with open_compressed_file(path) as fh:
+                lines = fh.readlines()
+            self.assertEqual(len(lines), 2)
+            self.assertIn('"a": 1', lines[0])
+        finally:
+            Path(path).unlink()
+
+    def test_read_gzip(self):
+        with tempfile.NamedTemporaryFile(suffix=".gz", delete=False) as f:
+            path = f.name
+            with gzip.open(f, "wt", encoding="utf-8") as gz:
+                gz.write('{"b": 1}\n{"b": 2}\n')
+        try:
+            with open_compressed_file(path) as fh:
+                lines = fh.readlines()
+            self.assertEqual(len(lines), 2)
+        finally:
+            Path(path).unlink()
+
+    def test_read_gzip_multi_member(self):
+        """Gzip member concatenation (same pattern as TritonTraceHandler gzip mode)."""
+        with tempfile.NamedTemporaryFile(suffix=".bin.ndjson", delete=False) as f:
+            path = f.name
+            for i in range(5):
+                record = f'{{"line": {i}}}\n'.encode("utf-8")
+                member = gzip.compress(record)
+                f.write(member)
+        try:
+            with open_compressed_file(path) as fh:
+                lines = fh.readlines()
+            self.assertEqual(len(lines), 5)
+            self.assertIn('"line": 0', lines[0])
+            self.assertIn('"line": 4', lines[4])
+        finally:
+            Path(path).unlink()
+
+    def test_read_zstd_single_frame(self):
+        cctx = zstd.ZstdCompressor()
+        content = '{"c": 1}\n{"c": 2}\n'
+        with tempfile.NamedTemporaryFile(suffix=".zst", delete=False) as f:
+            path = f.name
+            f.write(cctx.compress(content.encode("utf-8")))
+        try:
+            with open_compressed_file(path) as fh:
+                lines = fh.readlines()
+            self.assertEqual(len(lines), 2)
+        finally:
+            Path(path).unlink()
+
+    def test_read_zstd_multi_frame(self):
+        """Multi-frame zstd (same pattern as TritonTraceHandler zstd mode).
+
+        This is the critical test: each JSON record is compressed as a separate
+        zstd frame. The reader must use read_across_frames=True to read all
+        frames, not just the first one.
+        """
+        cctx = zstd.ZstdCompressor()
+        with tempfile.NamedTemporaryFile(suffix=".bin.ndjson", delete=False) as f:
+            path = f.name
+            for i in range(10):
+                record = f'{{"line": {i}}}\n'.encode("utf-8")
+                f.write(cctx.compress(record))
+        try:
+            with open_compressed_file(path) as fh:
+                lines = fh.readlines()
+            # Must read ALL 10 frames, not just the first one
+            self.assertEqual(len(lines), 10)
+            for i in range(10):
+                self.assertIn(f'"line": {i}', lines[i])
+        finally:
+            Path(path).unlink()
+
+    def test_nonexistent_file_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            with open_compressed_file("/nonexistent/file"):
+                pass
+
+
+class IterLinesTest(unittest.TestCase):
+    """Tests for iter_lines() helper."""
+
+    def test_iter_lines_plain(self):
+        with tempfile.NamedTemporaryFile(suffix=".ndjson", delete=False, mode="w") as f:
+            path = f.name
+            f.write("line1\nline2\nline3\n")
+        try:
+            lines = list(iter_lines(path))
+            self.assertEqual(lines, ["line1", "line2", "line3"])
+        finally:
+            Path(path).unlink()
+
+    def test_iter_lines_zstd_multi_frame(self):
+        """iter_lines must handle multi-frame zstd files correctly."""
+        cctx = zstd.ZstdCompressor()
+        with tempfile.NamedTemporaryFile(suffix=".bin.ndjson", delete=False) as f:
+            path = f.name
+            for i in range(5):
+                f.write(cctx.compress(f"record_{i}\n".encode("utf-8")))
+        try:
+            lines = list(iter_lines(path))
+            self.assertEqual(len(lines), 5)
+            self.assertEqual(lines[0], "record_0")
+            self.assertEqual(lines[4], "record_4")
+        finally:
+            Path(path).unlink()
+
+
+class ZstdRoundTripTest(unittest.TestCase):
+    """End-to-end round-trip test simulating TritonTraceHandler write + read."""
+
+    def test_write_read_round_trip(self):
+        """Simulate TritonTraceHandler.emit() zstd path, then read back."""
+        cctx = zstd.ZstdCompressor()
+        records = [
+            '{"event": "compilation", "kernel": "add_kernel", "idx": 0}\n',
+            '{"event": "compilation", "kernel": "matmul_kernel", "idx": 1}\n',
+            '{"event": "launch", "kernel": "add_kernel", "idx": 2}\n',
+        ]
+
+        with tempfile.NamedTemporaryFile(
+            suffix=".bin.ndjson", mode="ab+", delete=False
+        ) as f:
+            path = f.name
+            # Simulate per-record compression (same as emit())
+            for record in records:
+                compressed = cctx.compress(record.encode("utf-8"))
+                f.write(compressed)
+
+        try:
+            # Verify magic number detection identifies as zstd
+            self.assertEqual(detect_compression(path), "zstd")
+
+            # Verify all records are readable
+            with open_compressed_file(path) as fh:
+                read_lines = fh.readlines()
+
+            self.assertEqual(len(read_lines), len(records))
+            for original, read_back in zip(records, read_lines):
+                self.assertEqual(original, read_back)
+        finally:
+            Path(path).unlink()
+
+    def test_empty_file(self):
+        """Empty file should be detected as plain text."""
+        with tempfile.NamedTemporaryFile(suffix=".ndjson", delete=False) as f:
+            path = f.name
+        try:
+            self.assertEqual(detect_compression(path), "none")
+            with open_compressed_file(path) as fh:
+                lines = fh.readlines()
+            self.assertEqual(lines, [])
+        finally:
+            Path(path).unlink()

--- a/tests/gpu/test_structured_logging.py
+++ b/tests/gpu/test_structured_logging.py
@@ -23,6 +23,7 @@ import triton  # @manual=//triton:triton
 import triton.language as tl  # @manual=//triton:triton
 import tritonparse.parse.utils
 import tritonparse.structured_logging
+from parameterized import parameterized  # @manual
 from tests.test_utils import GPUTestBase
 from triton.compiler import ASTSource, IRSource  # @manual=//triton:triton
 from triton.knobs import CompileTimes  # @manual=//triton:triton
@@ -134,8 +135,15 @@ class TestStructuredLogging(GPUTestBase):
         self.assertEqual(convert(nested_structure), expected_nested)
         print("✓ Convert function tests passed")
 
-    def test_whole_workflow(self):
-        """Test unified_parse functionality including SASS extraction"""
+    @parameterized.expand(
+        [
+            ("none",),
+            ("gzip",),
+            ("zstd",),
+        ]
+    )
+    def test_whole_workflow(self, compression):
+        """Test unified_parse functionality including SASS extraction with different compression modes"""
 
         # Define a simple kernel directly in the test function
         @triton.jit
@@ -165,17 +173,19 @@ class TestStructuredLogging(GPUTestBase):
         os.makedirs(temp_dir_logs, exist_ok=True)
         os.makedirs(temp_dir_parsed, exist_ok=True)
         print(f"Temporary directory: {temp_dir}")
+        print(f"Compression mode: {compression}")
         nvdisasm_available = is_nvdisasm_available()
         if nvdisasm_available:
             print("✓ nvdisasm tool is available, enabling SASS dumping")
         else:
             print("⚠️  nvdisasm tool not available, SASS dumping will be disabled")
 
-        # Initialize logging with conditional SASS dumping
+        # Initialize logging with conditional SASS dumping and compression mode
         tritonparse.structured_logging.init(
             temp_dir_logs,
             enable_trace_launch=True,
             enable_sass_dump=nvdisasm_available,
+            compression=compression,
         )
 
         # Generate test data and run kernels

--- a/tritonparse/structured_logging.py
+++ b/tritonparse/structured_logging.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import torch
+import zstandard as zstd  # @manual=fbsource//third-party/pypi/zstandard:zstandard
 from torch.utils._traceback import CapturedTraceback
 from triton.knobs import JITHook, LaunchHook
 from tritonparse._json_compat import dumps, loads
@@ -60,10 +61,11 @@ TRITON_FULL_PYTHON_SOURCE = os.getenv("TRITON_FULL_PYTHON_SOURCE", "0") in [
     "True",
 ]
 # Compression algorithm for raw trace files
-# When enabled, each JSON record is written as a separate gzip member,
-# concatenated in sequence within a .bin.ndjson file.
-# Supported values: "none", "gzip", "clp", "zstd" (future)
+# When enabled, each JSON record is compressed as a separate frame/member
+# and concatenated in sequence within a .bin.ndjson file.
+# Supported values: "none", "gzip", "clp", "zstd"
 # - "gzip": Outputs .bin.ndjson (gzip member concatenation format)
+# - "zstd": Outputs .bin.ndjson (zstd frame concatenation format)
 # - "clp": Outputs .clp (Compressed Log Processor format)
 # - "none": Outputs .ndjson (plain text)
 # If TRITON_TRACE_COMPRESSION is explicitly set, respect that value;
@@ -991,6 +993,7 @@ class TritonTraceHandler(logging.StreamHandler):
         # Track the rank used when creating the current log file
         # _UNINITIALIZED means we haven't created a file yet
         self._last_rank = self._UNINITIALIZED
+        self._zstd_compressor = None
         # If the program is unexpected terminated, atexit can ensure  file resources are properly closed and released.
         # it is because we use `self.stream` to keep the opened file stream, if the program is interrupted by some errors, the stream may not be closed.
         atexit.register(self._cleanup)
@@ -1082,6 +1085,9 @@ class TritonTraceHandler(logging.StreamHandler):
                     if TRITON_TRACE_COMPRESSION == "gzip":
                         file_extension = ".bin.ndjson"
                         file_mode = "ab+"  # Binary mode for gzip member concatenation
+                    elif TRITON_TRACE_COMPRESSION == "zstd":
+                        file_extension = ".bin.ndjson"
+                        file_mode = "ab+"  # Binary mode for zstd frame concatenation
                     elif TRITON_TRACE_COMPRESSION == "clp":
                         file_extension = ".clp"
                         file_mode = "w"  # CLP write mode
@@ -1115,6 +1121,16 @@ class TritonTraceHandler(logging.StreamHandler):
                         gz.write(formatted.encode("utf-8"))
                     # Write the complete gzip member to the file
                     compressed_data = buffer.getvalue()
+                    self.stream.write(compressed_data)
+                elif TRITON_TRACE_COMPRESSION == "zstd":
+                    # Create a separate zstd frame for each record
+                    # ZstdDecompressor.stream_reader() handles multi-frame files
+                    # via read_across_frames=True
+                    if self._zstd_compressor is None:
+                        self._zstd_compressor = zstd.ZstdCompressor()
+                    compressed_data = self._zstd_compressor.compress(
+                        formatted.encode("utf-8")
+                    )
                     self.stream.write(compressed_data)
                 elif TRITON_TRACE_COMPRESSION == "clp":
                     self.stream.add(io.StringIO(formatted))
@@ -1749,7 +1765,7 @@ def init(
         enable_sass_dump (Optional[bool]): Whether to enable SASS dumping.
         enable_tensor_blob_storage (bool): Whether to enable tensor blob storage.
         tensor_storage_quota (Optional[int]): Storage quota in bytes for tensor blobs (default: 100GB).
-        compression (Optional[str]): Compression format for trace files ("none", "gzip", or "clp").
+        compression (Optional[str]): Compression format for trace files ("none", "gzip", "zstd", or "clp").
             If not specified, respects TRITON_TRACE_COMPRESSION env var, or defaults to "none".
         tensor_save_skip_runs (Optional[int]): Skip tensor blob saving for the first N kernel runs.
         tensor_save_max_runs (Optional[int]): Save tensor blobs for at most N kernel runs after skipping.

--- a/tritonparse/tools/compression.py
+++ b/tritonparse/tools/compression.py
@@ -27,6 +27,8 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator, TextIO, Union
 
+import zstandard as zstd
+
 # Magic numbers for compression format detection
 # gzip: 0x1F 0x8B (RFC 1952)
 GZIP_MAGIC = b"\x1f\x8b"
@@ -113,7 +115,6 @@ def open_compressed_file(filepath: Union[str, Path]) -> Iterator[TextIO]:
 
     Raises:
         FileNotFoundError: If file does not exist
-        ImportError: If zstd file is detected but zstandard is not installed
 
     Example:
         >>> with open_compressed_file("trace.bin.ndjson") as f:
@@ -132,17 +133,9 @@ def open_compressed_file(filepath: Union[str, Path]) -> Iterator[TextIO]:
         with gzip.open(filepath, "rt", encoding="utf-8") as f:
             yield f
     elif compression == "zstd":
-        try:
-            import zstandard as zstd
-        except ImportError as e:
-            raise ImportError(
-                "zstandard package is required to read zstd compressed files. "
-                "Install it with: pip install zstandard"
-            ) from e
-
         dctx = zstd.ZstdDecompressor()
         with open(filepath, "rb") as binary_file:
-            with dctx.stream_reader(binary_file) as reader:
+            with dctx.stream_reader(binary_file, read_across_frames=True) as reader:
                 with io.TextIOWrapper(reader, encoding="utf-8") as text_stream:
                     yield text_stream
     else:


### PR DESCRIPTION
Summary:

Add zstd as a supported compression format for writing trace files, complementing existing gzip and clp support. The read side already supported zstd via `tools/compression.py`; this change enables write-side support.

Changes:
- `structured_logging.py`: Add zstd conditional import and per-record zstd frame compression in `TritonTraceHandler.emit()`. Each JSON record is compressed as a separate zstd frame, which `ZstdDecompressor.stream_reader()` handles transparently via `read_across_frames=True` (default).
- `pyproject.toml`: Add `zstd` optional dependency group (`zstandard>=0.19.0`) for OSS.

Usage: Set `TRITON_TRACE_COMPRESSION=zstd` to enable. Output files use `.bin.ndjson` extension.

Differential Revision: D100278437


