### PR TITLE
Fix sed regex error in sync-wiki GitHub Action

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -34,7 +34,7 @@ jobs:
                   # e.g., (01.-Installation.md#anchor) -> (01.-Installation#anchor)
                   cd wiki
                   for f in *.md; do
-                    sed -i -E 's/\]\(([0-9]{2}\.-[A-Za-z0-9_-]+)\.md(#[^)]*)?)/](\1\2)/g' "$f"
+                    sed -i -E 's/\]\(([0-9]{2}\.-[A-Za-z0-9_-]+)\.md(#[^)]*)?\)/](\1\2)/g' "$f"
                   done
 
             - name: Push to wiki


### PR DESCRIPTION
Summary:
Fix "Unmatched ) or \)" error in the sync-wiki.yml workflow.

In sed extended regex mode (`-E`), parentheses are grouping metacharacters. The original pattern ended with `?)` where the `)` was intended to match the literal closing parenthesis of a markdown link `](...)`, but sed interpreted it as a regex group closer, causing the syntax error.

Fix: escape the literal `)` as `\)` so sed treats it as a character to match, not regex syntax.

Before: `(#[^)]*)?)`  — sed sees unmatched )
After:  `(#[^)]*)?\)` — sed matches literal )

Differential Revision: D102049331


