### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/tritonparse/clp.py
+++ b/tritonparse/clp.py
@@ -7,5 +7,6 @@ import yscope_clp_core
 
 
 def clp_open(clp_dir: str, open_mode: str):
-    assert open_mode in ["r", "w"], "CLP only supports r and w modes."
+    if open_mode not in ["r", "w"]:
+        raise ValueError("CLP only supports r and w modes.")
     return yscope_clp_core.open_archive(clp_dir, open_mode)

--- a/tritonparse/tools/load_tensor.py
+++ b/tritonparse/tools/load_tensor.py
@@ -69,8 +69,11 @@ def load_tensor(tensor_file_path: Union[str, Path], device: str = None) -> torch
         )
 
     try:
-        # Load the tensor from memory buffer
-        tensor = torch.load(io.BytesIO(file_contents), map_location=device)
+        tensor = torch.load(io.BytesIO(file_contents), map_location=device, weights_only=True)
         return tensor
+    except TypeError as e:
+        raise RuntimeError(
+            "Secure tensor loading requires a PyTorch version that supports weights_only=True"
+        ) from e
     except Exception as e:
         raise RuntimeError(f"Failed to load tensor from {blob_path}: {str(e)}")


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `tritonparse/tools/load_tensor.py:L73`

The `load_tensor` utility reads arbitrary file content and passes it directly to `torch.load(...)`. `torch.load` uses Python pickle under the hood and can execute arbitrary code during deserialization if the input is malicious. If users load `.bin`/`.bin.gz` files from untrusted sources, this can lead to remote code execution.

## Solution

Avoid using pickle-based deserialization for untrusted data. Prefer a safe format (e.g., `safetensors`, NumPy `.npz`, or custom raw tensor encoding). If backward compatibility is required, add a strict trust boundary check and explicit warning/error for untrusted paths, and consider using `torch.load(..., weights_only=True)` where compatible.

## Changes

- `tritonparse/tools/load_tensor.py` (modified)
- `tritonparse/clp.py` (modified)