### PR TITLE
General Backend Infrastructure & Generic Parsing Flow Refactoring

### DIFF
--- a/tests/cpu/test_multi_backend_stage.py
+++ b/tests/cpu/test_multi_backend_stage.py
@@ -1,0 +1,170 @@
+import unittest
+
+from tritonparse.backend import (
+    AmdTritonAdapter,
+    deserialize_stage_descriptors_from_event,
+    NvidiaTritonAdapter,
+    PipelineAdapterRegistry,
+)
+from tritonparse.parse.trace_processor import _resolve_source_mappable_stage_keys
+
+
+def make_event(file_content: dict, stage_descriptors: list | None = None):
+    payload = {"file_content": file_content}
+    if stage_descriptors is not None:
+        payload["metadata"] = {"stage_descriptors": stage_descriptors}
+    else:
+        payload["metadata"] = {}
+    return {"payload": payload}
+
+
+class TestMultiBackendStage(unittest.TestCase):
+    def test_metadata_resolution_and_ordering(self):
+        # Two stages provided out-of-order; display_order should control final order
+        stages = [
+            {
+                "name": "ptx",
+                "extension": ".ptx",
+                "display_name": "PTX",
+                "display_order": 20,
+                "is_text": True,
+                "supports_source_mapping": True,
+                "parser_id": "p",
+                "syntax_id": "s",
+            },
+            {
+                "name": "ttir",
+                "extension": ".ttir",
+                "display_name": "TTIR",
+                "display_order": 10,
+                "is_text": True,
+                "supports_source_mapping": True,
+                "parser_id": "p",
+                "syntax_id": "s",
+            },
+        ]
+
+        file_content = {"kernel.ptx": "...", "kernel.ttir": "..."}
+        event = make_event(file_content, stages)
+
+        stage_keys = _resolve_source_mappable_stage_keys(event)
+
+        # Expect keys ordered by display_order (ttir then ptx)
+        self.assertEqual(list(stage_keys.keys()), ["ttir", "ptx"])
+        self.assertEqual(stage_keys["ttir"], "kernel.ttir")
+        self.assertEqual(stage_keys["ptx"], "kernel.ptx")
+
+    def test_legacy_fallback_resolution_order(self):
+        # No metadata provided -> use hardcoded fallback order
+        file_content = {"a.ptx": "...", "b.ttir": "..."}
+        event = make_event(file_content, stage_descriptors=None)
+
+        stage_keys = _resolve_source_mappable_stage_keys(event)
+
+        # Fallback dict orders ttir before ptx, so keys should reflect that order
+        self.assertIn("ttir", stage_keys)
+        self.assertIn("ptx", stage_keys)
+        self.assertEqual(list(stage_keys.keys()), [k for k in list(stage_keys.keys())])
+        # Check values mapped correctly
+        self.assertEqual(stage_keys["ttir"], "b.ttir")
+        self.assertEqual(stage_keys["ptx"], "a.ptx")
+
+    def test_no_artifacts_returns_empty(self):
+        event = make_event({}, stage_descriptors=None)
+        stage_keys = _resolve_source_mappable_stage_keys(event)
+        self.assertEqual(stage_keys, {})
+
+    def test_register_and_resolve(self):
+        registry = PipelineAdapterRegistry()
+        registry.register(NvidiaTritonAdapter)
+        registry.register(AmdTritonAdapter)
+
+        # resolve by exact name
+        cuda_adapter = registry.resolve(adapter_name="cuda_triton")
+        self.assertEqual(cuda_adapter.adapter_name, "cuda_triton")
+
+        # resolve should be case-insensitive for lookup
+        hip_adapter = registry.resolve(adapter_name="HIP_TRITON")
+        self.assertEqual(hip_adapter.adapter_name, "hip_triton")
+
+        # unknown adapter should raise
+        with self.assertRaises(ValueError):
+            registry.resolve(adapter_name="unknown_adapter")
+
+    def test_resolve_from_trace(self):
+        registry = PipelineAdapterRegistry()
+        registry.register(NvidiaTritonAdapter)
+        registry.register(AmdTritonAdapter)
+
+        metadata = {"backend_name": "cuda"}
+        adapter = registry.resolve_from_trace(metadata=metadata)
+        self.assertEqual(adapter.adapter_name, "cuda_triton")
+
+        # missing or invalid backend_name should raise
+        with self.assertRaises(ValueError):
+            registry.resolve_from_trace(metadata={})
+
+    def test_deserialize_and_ordering(self):
+        event = {
+            "payload": {
+                "metadata": {
+                    "stage_descriptors": [
+                        {
+                            "name": "b_stage",
+                            "extension": ".bst",
+                            "display_name": "B",
+                            "display_order": 20,
+                            "is_text": True,
+                            "supports_source_mapping": True,
+                            "parser_id": "p",
+                            "syntax_id": "s",
+                        },
+                        {
+                            "name": "a_stage",
+                            "extension": ".ast",
+                            "display_name": "A",
+                            "display_order": 10,
+                            "is_text": True,
+                            "supports_source_mapping": True,
+                            "parser_id": "p",
+                            "syntax_id": "s",
+                        },
+                    ]
+                }
+            }
+        }
+
+        stages = deserialize_stage_descriptors_from_event(event)
+        self.assertIsInstance(stages, list)
+        self.assertEqual(len(stages), 2)
+        # Should be ordered by display_order (10 then 20)
+        self.assertEqual(stages[0].name, "a_stage")
+        self.assertEqual(stages[1].name, "b_stage")
+
+    def test_missing_required_field_raises(self):
+        # missing 'extension' should raise ValueError
+        event = {
+            "payload": {
+                "metadata": {
+                    "stage_descriptors": [
+                        {
+                            "name": "bad_stage",
+                            # "extension": ".bad",  # omitted
+                            "display_name": "Bad",
+                            "display_order": 1,
+                            "is_text": True,
+                            "supports_source_mapping": True,
+                            "parser_id": "p",
+                            "syntax_id": "s",
+                        }
+                    ]
+                }
+            }
+        }
+
+        with self.assertRaises(ValueError):
+            deserialize_stage_descriptors_from_event(event)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cpu/test_multi_backend_stage.py
+++ b/tests/cpu/test_multi_backend_stage.py
@@ -62,9 +62,7 @@ class TestMultiBackendStage(unittest.TestCase):
         stage_keys = _resolve_source_mappable_stage_keys(event)
 
         # Fallback dict orders ttir before ptx, so keys should reflect that order
-        self.assertIn("ttir", stage_keys)
-        self.assertIn("ptx", stage_keys)
-        self.assertEqual(list(stage_keys.keys()), [k for k in list(stage_keys.keys())])
+        self.assertEqual(list(stage_keys.keys()), ["ttir", "ptx"])
         # Check values mapped correctly
         self.assertEqual(stage_keys["ttir"], "b.ttir")
         self.assertEqual(stage_keys["ptx"], "a.ptx")

--- a/tritonparse/backend.py
+++ b/tritonparse/backend.py
@@ -1,3 +1,4 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
@@ -8,6 +9,19 @@ from typing import Any
 
 @dataclass(frozen=True)
 class IRStageDescriptor:
+    """Describes an IR stage in the compilation pipeline.
+
+    Fields:
+        name: Internal stage identifier (e.g., "ttir", "ptx").
+        extension: File extension for artifacts (e.g., ".ttir", ".ptx").
+        display_name: Human-readable name for UI display.
+        display_order: UI display order (lower values appear first).
+        is_text: True if format is text, False if binary.
+        supports_source_mapping: True if this stage supports source-to-source mapping.
+        parser_id: Identifier for the parser to use.
+        syntax_id: Syntax highlighting identifier for web display.
+    """
+
     name: str
     extension: str
     display_name: str
@@ -20,6 +34,15 @@ class IRStageDescriptor:
 
 @dataclass(frozen=True)
 class DerivedArtifactDescriptor:
+    """Describes an artifact derived by running tools on another stage's output.
+
+    Fields:
+        source_extension: Extension of the source artifact (e.g., ".ptx").
+        output_stage_name: Name of the stage this derived artifact belongs to.
+        output_extension: Extension for the derived artifact (e.g., ".sass").
+        tool_name: Name of the tool used to generate the artifact.
+    """
+
     source_extension: str
     output_stage_name: str
     output_extension: str
@@ -28,11 +51,25 @@ class DerivedArtifactDescriptor:
 
 @dataclass(frozen=True)
 class AnalysisPassDescriptor:
+    """Describes an analysis pass that operates on specific compilation stages.
+
+    Fields:
+        name: Name of the analysis pass.
+        required_stages: Tuple of stage names that must be present for this pass to run.
+    """
+
     name: str
     required_stages: tuple[str, ...]
 
 
 class CompilationPipelineAdapter(ABC):
+    """Abstract base class for compilation pipeline adapters.
+
+    Adapters provide backend-specific configuration for different
+    compilation pipelines (e.g., CUDA vs HIP). Each adapter defines the
+    IR stages, derived artifacts, and analysis passes for its pipeline.
+    """
+
     @property
     @abstractmethod
     def adapter_name(self) -> str:
@@ -144,6 +181,12 @@ class AmdTritonAdapter(CompilationPipelineAdapter):
 
 
 class PipelineAdapterRegistry:
+    """Registry for managing and resolving compilation pipeline adapters.
+
+    Provides registration and resolution methods for different backend adapters.
+    Adapters can be looked up by name or inferred from trace metadata.
+    """
+
     def __init__(self) -> None:
         self._adapter_types: dict[str, type[CompilationPipelineAdapter]] = {}
 
@@ -230,6 +273,10 @@ def _validate_stage_dict(raw_stage: dict[str, Any]) -> None:
             int(raw_stage["display_order"])
         except Exception:
             raise ValueError("stage 'display_order' must be an integer or integer-like")
+    if not isinstance(raw_stage["is_text"], bool):
+        raise ValueError("stage 'is_text' must be a boolean")
+    if not isinstance(raw_stage["supports_source_mapping"], bool):
+        raise ValueError("stage 'supports_source_mapping' must be a boolean")
     if not isinstance(raw_stage["parser_id"], str):
         raise ValueError("stage 'parser_id' must be a string")
     if not isinstance(raw_stage["syntax_id"], str):

--- a/tritonparse/backend.py
+++ b/tritonparse/backend.py
@@ -101,6 +101,8 @@ class NvidiaTritonAdapter(CompilationPipelineAdapter):
                              False, False, "none", "plaintext"),
             IRStageDescriptor("sass", ".sass", "SASS", 60,
                              True, True, "sass_loc", "asm"),
+            IRStageDescriptor("json", ".json", "JSON", 100,
+                             True, False, "none", "json"),
         ]
 
 
@@ -128,6 +130,8 @@ class AmdTritonAdapter(CompilationPipelineAdapter):
                              True, True, "generic_loc", "llvm"),
             IRStageDescriptor("amdgcn", ".amdgcn", "AMDGCN", 40,
                              True, True, "amdgcn_loc", "asm"),
+            IRStageDescriptor("json", ".json", "JSON", 100,
+                             True, False, "none", "json"),
         ]
 
 

--- a/tritonparse/backend.py
+++ b/tritonparse/backend.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class IRStageDescriptor:
+    name: str
+    extension: str
+    display_name: str
+    display_order: int
+    is_text: bool
+    supports_source_mapping: bool
+    parser_id: str
+    syntax_id: str
+
+
+@dataclass(frozen=True)
+class DerivedArtifactDescriptor:
+    source_extension: str
+    output_stage_name: str
+    output_extension: str
+    tool_name: str
+
+
+@dataclass(frozen=True)
+class AnalysisPassDescriptor:
+    name: str
+    required_stages: tuple[str, ...]
+
+
+class CompilationPipelineAdapter(ABC):
+    @property
+    @abstractmethod
+    def adapter_name(self) -> str:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def runtime_backend(self) -> str:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def pytorch_module(self) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_ir_stages(self) -> list[IRStageDescriptor]:
+        raise NotImplementedError
+
+    def classify_artifact(self, artifact_name: str) -> IRStageDescriptor | None:
+        artifact_suffix = Path(artifact_name).suffix
+        for stage in self.get_ir_stages():
+            if stage.extension == artifact_suffix:
+                return stage
+        return None
+
+    @property
+    def known_stage_extensions(self) -> set[str]:
+        return {stage.extension for stage in self.get_ir_stages()}
+
+    def get_derived_artifacts(self) -> list[DerivedArtifactDescriptor]:
+        return []
+
+    def get_analysis_passes(self) -> list[AnalysisPassDescriptor]:
+        return []
+
+    def normalize_device_string(self, device: str) -> str:
+        return device
+
+
+
+class NvidiaTritonAdapter(CompilationPipelineAdapter):
+    @property
+    def adapter_name(self) -> str:
+        return "cuda_triton"
+
+    @property
+    def runtime_backend(self) -> str:
+        return "cuda"
+
+    @property
+    def pytorch_module(self) -> str:
+        return "torch.cuda"
+
+    def get_ir_stages(self) -> list[IRStageDescriptor]:
+        return [
+            IRStageDescriptor("ttir", ".ttir", "TTIR", 10,
+                             True, True, "generic_loc", "mlir"),
+            IRStageDescriptor("ttgir", ".ttgir", "TTGIR", 20,
+                             True, True, "generic_loc", "mlir"),
+            IRStageDescriptor("llir", ".llir", "LLIR", 30,
+                             True, True, "generic_loc", "llvm"),
+            IRStageDescriptor("ptx", ".ptx", "PTX", 40,
+                             True, True, "ptx_loc", "ptx"),
+            IRStageDescriptor("cubin", ".cubin", "CUBIN", 50,
+                             False, False, "none", "plaintext"),
+            IRStageDescriptor("sass", ".sass", "SASS", 60,
+                             True, True, "sass_loc", "asm"),
+        ]
+
+
+
+class AmdTritonAdapter(CompilationPipelineAdapter):
+    @property
+    def adapter_name(self) -> str:
+        return "hip_triton"
+
+    @property
+    def runtime_backend(self) -> str:
+        return "hip"
+
+    @property
+    def pytorch_module(self) -> str:
+        return "torch.cuda"
+
+    def get_ir_stages(self) -> list[IRStageDescriptor]:
+        return [
+            IRStageDescriptor("ttir", ".ttir", "TTIR", 10,
+                             True, True, "generic_loc", "mlir"),
+            IRStageDescriptor("ttgir", ".ttgir", "TTGIR", 20,
+                             True, True, "generic_loc", "mlir"),
+            IRStageDescriptor("llir", ".llir", "LLIR", 30,
+                             True, True, "generic_loc", "llvm"),
+            IRStageDescriptor("amdgcn", ".amdgcn", "AMDGCN", 40,
+                             True, True, "amdgcn_loc", "asm"),
+        ]
+
+
+class PipelineAdapterRegistry:
+    def __init__(self) -> None:
+        self._adapter_types: dict[str, type[CompilationPipelineAdapter]] = {}
+
+    def register(self, adapter_cls: type[CompilationPipelineAdapter]) -> None:
+        adapter = adapter_cls()
+        self._adapter_types[adapter.adapter_name] = adapter_cls
+
+    def create_all(self) -> list[CompilationPipelineAdapter]:
+        return [adapter_cls() for adapter_cls in self._adapter_types.values()]
+
+    def resolve(
+        self,
+        *,
+        adapter_name: str,
+    ) -> CompilationPipelineAdapter:
+        adapter_cls = self._adapter_types.get(adapter_name.lower())
+        if adapter_cls is None:
+            raise ValueError(
+                "Unable to resolve adapter from adapter_name: "
+                f"adapter_name={adapter_name!r}"
+            )
+        return adapter_cls()
+
+    def resolve_from_trace(
+        self,
+        metadata: dict[str, Any],
+    ) -> CompilationPipelineAdapter:
+        backend_name = metadata.get("backend_name")
+        if isinstance(backend_name, str):
+            inferred_adapter_name = f"{backend_name}_triton"
+            return self.resolve(adapter_name=inferred_adapter_name)
+
+        raise ValueError(
+            "Unable to resolve adapter from trace metadata: "
+            f"backend_name={backend_name!r}"
+        )
+
+
+def _deserialize_stage_descriptor(raw_stage: dict[str, Any]) -> IRStageDescriptor:
+    return IRStageDescriptor(
+        name=str(raw_stage["name"]),
+        extension=str(raw_stage["extension"]),
+        display_name=str(raw_stage["display_name"]),
+        display_order=int(raw_stage["display_order"]),
+        is_text=bool(raw_stage["is_text"]),
+        supports_source_mapping=bool(raw_stage["supports_source_mapping"]),
+        parser_id=str(raw_stage["parser_id"]),
+        syntax_id=str(raw_stage["syntax_id"]),
+    )
+
+
+def get_present_stage_descriptors_from_event(event: dict[str, Any]) -> list[IRStageDescriptor]:
+    payload = event.get("payload", {})
+    metadata = payload.get("metadata", {})
+    serialized_stage_descriptors = metadata.get("stage_descriptors")
+    if isinstance(serialized_stage_descriptors, list) and serialized_stage_descriptors:
+        stages = [
+            _deserialize_stage_descriptor(raw_stage)
+            for raw_stage in serialized_stage_descriptors
+            if isinstance(raw_stage, dict) and "name" in raw_stage and "extension" in raw_stage
+        ]
+        return sorted(stages, key=lambda stage: stage.display_order)
+
+    artifact_names = list((payload.get("file_content") or {}).keys()) + list((payload.get("file_path") or {}).keys())
+    present_extensions = {Path(artifact_name).suffix for artifact_name in artifact_names}
+    seen_stage_names: set[str] = set()
+    descriptors: list[IRStageDescriptor] = []
+    for adapter in get_backend_registry().create_all():
+        for stage in adapter.get_ir_stages():
+            if stage.name in seen_stage_names:
+                continue
+            if stage.extension not in present_extensions:
+                continue
+            descriptors.append(stage)
+            seen_stage_names.add(stage.name)
+    return sorted(descriptors, key=lambda stage: stage.display_order)
+
+
+_REGISTRY = PipelineAdapterRegistry()
+for _adapter_cls in (NvidiaTritonAdapter, AmdTritonAdapter):
+    _REGISTRY.register(_adapter_cls)
+
+
+def get_backend_registry() -> PipelineAdapterRegistry:
+    return _REGISTRY

--- a/tritonparse/backend.py
+++ b/tritonparse/backend.py
@@ -149,7 +149,7 @@ class PipelineAdapterRegistry:
 
     def register(self, adapter_cls: type[CompilationPipelineAdapter]) -> None:
         adapter = adapter_cls()
-        self._adapter_types[adapter.adapter_name] = adapter_cls
+        self._adapter_types[adapter.adapter_name.lower()] = adapter_cls
 
     def create_all(self) -> list[CompilationPipelineAdapter]:
         return [adapter_cls() for adapter_cls in self._adapter_types.values()]
@@ -183,6 +183,7 @@ class PipelineAdapterRegistry:
 
 
 def _deserialize_stage_descriptor(raw_stage: dict[str, Any]) -> IRStageDescriptor:
+    _validate_stage_dict(raw_stage)
     return IRStageDescriptor(
         name=str(raw_stage["name"]),
         extension=str(raw_stage["extension"]),
@@ -195,39 +196,62 @@ def _deserialize_stage_descriptor(raw_stage: dict[str, Any]) -> IRStageDescripto
     )
 
 
-def get_present_stage_descriptors_from_event(
+def _validate_stage_dict(raw_stage: dict[str, Any]) -> None:
+    """Strictly validate a raw stage dict from metadata.
+
+    Raises ValueError if required fields are missing or have invalid types.
+    """
+    if not isinstance(raw_stage, dict):
+        raise ValueError("stage descriptor must be a dict")
+
+    required_fields = [
+        "name",
+        "extension",
+        "display_name",
+        "display_order",
+        "is_text",
+        "supports_source_mapping",
+        "parser_id",
+        "syntax_id",
+    ]
+
+    missing = [f for f in required_fields if f not in raw_stage]
+    if missing:
+        raise ValueError(f"Missing required stage descriptor fields: {missing}")
+
+    if not isinstance(raw_stage["name"], str):
+        raise ValueError("stage 'name' must be a string")
+    if not isinstance(raw_stage["extension"], str):
+        raise ValueError("stage 'extension' must be a string")
+    if not isinstance(raw_stage["display_name"], str):
+        raise ValueError("stage 'display_name' must be a string")
+    if "display_order" in raw_stage:
+        try:
+            int(raw_stage["display_order"])
+        except Exception:
+            raise ValueError("stage 'display_order' must be an integer or integer-like")
+    if not isinstance(raw_stage["parser_id"], str):
+        raise ValueError("stage 'parser_id' must be a string")
+    if not isinstance(raw_stage["syntax_id"], str):
+        raise ValueError("stage 'syntax_id' must be a string")
+
+
+def deserialize_stage_descriptors_from_event(
     event: dict[str, Any],
 ) -> list[IRStageDescriptor]:
     payload = event.get("payload", {})
     metadata = payload.get("metadata", {})
     serialized_stage_descriptors = metadata.get("stage_descriptors")
-    if isinstance(serialized_stage_descriptors, list) and serialized_stage_descriptors:
-        stages = [
-            _deserialize_stage_descriptor(raw_stage)
-            for raw_stage in serialized_stage_descriptors
-            if isinstance(raw_stage, dict)
-            and "name" in raw_stage
-            and "extension" in raw_stage
-        ]
-        return sorted(stages, key=lambda stage: stage.display_order)
-
-    artifact_names = list((payload.get("file_content") or {}).keys()) + list(
-        (payload.get("file_path") or {}).keys()
-    )
-    present_extensions = {
-        Path(artifact_name).suffix for artifact_name in artifact_names
-    }
-    seen_stage_names: set[str] = set()
-    descriptors: list[IRStageDescriptor] = []
-    for adapter in get_backend_registry().create_all():
-        for stage in adapter.get_ir_stages():
-            if stage.name in seen_stage_names:
-                continue
-            if stage.extension not in present_extensions:
-                continue
-            descriptors.append(stage)
-            seen_stage_names.add(stage.name)
-    return sorted(descriptors, key=lambda stage: stage.display_order)
+    if not (
+        isinstance(serialized_stage_descriptors, list) and serialized_stage_descriptors
+    ):
+        return []
+    stages = [
+        _deserialize_stage_descriptor(raw_stage)
+        for raw_stage in serialized_stage_descriptors
+        if isinstance(raw_stage, dict)
+    ]
+    return sorted(stages, key=lambda stage: stage.display_order)
 
 
 _REGISTRY = PipelineAdapterRegistry()

--- a/tritonparse/backend.py
+++ b/tritonparse/backend.py
@@ -73,7 +73,6 @@ class CompilationPipelineAdapter(ABC):
         return device
 
 
-
 class NvidiaTritonAdapter(CompilationPipelineAdapter):
     @property
     def adapter_name(self) -> str:
@@ -89,22 +88,26 @@ class NvidiaTritonAdapter(CompilationPipelineAdapter):
 
     def get_ir_stages(self) -> list[IRStageDescriptor]:
         return [
-            IRStageDescriptor("ttir", ".ttir", "TTIR", 10,
-                             True, True, "generic_loc", "mlir"),
-            IRStageDescriptor("ttgir", ".ttgir", "TTGIR", 20,
-                             True, True, "generic_loc", "mlir"),
-            IRStageDescriptor("llir", ".llir", "LLIR", 30,
-                             True, True, "generic_loc", "llvm"),
-            IRStageDescriptor("ptx", ".ptx", "PTX", 40,
-                             True, True, "ptx_loc", "ptx"),
-            IRStageDescriptor("cubin", ".cubin", "CUBIN", 50,
-                             False, False, "none", "plaintext"),
-            IRStageDescriptor("sass", ".sass", "SASS", 60,
-                             True, True, "sass_loc", "asm"),
-            IRStageDescriptor("json", ".json", "JSON", 100,
-                             True, False, "none", "json"),
+            IRStageDescriptor(
+                "ttir", ".ttir", "TTIR", 10, True, True, "generic_loc", "mlir"
+            ),
+            IRStageDescriptor(
+                "ttgir", ".ttgir", "TTGIR", 20, True, True, "generic_loc", "mlir"
+            ),
+            IRStageDescriptor(
+                "llir", ".llir", "LLIR", 30, True, True, "generic_loc", "llvm"
+            ),
+            IRStageDescriptor("ptx", ".ptx", "PTX", 40, True, True, "ptx_loc", "ptx"),
+            IRStageDescriptor(
+                "cubin", ".cubin", "CUBIN", 50, False, False, "none", "plaintext"
+            ),
+            IRStageDescriptor(
+                "sass", ".sass", "SASS", 60, True, True, "sass_loc", "asm"
+            ),
+            IRStageDescriptor(
+                "json", ".json", "JSON", 100, True, False, "none", "json"
+            ),
         ]
-
 
 
 class AmdTritonAdapter(CompilationPipelineAdapter):
@@ -122,16 +125,21 @@ class AmdTritonAdapter(CompilationPipelineAdapter):
 
     def get_ir_stages(self) -> list[IRStageDescriptor]:
         return [
-            IRStageDescriptor("ttir", ".ttir", "TTIR", 10,
-                             True, True, "generic_loc", "mlir"),
-            IRStageDescriptor("ttgir", ".ttgir", "TTGIR", 20,
-                             True, True, "generic_loc", "mlir"),
-            IRStageDescriptor("llir", ".llir", "LLIR", 30,
-                             True, True, "generic_loc", "llvm"),
-            IRStageDescriptor("amdgcn", ".amdgcn", "AMDGCN", 40,
-                             True, True, "amdgcn_loc", "asm"),
-            IRStageDescriptor("json", ".json", "JSON", 100,
-                             True, False, "none", "json"),
+            IRStageDescriptor(
+                "ttir", ".ttir", "TTIR", 10, True, True, "generic_loc", "mlir"
+            ),
+            IRStageDescriptor(
+                "ttgir", ".ttgir", "TTGIR", 20, True, True, "generic_loc", "mlir"
+            ),
+            IRStageDescriptor(
+                "llir", ".llir", "LLIR", 30, True, True, "generic_loc", "llvm"
+            ),
+            IRStageDescriptor(
+                "amdgcn", ".amdgcn", "AMDGCN", 40, True, True, "amdgcn_loc", "asm"
+            ),
+            IRStageDescriptor(
+                "json", ".json", "JSON", 100, True, False, "none", "json"
+            ),
         ]
 
 
@@ -187,7 +195,9 @@ def _deserialize_stage_descriptor(raw_stage: dict[str, Any]) -> IRStageDescripto
     )
 
 
-def get_present_stage_descriptors_from_event(event: dict[str, Any]) -> list[IRStageDescriptor]:
+def get_present_stage_descriptors_from_event(
+    event: dict[str, Any],
+) -> list[IRStageDescriptor]:
     payload = event.get("payload", {})
     metadata = payload.get("metadata", {})
     serialized_stage_descriptors = metadata.get("stage_descriptors")
@@ -195,12 +205,18 @@ def get_present_stage_descriptors_from_event(event: dict[str, Any]) -> list[IRSt
         stages = [
             _deserialize_stage_descriptor(raw_stage)
             for raw_stage in serialized_stage_descriptors
-            if isinstance(raw_stage, dict) and "name" in raw_stage and "extension" in raw_stage
+            if isinstance(raw_stage, dict)
+            and "name" in raw_stage
+            and "extension" in raw_stage
         ]
         return sorted(stages, key=lambda stage: stage.display_order)
 
-    artifact_names = list((payload.get("file_content") or {}).keys()) + list((payload.get("file_path") or {}).keys())
-    present_extensions = {Path(artifact_name).suffix for artifact_name in artifact_names}
+    artifact_names = list((payload.get("file_content") or {}).keys()) + list(
+        (payload.get("file_path") or {}).keys()
+    )
+    present_extensions = {
+        Path(artifact_name).suffix for artifact_name in artifact_names
+    }
     seen_stage_names: set[str] = set()
     descriptors: list[IRStageDescriptor] = []
     for adapter in get_backend_registry().create_all():

--- a/tritonparse/parse/trace_processor.py
+++ b/tritonparse/parse/trace_processor.py
@@ -329,11 +329,10 @@ def _resolve_source_mappable_stage_keys(
                 continue
             stage_keys[stage.name] = artifact_name
 
-        if stage_keys:
-            logger.debug(
-                f"Resolved stage keys from metadata.stage_descriptors: {list(stage_keys.keys())}"
-            )
-            return stage_keys
+        logger.debug(
+            f"Resolved stage keys from metadata.stage_descriptors: {list(stage_keys.keys())}"
+        )
+        return stage_keys
 
     # Path 2: hardcoded extension fallback (original upstream behavior).
     # This intentionally mirrors the upstream hardcoded logic and only scans file_content.

--- a/tritonparse/parse/trace_processor.py
+++ b/tritonparse/parse/trace_processor.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from tritonparse._json_compat import dumps, JSONDecodeError, loads
+from tritonparse.backend import deserialize_stage_descriptors_from_event
 from tritonparse.tools.compression import open_compressed_file
 from tritonparse.tp_logger import get_logger
 
@@ -292,44 +293,41 @@ def _resolve_source_mappable_stage_keys(
         Output: {"ttir": "kernel.ttir"}
     """
     payload = entry.get("payload", {})
-    metadata = payload.get("metadata", {})
     file_content = payload.get("file_content", {})
 
     # Only consider file_content: source mapping requires parsing file contents.
     # If content was not captured, source mapping cannot be generated.
-    available_artifacts = set(file_content.keys())
 
     # Path 1: resolve from metadata.stage_descriptors (new trace format).
-    serialized_stage_descriptors = metadata.get("stage_descriptors")
     stage_keys: Dict[str, str] = {}
+    try:
+        stage_descriptors = deserialize_stage_descriptors_from_event(entry)
+    except ValueError as e:
+        logger.debug(
+            f"Failed to deserialize metadata.stage_descriptors: {e}; falling back to legacy behavior"
+        )
+        stage_descriptors = []
 
-    if isinstance(serialized_stage_descriptors, list):
-        for raw_stage in sorted(
-            [
-                stage
-                for stage in serialized_stage_descriptors
-                if isinstance(stage, dict)
-            ],
-            key=lambda stage: int(stage.get("display_order", 0)),
-        ):
-            stage_name = raw_stage.get("name")
-            extension = raw_stage.get("extension")
-            supports_source_mapping = raw_stage.get("supports_source_mapping", True)
-
-            if not isinstance(stage_name, str) or not isinstance(extension, str):
-                continue
-            if not supports_source_mapping:
+    if stage_descriptors:
+        for stage in stage_descriptors:
+            if not getattr(stage, "supports_source_mapping", True):
                 continue
 
-            # Find the matching artifact name in available_artifacts by extension.
+            extension = getattr(stage, "extension", None)
+            if not isinstance(extension, str):
+                continue
+            # Find the first artifact in file_content that endswith the extension.
+            # Our data model guarantees at most one matching key per extension; use
+            # generator to avoid allocating an intermediate list.
             artifact_name = next(
-                (name for name in available_artifacts if name.endswith(extension)), None
+                (name for name in file_content if name.endswith(extension)),
+                None,
             )
-
-            if artifact_name is None or stage_name in stage_keys:
+            if artifact_name is None:
                 continue
-
-            stage_keys[stage_name] = artifact_name
+            if stage.name in stage_keys:
+                continue
+            stage_keys[stage.name] = artifact_name
 
         if stage_keys:
             logger.debug(

--- a/tritonparse/parse/trace_processor.py
+++ b/tritonparse/parse/trace_processor.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from tritonparse._json_compat import dumps, JSONDecodeError, loads
-from tritonparse.backend import get_backend_registry
 from tritonparse.tools.compression import open_compressed_file
 from tritonparse.tp_logger import get_logger
 
@@ -306,7 +305,11 @@ def _resolve_source_mappable_stage_keys(
 
     if isinstance(serialized_stage_descriptors, list):
         for raw_stage in sorted(
-            [stage for stage in serialized_stage_descriptors if isinstance(stage, dict)],
+            [
+                stage
+                for stage in serialized_stage_descriptors
+                if isinstance(stage, dict)
+            ],
             key=lambda stage: int(stage.get("display_order", 0)),
         ):
             stage_name = raw_stage.get("name")
@@ -320,8 +323,7 @@ def _resolve_source_mappable_stage_keys(
 
             # Find the matching artifact name in available_artifacts by extension.
             artifact_name = next(
-                (name for name in available_artifacts if name.endswith(extension)),
-                None
+                (name for name in available_artifacts if name.endswith(extension)), None
             )
 
             if artifact_name is None or stage_name in stage_keys:
@@ -330,7 +332,9 @@ def _resolve_source_mappable_stage_keys(
             stage_keys[stage_name] = artifact_name
 
         if stage_keys:
-            logger.debug(f"Resolved stage keys from metadata.stage_descriptors: {list(stage_keys.keys())}")
+            logger.debug(
+                f"Resolved stage keys from metadata.stage_descriptors: {list(stage_keys.keys())}"
+            )
             return stage_keys
 
     # Path 2: hardcoded extension fallback (original upstream behavior).
@@ -345,14 +349,15 @@ def _resolve_source_mappable_stage_keys(
 
     for stage_name, extension in fallback_extensions.items():
         artifact_name = next(
-            (name for name in file_content if name.endswith(extension)),
-            None
+            (name for name in file_content if name.endswith(extension)), None
         )
         if artifact_name is not None:
             stage_keys[stage_name] = artifact_name
 
     if stage_keys:
-        logger.debug(f"Resolved stage keys from hardcoded extensions: {list(stage_keys.keys())}")
+        logger.debug(
+            f"Resolved stage keys from hardcoded extensions: {list(stage_keys.keys())}"
+        )
 
     return stage_keys
 
@@ -498,7 +503,7 @@ def parse_single_trace_content(trace_content: str) -> str:
         # If upstream Triton already set num_warps_base, trust it; otherwise
         # recover the value from the TTGIR "ttg.num-warps" module attribute.
         if "num_warps_base" not in metadata:
-            ttgir_key = stage_keys.get("ttgir") 
+            ttgir_key = stage_keys.get("ttgir")
             if ttgir_key and ttgir_key in file_content:
                 ttgir_content = file_content[ttgir_key]
                 if isinstance(ttgir_content, str):
@@ -527,9 +532,18 @@ def parse_single_trace_content(trace_content: str) -> str:
 
             # Collect mappings from previously processed stages for use by
             # later stages such as PTX or AMDGCN.
-            other_mappings = [stage_maps[prev_stage] for prev_stage in stage_names[:i] if stage_maps.get(prev_stage)]
+            other_mappings = [
+                stage_maps[prev_stage]
+                for prev_stage in stage_names[:i]
+                if stage_maps.get(prev_stage)
+            ]
 
-            stage_map = process_ir(artifact_key, file_content, file_path, other_mappings if other_mappings else None)
+            stage_map = process_ir(
+                artifact_key,
+                file_content,
+                file_path,
+                other_mappings if other_mappings else None,
+            )
             if stage_map:
                 stage_maps[stage_name] = stage_map
 
@@ -537,7 +551,7 @@ def parse_single_trace_content(trace_content: str) -> str:
         # for example TTIR ↔ TTGIR, TTIR ↔ PTX, TTGIR ↔ PTX, ...
         stage_names = list(stage_maps.keys())
         for i, src_stage in enumerate(stage_names):
-            for tgt_stage in stage_names[i + 1:]:
+            for tgt_stage in stage_names[i + 1 :]:
                 if stage_maps[src_stage] and stage_maps[tgt_stage]:
                     create_bidirectional_mapping(
                         stage_maps[src_stage],
@@ -571,7 +585,7 @@ def parse_single_trace_content(trace_content: str) -> str:
         payload["source_mappings"] = {
             stage_name: stage_map
             for stage_name, stage_map in stage_maps.items()
-            if stage_map 
+            if stage_map
         }
         payload["source_mappings"]["python"] = py_map
     # NDJSON format requires a newline at the end of each line

--- a/tritonparse/parse/trace_processor.py
+++ b/tritonparse/parse/trace_processor.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from tritonparse._json_compat import dumps, JSONDecodeError, loads
+from tritonparse.backend import get_backend_registry
 from tritonparse.tools.compression import open_compressed_file
 from tritonparse.tp_logger import get_logger
 
@@ -269,6 +270,93 @@ def generate_source_mappings(
     return mappings
 
 
+def _resolve_source_mappable_stage_keys(
+    entry: Dict[str, Any],
+) -> Dict[str, str]:
+    """
+    Resolve stage keys in a trace that support source mapping.
+
+    Two resolution paths are supported:
+    1. metadata.stage_descriptors (new trace format)
+    2. Hardcoded extension fallback (legacy trace format)
+
+    Args:
+        entry: Trace event dict containing event_type and payload.
+
+    Returns:
+        Dict mapping stage name to artifact filename
+        Example: {"ttir": "kernel.ttir", "ttgir": "kernel.ttgir"}
+
+    Example:
+        Input: entry contains file_content={"kernel.ttir": "...", "kernel.ptx": "..."}
+               and stage_descriptors=[{"name": "ttir", "extension": ".ttir", ...}]
+        Output: {"ttir": "kernel.ttir"}
+    """
+    payload = entry.get("payload", {})
+    metadata = payload.get("metadata", {})
+    file_content = payload.get("file_content", {})
+
+    # Only consider file_content: source mapping requires parsing file contents.
+    # If content was not captured, source mapping cannot be generated.
+    available_artifacts = set(file_content.keys())
+
+    # Path 1: resolve from metadata.stage_descriptors (new trace format).
+    serialized_stage_descriptors = metadata.get("stage_descriptors")
+    stage_keys: Dict[str, str] = {}
+
+    if isinstance(serialized_stage_descriptors, list):
+        for raw_stage in sorted(
+            [stage for stage in serialized_stage_descriptors if isinstance(stage, dict)],
+            key=lambda stage: int(stage.get("display_order", 0)),
+        ):
+            stage_name = raw_stage.get("name")
+            extension = raw_stage.get("extension")
+            supports_source_mapping = raw_stage.get("supports_source_mapping", True)
+
+            if not isinstance(stage_name, str) or not isinstance(extension, str):
+                continue
+            if not supports_source_mapping:
+                continue
+
+            # Find the matching artifact name in available_artifacts by extension.
+            artifact_name = next(
+                (name for name in available_artifacts if name.endswith(extension)),
+                None
+            )
+
+            if artifact_name is None or stage_name in stage_keys:
+                continue
+
+            stage_keys[stage_name] = artifact_name
+
+        if stage_keys:
+            logger.debug(f"Resolved stage keys from metadata.stage_descriptors: {list(stage_keys.keys())}")
+            return stage_keys
+
+    # Path 2: hardcoded extension fallback (original upstream behavior).
+    # This intentionally mirrors the upstream hardcoded logic and only scans file_content.
+    fallback_extensions = {
+        "ttir": ".ttir",
+        "ttgir": ".ttgir",
+        "ptx": ".ptx",
+        "amdgcn": ".amdgcn",
+        "sass": ".sass",
+    }
+
+    for stage_name, extension in fallback_extensions.items():
+        artifact_name = next(
+            (name for name in file_content if name.endswith(extension)),
+            None
+        )
+        if artifact_name is not None:
+            stage_keys[stage_name] = artifact_name
+
+    if stage_keys:
+        logger.debug(f"Resolved stage keys from hardcoded extensions: {list(stage_keys.keys())}")
+
+    return stage_keys
+
+
 def process_ir(
     key: str,
     file_content: Dict[str, str],
@@ -400,62 +488,65 @@ def parse_single_trace_content(trace_content: str) -> str:
         payload = entry.setdefault("payload", {})
         file_content = payload.get("file_content", {})
         file_path = payload.get("file_path", {})
+        metadata = payload.setdefault("metadata", {})
 
-        # Find the IR file keys
-        ttir_key = next((k for k in file_content if k.endswith(".ttir")), None)
-        ttgir_key = next((k for k in file_content if k.endswith(".ttgir")), None)
-        ptx_key = next((k for k in file_content if k.endswith(".ptx")), None)
-        amdgcn_key = next((k for k in file_content if k.endswith(".amdgcn")), None)
-        sass_key = next((k for k in file_content if k.endswith(".sass")), None)
+        # Use the new stage resolution helper instead of hardcoded stage lookup.
+        # Returns: {"ttir": "kernel.ttir", "ttgir": "kernel.ttgir", ...}
+        stage_keys = _resolve_source_mappable_stage_keys(entry)
 
         # Extract original num_warps from TTGIR for warp-specialized kernels.
         # If upstream Triton already set num_warps_base, trust it; otherwise
         # recover the value from the TTGIR "ttg.num-warps" module attribute.
-        metadata = payload.setdefault("metadata", {})
-        if "num_warps_base" not in metadata and ttgir_key and ttgir_key in file_content:
-            ttgir_content = file_content[ttgir_key]
-            if isinstance(ttgir_content, str):
-                match = re.search(r'"ttg\.num-warps"\s*=\s*(\d+)', ttgir_content)
-                if match:
-                    original = int(match.group(1))
-                    current = metadata.get("num_warps")
-                    if current is not None and original != current:
-                        metadata["num_warps_base"] = original
+        if "num_warps_base" not in metadata:
+            ttgir_key = stage_keys.get("ttgir") 
+            if ttgir_key and ttgir_key in file_content:
+                ttgir_content = file_content[ttgir_key]
+                if isinstance(ttgir_content, str):
+                    match = re.search(r'"ttg\.num-warps"\s*=\s*(\d+)', ttgir_content)
+                    if match:
+                        original = int(match.group(1))
+                        current = metadata.get("num_warps")
+                        if current is not None and original != current:
+                            metadata["num_warps_base"] = original
 
         # Skip if no IR files found
-        if not (ttir_key or ttgir_key or ptx_key or amdgcn_key or sass_key):
+        if not stage_keys:
             logger.warning("No IR files found in the payload.")
             # Still return with proper NDJSON format (with newline)
             return dumps(entry) + "\n"
 
-        # generate ttir->source, ttgir->source, ptx->source, sass->source
-        ttir_map = process_ir(ttir_key, file_content, file_path)
-        ttgir_map = process_ir(ttgir_key, file_content, file_path)
-        ptx_map = process_ir(ptx_key, file_content, file_path, [ttir_map, ttgir_map])
-        amdgcn_map = process_ir(
-            amdgcn_key, file_content, file_path, [ttir_map, ttgir_map]
-        )
-        sass_map = process_ir(sass_key, file_content, file_path, [ttir_map, ttgir_map])
+        # Generate source mappings for all resolved stages dynamically.
+        # Process in order: earlier stages (for example ttir, ttgir) first,
+        # then later stages (for example ptx, sass), so later stages can
+        # reuse mappings produced by earlier ones.
+        stage_maps: Dict[str, Dict[str, Dict[str, Any]]] = {}
+        stage_names = list(stage_keys.keys())
 
-        # Create bidirectional mappings between all IR types
-        ir_maps = {
-            "ttir": ttir_map,
-            "ttgir": ttgir_map,
-            "ptx": ptx_map,
-            "amdgcn": amdgcn_map,
-            "sass": sass_map,
-        }
+        for i, stage_name in enumerate(stage_names):
+            artifact_key = stage_keys[stage_name]
 
-        # Create mappings between all pairs of IR types
-        ir_types = list(ir_maps.keys())
-        for i, src_type in enumerate(ir_types):
-            for tgt_type in ir_types[i + 1 :]:
-                if ir_maps[src_type] and ir_maps[tgt_type]:
+            # Collect mappings from previously processed stages for use by
+            # later stages such as PTX or AMDGCN.
+            other_mappings = [stage_maps[prev_stage] for prev_stage in stage_names[:i] if stage_maps.get(prev_stage)]
+
+            stage_map = process_ir(artifact_key, file_content, file_path, other_mappings if other_mappings else None)
+            if stage_map:
+                stage_maps[stage_name] = stage_map
+
+        # Create bidirectional mappings between every pair of populated stages,
+        # for example TTIR ↔ TTGIR, TTIR ↔ PTX, TTGIR ↔ PTX, ...
+        stage_names = list(stage_maps.keys())
+        for i, src_stage in enumerate(stage_names):
+            for tgt_stage in stage_names[i + 1:]:
+                if stage_maps[src_stage] and stage_maps[tgt_stage]:
                     create_bidirectional_mapping(
-                        ir_maps[src_type], ir_maps[tgt_type], src_type, tgt_type
+                        stage_maps[src_stage],
+                        stage_maps[tgt_stage],
+                        src_stage,
+                        tgt_stage,
                     )
                     logger.debug(
-                        f"Created bidirectional mapping between {src_type} and {tgt_type}"
+                        f"Created bidirectional mapping between {src_stage} and {tgt_stage}"
                     )
 
         py_map = {}
@@ -465,32 +556,24 @@ def parse_single_trace_content(trace_content: str) -> str:
                 f"Added Python source information (lines {payload['python_source']['start_line']}-{payload['python_source']['end_line']})"
             )
 
-            # 4. Create Python source to IR mappings. We use the original line numbers as key in the python source code.
-            # Create a list of valid IR mappings, filtering out None keys
+            # Create mappings from Python source to IR.
+            # Collect all non-empty IR mappings.
             ir_mappings = []
-            ir_keys_and_maps = [
-                (ttir_key, ttir_map),
-                (ttgir_key, ttgir_map),
-                (ptx_key, ptx_map),
-                (amdgcn_key, amdgcn_map),
-                (sass_key, sass_map),
-            ]
-
-            for key, mapping in ir_keys_and_maps:
-                if key:
-                    ir_mappings.append((get_file_extension(key), mapping))
+            for stage_name, artifact_key in stage_keys.items():
+                stage_map = stage_maps.get(stage_name)
+                if stage_map and artifact_key:
+                    ir_mappings.append((get_file_extension(artifact_key), stage_map))
 
             py_map = create_python_mapping(ir_mappings)
 
-        # Store the mappings in the payload
+        # Build the final source_mappings payload.
+        # Add all populated stage mappings plus the Python mapping.
         payload["source_mappings"] = {
-            "ttir": ttir_map,
-            "ttgir": ttgir_map,
-            **({"ptx": ptx_map} if ptx_map else {}),
-            **({"amdgcn": amdgcn_map} if amdgcn_map else {}),
-            **({"sass": sass_map} if sass_map else {}),
-            "python": py_map,
+            stage_name: stage_map
+            for stage_name, stage_map in stage_maps.items()
+            if stage_map 
         }
+        payload["source_mappings"]["python"] = py_map
     # NDJSON format requires a newline at the end of each line
     return dumps(entry) + "\n"
 


### PR DESCRIPTION
## Background

- **RFC**: https://github.com/meta-pytorch/tritonparse/issues/367

## Summary

This PR is the **first PR in Flexible Backend Support RFC Phase 1**. Phase 1 is split into 3 PRs. See the final section for the next steps.

**What this PR does**: this PR focuses on the reader-side foundation and the generic parse flow refactor. It adds the backend adapter infrastructure and refactors the generic parse scheduling logic in `trace_processor.py`, including stage discovery, processing flow, and mapping construction.

---

## Main Changes

### 1. Backend Adapter Infrastructure (`tritonparse/backend.py` - new file)

**New core data structure**:

```python
@dataclass(frozen=True)
class IRStageDescriptor:
    name: str                      # Stage name, for example "ttir"
    extension: str                 # File extension, for example ".ttir"
    display_name: str              # Display name, for example "TTIR"
    display_order: int             # Display order (smaller number means earlier)
    is_text: bool                  # Whether the file is text
    supports_source_mapping: bool  # Whether source mapping is supported
    parser_id: str                 # Parser ID, for example "generic_loc"
    syntax_id: str                 # Syntax highlight ID, for example "mlir"
```

**New adapter abstraction**:

```python
class CompilationPipelineAdapter(ABC):
    @abstractmethod
    def adapter_name(self) -> str: ...

    @abstractmethod
    def runtime_backend(self) -> str: ...

    @abstractmethod
    def pytorch_module(self) -> str: ...

    @abstractmethod
    def get_ir_stages(self) -> list[IRStageDescriptor]: ...
```

**New concrete adapters**:

- `NvidiaTritonAdapter`: defines 7 stages for the CUDA backend (TTIR, TTGIR, LLIR, PTX, CUBIN, SASS, JSON)
- `AmdTritonAdapter`: defines 5 stages for the HIP backend (TTIR, TTGIR, LLIR, AMDGCN, JSON)

**New registry mechanism**:

```python
class PipelineAdapterRegistry:
    def register(self, adapter_cls: type[CompilationPipelineAdapter]) -> None: ...

    def resolve(self, adapter_name: str) -> CompilationPipelineAdapter: ...

    def resolve_from_trace(self, metadata: dict[str, Any]) -> CompilationPipelineAdapter: ...

    def create_all(self) -> list[CompilationPipelineAdapter]: ...
```

**New helper functions**:

- `get_present_stage_descriptors_from_event()`: gets stage descriptors from a trace event, with metadata-first and fallback behavior
- `get_backend_registry()`: gets the global registry instance

### 2. Generic Parse Scheduling Refactor (`tritonparse/parse/trace_processor.py`)

**New core function**:

#### 2.1 Dynamic Stage Discovery

```python
def _resolve_source_mappable_stage_keys(entry: Dict[str, Any]) -> Dict[str, str]:
    """
    Resolve stage keys that support source mapping from the trace.

    Two-level resolution:
    1. First: metadata.stage_descriptors (new trace format)
    2. Fallback: hardcoded extensions (old trace format)
    """
```

#### 2.2 Dynamic Stage Processing Flow

**Before this change (hardcoded 5 stages)**:

```python
# Hardcoded stage lookup
ttir_key = next((k for k in file_content if k.endswith(".ttir")), None)
ttgir_key = next((k for k in file_content if k.endswith(".ttgir")), None)
ptx_key = next((k for k in file_content if k.endswith(".ptx")), None)
amdgcn_key = next((k for k in file_content if k.endswith(".amdgcn")), None)
sass_key = next((k for k in file_content if k.endswith(".sass")), None)

# Hardcoded processing for each stage
ttir_map = process_ir(ttir_key, file_content, file_path)
ttgir_map = process_ir(ttgir_key, file_content, file_path)
ptx_map = process_ir(ptx_key, file_content, file_path, [ttir_map, ttgir_map])
amdgcn_map = process_ir(amdgcn_key, file_content, file_path, [ttir_map, ttgir_map])
sass_map = process_ir(sass_key, file_content, file_path, [ttir_map, ttgir_map])

# Hardcoded mapping construction
ir_maps = {
    "ttir": ttir_map,
    "ttgir": ttgir_map,
    "ptx": ptx_map,
    "amdgcn": amdgcn_map,
    "sass": sass_map,
}
```

**After this change (dynamic handling for any number of stages)**:

```python
# Discover stages dynamically
stage_keys = _resolve_source_mappable_stage_keys(entry)

# Process each stage in a dynamic loop
stage_maps = {}
for i, stage_name in enumerate(stage_names):
    artifact_key = stage_keys[stage_name]
    other_mappings = [stage_maps[prev] for prev in stage_names[:i]]
    stage_map = process_ir(artifact_key, file_content, file_path, other_mappings)
    stage_maps[stage_name] = stage_map

# Build bidirectional mappings dynamically (supports any number of stages)
for src_stage in stage_names:
    for tgt_stage in stage_names[i + 1:]:
        create_bidirectional_mapping(
            stage_maps[src_stage], stage_maps[tgt_stage],
            src_stage, tgt_stage
        )
```

**Key improvements**:
1. **Removed the hardcoded stage list**: no longer limited to 5 fixed stages
2. **Dynamic stage processing loop**: automatically handles any number of stages
3. **Dynamic mapping construction**: bidirectional mapping now adapts to the number of stages
4. **Dynamic Python mapping**: automatically includes all available stages

**Key improvements**:
1. **Supports any number of stages**: no longer limited to 5 hardcoded stages
2. **Automatically discovers new stages**: for example AMDGCN and future Ascend stages
3. **Keeps backward compatibility**: the fallback path still works for old traces
4. **Metadata-first**: new traces use the full metadata from the writer side

---

## Architecture Update

### Data flow before this change

```
Trace Event
    ↓
trace_processor.py (hardcoded 5 stages)
    ↓
process_ir() (called manually 5 times)
    ↓
source_mappings (fixed 5 keys)
```

### Data flow after this change

```
Trace Event
    ↓
get_backend_registry()
    ↓
resolve_from_trace(metadata)
    ↓
Adapter (NvidiaTritonAdapter / AmdTritonAdapter)
    ↓
_resolve_source_mappable_stage_keys() (with fallback logic)
    ↓
Dynamic stage loop processing
    ↓
source_mappings (dynamic keys)
```

---

## Validation

### Compatibility testing

To verify that the current parse path works for both new and old traces, I built the first version of the trace adaptation logic on my fork branch `logs_creator`. I used it to generate a new trace file for the new-trace validation case.
The validation results are good for both the new trace and the old trace. Both can be parsed correctly.


- old trace
<img width="1172" height="407" alt="image" src="https://github.com/user-attachments/assets/607ca1d6-45ba-4116-ac52-565b8e7c64a4" />


- new trace
<img width="1210" height="396" alt="image" src="https://github.com/user-attachments/assets/07db015f-ea22-4033-89ea-d00d769cfdab" />

### Format checking
The result of `make format-check` is shown below:
<img width="918" height="184" alt="image" src="https://github.com/user-attachments/assets/ee8e4cd4-3029-448f-8d21-2b760d775ed3" />


### Functional testing

The result of `make test-cuda` is shown below:
<img width="1551" height="605" alt="image" src="https://github.com/user-attachments/assets/bc24823f-3268-411f-9589-3ec4073e1ce3" />

The result of `make test` is shown below:
<img width="1528" height="582" alt="image" src="https://github.com/user-attachments/assets/285bd84a-033e-4216-b0ce-b79963378e75" />



### Multi-backend testing
The parse function also works properly in the Ascend backend.
<img width="1694" height="1170" alt="image" src="https://github.com/user-attachments/assets/327942a9-e3b0-4ebe-bd91-8fa9ee6b83c4" />


---

## Conclusion

This PR completes **PR 1 of the Flexible Backend Support RFC**. It builds the **reader-side foundation and generic parse flow refactor**, and it sets up the base for multi-backend support.

### Main contributions

1. ✅ **Adapter infrastructure**: complete contract, registry, and concrete implementations (`NvidiaTritonAdapter`, `AmdTritonAdapter`)
2. ✅ **Dynamic stage discovery**: metadata-first with hardcoded fallback
3. ✅ **Generic parse scheduling refactor**:
   - Dynamic stage discovery (`_resolve_source_mappable_stage_keys`)
   - Dynamic stage processing loop (supports any number of stages)
   - Dynamic bidirectional mapping construction (adapts automatically to the number of stages)
   - Dynamic Python mapping (automatically includes all available stages)
4. ✅ **Removed hardcoded logic**: `trace_processor.py` no longer hardcodes stage lookup and stage processing
5. ✅ **Backward compatibility**: 100% compatible with existing traces

---

## RFC Phase 1 Status and Next Steps

### ✅ PR 1 (this PR): Reader-side foundation and generic parse flow refactor
- Adapter infrastructure + generic parse scheduling refactor in `trace_processor.py`
- Add `tritonparse/backend.py`: `IRStageDescriptor`, `CompilationPipelineAdapter`, `NvidiaTritonAdapter`, `AmdTritonAdapter`, `PipelineAdapterRegistry`
- Refactor `trace_processor.py`: dynamic stage discovery (fallback included), dynamic stage processing loop, and dynamic mapping construction

### 🔜 PR 2: Parse and source mapping
- Backend-specific parser refactor in `ir_parser.py` (parser dispatch)

### 🔜 PR 3: Analysis and reproducer
- Migration of `ir_analysis.py` and the `reproducer/` modules