### PR TITLE
Optimize homepage button display

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -515,6 +515,65 @@ function App() {
     }
   };
 
+  // Helper: whether any trace/kernel data is available for enabling tabs
+  const isTraceLoaded = dataLoaded && kernels.length > 0;
+
+  // Helper to build class names for tab buttons
+  const tabClassName = (isDisabled: boolean, isActive: boolean) =>
+    `px-3 py-2 text-sm font-medium rounded-md ${
+      isDisabled
+        ? "bg-gray-100 text-gray-400 cursor-not-allowed"
+        : isActive
+        ? "bg-blue-700 text-white shadow-md"
+        : "bg-blue-100 text-blue-700 hover:bg-blue-200"
+    }`;
+
+  // Factory to create tab buttons with consistent behavior and accessibility
+  const makeTabButton = (opts: {
+    label: string;
+    isActive: boolean;
+    includeSelectedIR?: boolean;
+    onActivate: () => void;
+    enabledTitle?: string;
+    disabledTitle?: string;
+  }) => {
+    const { label, isActive, includeSelectedIR = true, onActivate, enabledTitle, disabledTitle } = opts;
+    const isDisabled = !isTraceLoaded || (includeSelectedIR && !!selectedIR);
+
+    // Use aria-disabled + click guard so tooltip and keyboard users can discover the hint
+    const handleClick = () => {
+      if (isDisabled) return;
+      onActivate();
+    };
+
+    const title = isDisabled ? disabledTitle ?? "Please load a trace file first" : enabledTitle ?? label;
+    const descriptionId = isDisabled ? `tab-hint-${label.toLowerCase().replace(/[^a-z0-9]+/g, "-")}` : undefined;
+
+    return (
+      <span className="group relative inline-flex focus-within:z-10">
+        <button
+          className={tabClassName(isDisabled, isActive)}
+          aria-disabled={isDisabled}
+          aria-describedby={descriptionId}
+          onClick={handleClick}
+        >
+          {label}
+        </button>
+        {descriptionId && (
+          <>
+            <span id={descriptionId} className="sr-only">{title}</span>
+            <span
+              aria-hidden="true"
+              className="pointer-events-none absolute left-1/2 top-full z-20 mt-2 -translate-x-1/2 whitespace-nowrap rounded-md bg-gray-900 px-2 py-1 text-xs text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100"
+            >
+              {title}
+            </span>
+          </>
+        )}
+      </span>
+    );
+  };
+
   return (
     <div className="min-h-screen w-full bg-gray-50 flex flex-col">
       {/* Header with navigation */}
@@ -576,95 +635,73 @@ function App() {
               onShowUrlInputChange={setShowUrlInput}
             />
 
-            {/* Tab navigation: All buttons always visible, disabled when no data loaded */}
+            {/* Tab navigation: All buttons always visible; use shared helper for state, styling, and accessibility */}
             <div className="flex space-x-4">
-              <button
-                className={`px-3 py-2 text-sm font-medium rounded-md ${
-                  !dataLoaded || kernels.length === 0 || selectedIR
-                    ? "bg-gray-100 text-gray-400 cursor-not-allowed"
-                    : activeTab === "overview"
-                    ? "bg-blue-700 text-white shadow-md"
-                    : "bg-blue-100 text-blue-700 hover:bg-blue-200"
-                }`}
-                onClick={() => {
-                  if (!dataLoaded || kernels.length === 0) return;
+              {makeTabButton({
+                label: "Kernel Overview",
+                isActive: activeTab === "overview",
+                includeSelectedIR: true,
+                onActivate: () => {
                   if (sess.preview?.active) sess.clearPreview();
                   setShowWelcome(false);
                   setActiveTab("overview");
-
                   if (loadedUrl) {
                     const newUrl = new URL(window.location.href);
                     newUrl.searchParams.delete("view");
                     window.history.replaceState({}, "", newUrl.toString());
                   }
-                }}
-                disabled={!dataLoaded || kernels.length === 0}
-                title={!dataLoaded || kernels.length === 0 ? "Please load a trace file first" : "View kernel overview"}
-              >
-                Kernel Overview
-              </button>
-              <button
-                className={`px-3 py-2 text-sm font-medium rounded-md ${
-                  !dataLoaded || kernels.length === 0 || selectedIR
-                    ? "bg-gray-100 text-gray-400 cursor-not-allowed"
-                    : activeTab === "comparison"
-                    ? "bg-blue-700 text-white shadow-md"
-                    : "bg-blue-100 text-blue-700 hover:bg-blue-200"
-                }`}
-                onClick={() => {
-                  if (!dataLoaded || kernels.length === 0) return;
+                },
+                enabledTitle: "View kernel overview",
+                disabledTitle: "Please load a trace file first",
+              })}
+
+              {makeTabButton({
+                label: "IR Code",
+                isActive: activeTab === "comparison",
+                includeSelectedIR: true,
+                onActivate: () => {
                   if (sess.preview?.active) sess.clearPreview();
                   setShowWelcome(false);
                   setActiveTab("comparison");
-
                   if (loadedUrl) {
                     const newUrl = new URL(window.location.href);
                     newUrl.searchParams.set("view", "ir_code_comparison");
                     window.history.replaceState({}, "", newUrl.toString());
                   }
-                }}
-                disabled={!dataLoaded || kernels.length === 0}
-                title={!dataLoaded || kernels.length === 0 ? "Please load a trace file first" : "View IR code comparison"}
-              >
-                IR Code
-              </button>
-              <button
-                className={`px-3 py-2 text-sm font-medium rounded-md ${activeTab === "file_diff" ? "bg-blue-700 text-white shadow-md" : "bg-blue-100 text-blue-700 hover:bg-blue-200"
-                  }`}
-                onClick={() => {
+                },
+                enabledTitle: "View IR code comparison",
+                disabledTitle: "Please load a trace file first",
+              })}
+
+              {makeTabButton({
+                label: "File Diff",
+                isActive: activeTab === "file_diff",
+                includeSelectedIR: false,
+                onActivate: () => {
                   if (sess.preview?.active) sess.clearPreview();
                   setShowWelcome(false);
                   setActiveTab("file_diff");
-                }}
-                title="View file diff"
-              >
-                File Diff
-              </button>
-              <button
-                className={`px-3 py-2 text-sm font-medium rounded-md ${
-                  !dataLoaded || kernels.length === 0 || selectedIR
-                    ? "bg-gray-100 text-gray-400 cursor-not-allowed"
-                    : activeTab === "ir_analysis"
-                    ? "bg-blue-700 text-white shadow-md"
-                    : "bg-blue-100 text-blue-700 hover:bg-blue-200"
-                }`}
-                onClick={() => {
-                  if (!dataLoaded || kernels.length === 0) return;
+                },
+                enabledTitle: "View file diff",
+              })}
+
+              {makeTabButton({
+                label: "IR Analysis (Beta)",
+                isActive: activeTab === "ir_analysis",
+                includeSelectedIR: true,
+                onActivate: () => {
                   if (sess.preview?.active) sess.clearPreview();
                   setShowWelcome(false);
                   setActiveTab("ir_analysis");
-
                   if (loadedUrl) {
                     const newUrl = new URL(window.location.href);
                     newUrl.searchParams.set("view", "ir_analysis");
                     window.history.replaceState({}, "", newUrl.toString());
                   }
-                }}
-                disabled={!dataLoaded || kernels.length === 0}
-                title={!dataLoaded || kernels.length === 0 ? "Please load a trace file first" : "View IR analysis"}
-              >
-                IR Analysis (Beta)
-              </button>
+                },
+                enabledTitle: "View IR analysis",
+                disabledTitle: "Please load a trace file first",
+              })}
             </div>
           </div>
         </div>

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -576,46 +576,58 @@ function App() {
               onShowUrlInputChange={setShowUrlInput}
             />
 
-            {/* Tab navigation: File Diff button placed as the last (rightmost) button */}
+            {/* Tab navigation: All buttons always visible, disabled when no data loaded */}
             <div className="flex space-x-4">
-              {dataLoaded && kernels.length > 0 && !selectedIR && (
-                <>
-                  <button
-                    className={`px-3 py-2 text-sm font-medium rounded-md ${activeTab === "overview" ? "bg-blue-700 text-white shadow-md" : "bg-blue-100 text-blue-700 hover:bg-blue-200"
-                      }`}
-                    onClick={() => {
-                      if (sess.preview?.active) sess.clearPreview();
-                      setShowWelcome(false);
-                      setActiveTab("overview");
+              <button
+                className={`px-3 py-2 text-sm font-medium rounded-md ${
+                  !dataLoaded || kernels.length === 0 || selectedIR
+                    ? "bg-gray-100 text-gray-400 cursor-not-allowed"
+                    : activeTab === "overview"
+                    ? "bg-blue-700 text-white shadow-md"
+                    : "bg-blue-100 text-blue-700 hover:bg-blue-200"
+                }`}
+                onClick={() => {
+                  if (!dataLoaded || kernels.length === 0) return;
+                  if (sess.preview?.active) sess.clearPreview();
+                  setShowWelcome(false);
+                  setActiveTab("overview");
 
-                      if (loadedUrl) {
-                        const newUrl = new URL(window.location.href);
-                        newUrl.searchParams.delete("view");
-                        window.history.replaceState({}, "", newUrl.toString());
-                      }
-                    }}
-                  >
-                    Kernel Overview
-                  </button>
-                  <button
-                    className={`px-3 py-2 text-sm font-medium rounded-md ${activeTab === "comparison" ? "bg-blue-700 text-white shadow-md" : "bg-blue-100 text-blue-700 hover:bg-blue-200"
-                      }`}
-                    onClick={() => {
-                      if (sess.preview?.active) sess.clearPreview();
-                      setShowWelcome(false);
-                      setActiveTab("comparison");
+                  if (loadedUrl) {
+                    const newUrl = new URL(window.location.href);
+                    newUrl.searchParams.delete("view");
+                    window.history.replaceState({}, "", newUrl.toString());
+                  }
+                }}
+                disabled={!dataLoaded || kernels.length === 0}
+                title={!dataLoaded || kernels.length === 0 ? "Please load a trace file first" : "View kernel overview"}
+              >
+                Kernel Overview
+              </button>
+              <button
+                className={`px-3 py-2 text-sm font-medium rounded-md ${
+                  !dataLoaded || kernels.length === 0 || selectedIR
+                    ? "bg-gray-100 text-gray-400 cursor-not-allowed"
+                    : activeTab === "comparison"
+                    ? "bg-blue-700 text-white shadow-md"
+                    : "bg-blue-100 text-blue-700 hover:bg-blue-200"
+                }`}
+                onClick={() => {
+                  if (!dataLoaded || kernels.length === 0) return;
+                  if (sess.preview?.active) sess.clearPreview();
+                  setShowWelcome(false);
+                  setActiveTab("comparison");
 
-                      if (loadedUrl) {
-                        const newUrl = new URL(window.location.href);
-                        newUrl.searchParams.set("view", "ir_code_comparison");
-                        window.history.replaceState({}, "", newUrl.toString());
-                      }
-                    }}
-                  >
-                    IR Code
-                  </button>
-                </>
-              )}
+                  if (loadedUrl) {
+                    const newUrl = new URL(window.location.href);
+                    newUrl.searchParams.set("view", "ir_code_comparison");
+                    window.history.replaceState({}, "", newUrl.toString());
+                  }
+                }}
+                disabled={!dataLoaded || kernels.length === 0}
+                title={!dataLoaded || kernels.length === 0 ? "Please load a trace file first" : "View IR code comparison"}
+              >
+                IR Code
+              </button>
               <button
                 className={`px-3 py-2 text-sm font-medium rounded-md ${activeTab === "file_diff" ? "bg-blue-700 text-white shadow-md" : "bg-blue-100 text-blue-700 hover:bg-blue-200"
                   }`}
@@ -624,28 +636,35 @@ function App() {
                   setShowWelcome(false);
                   setActiveTab("file_diff");
                 }}
+                title="View file diff"
               >
                 File Diff
               </button>
-              {dataLoaded && kernels.length > 0 && (
               <button
-                    className={`px-3 py-2 text-sm font-medium rounded-md ${activeTab === "ir_analysis" ? "bg-blue-700 text-white shadow-md" : "bg-blue-100 text-blue-700 hover:bg-blue-200"
-                      }`}
-                    onClick={() => {
-                      if (sess.preview?.active) sess.clearPreview();
-                      setShowWelcome(false);
-                      setActiveTab("ir_analysis");
+                className={`px-3 py-2 text-sm font-medium rounded-md ${
+                  !dataLoaded || kernels.length === 0 || selectedIR
+                    ? "bg-gray-100 text-gray-400 cursor-not-allowed"
+                    : activeTab === "ir_analysis"
+                    ? "bg-blue-700 text-white shadow-md"
+                    : "bg-blue-100 text-blue-700 hover:bg-blue-200"
+                }`}
+                onClick={() => {
+                  if (!dataLoaded || kernels.length === 0) return;
+                  if (sess.preview?.active) sess.clearPreview();
+                  setShowWelcome(false);
+                  setActiveTab("ir_analysis");
 
-                      if (loadedUrl) {
-                        const newUrl = new URL(window.location.href);
-                        newUrl.searchParams.set("view", "ir_analysis");
-                        window.history.replaceState({}, "", newUrl.toString());
-                      }
-                    }}
-                  >
-                    IR Analysis (Beta)
-                  </button>
-              )}
+                  if (loadedUrl) {
+                    const newUrl = new URL(window.location.href);
+                    newUrl.searchParams.set("view", "ir_analysis");
+                    window.history.replaceState({}, "", newUrl.toString());
+                  }
+                }}
+                disabled={!dataLoaded || kernels.length === 0}
+                title={!dataLoaded || kernels.length === 0 ? "Please load a trace file first" : "View IR analysis"}
+              >
+                IR Analysis (Beta)
+              </button>
             </div>
           </div>
         </div>

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -532,13 +532,22 @@ function App() {
   const makeTabButton = (opts: {
     label: string;
     isActive: boolean;
+    requiresTrace?: boolean;
     includeSelectedIR?: boolean;
     onActivate: () => void;
     enabledTitle?: string;
     disabledTitle?: string;
   }) => {
-    const { label, isActive, includeSelectedIR = true, onActivate, enabledTitle, disabledTitle } = opts;
-    const isDisabled = !isTraceLoaded || (includeSelectedIR && !!selectedIR);
+    const {
+      label,
+      isActive,
+      requiresTrace = true,
+      includeSelectedIR = true,
+      onActivate,
+      enabledTitle,
+      disabledTitle,
+    } = opts;
+    const isDisabled = (requiresTrace && !isTraceLoaded) || (includeSelectedIR && !!selectedIR);
 
     // Use aria-disabled + click guard so tooltip and keyboard users can discover the hint
     const handleClick = () => {
@@ -676,6 +685,7 @@ function App() {
               {makeTabButton({
                 label: "File Diff",
                 isActive: activeTab === "file_diff",
+                requiresTrace: false,
                 includeSelectedIR: false,
                 onActivate: () => {
                   if (sess.preview?.active) sess.clearPreview();


### PR DESCRIPTION
## Summary
Optimize the display of functional buttons in the top right corner of the tritonparse frontend homepage when no parsing file is selected
## Current Status
When no parsing file is selected, only the File Diff functional button is displayed in the top right corner; additionally, the Open Local File and Load From URL buttons in the center are misaligned to the right.
<img width="2244" height="1285" alt="image" src="https://github.com/user-attachments/assets/0e4a315a-4ae4-4784-9acd-a92b07cfe152" />

## Optimization Details
- Persistent visibility for core buttons: Kernel Overview, IR Code, IR Analysis and File Diff are always visible in the top right corner.
- Disabled state configuration (when no data is loaded):
Kernel Overview, IR Code and IR Analysis are displayed with a gray background and gray text.
A not-allowed cursor is shown on mouse hover, with the tooltip prompt: Please load a trace file first.

## format check
<img width="900" height="196" alt="image" src="https://github.com/user-attachments/assets/44227a04-1693-45e1-9804-6d3e62c38ce7" />


## Expected Outcome
<img width="2560" height="1380" alt="image" src="https://github.com/user-attachments/assets/4ee191cc-4cb1-43ac-95e8-a794b0eec580" />


<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/aaf8269b-5ee2-4742-b5db-216f3c1589c0" />

<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/ea53ab90-fa19-4edf-b7c6-363412bbd53c" />


The frontend UI layout is more standardized and intuitive; users can clearly perceive all available functional modules at a glance, and the disabled state prompt guides users to complete the file loading operation first, improving the overall user experience.