### PR TITLE
Parser Distribution System Refactoring - From Hardcoded to Adapter-Driven Parser Registration and Selection

### DIFF
--- a/tests/cpu/test_multi_backend_stage.py
+++ b/tests/cpu/test_multi_backend_stage.py
@@ -233,36 +233,76 @@ class TestMultiBackendStage(unittest.TestCase):
             %0 = arith.constant 42 loc(#loc1)
             """
 
+        sentinel_mapping = {
+            "sentinel": {"file": "adapter_selected.py", "line": 999, "ttir_line": 1}
+        }
+
+        def sentinel_generic_loc_parser(*args, **kwargs):
+            return sentinel_mapping
+
+        original_generic_parser = ParserRegistry.get_parser("generic_loc")
+        self.assertIsNotNone(original_generic_parser)
+
         # Test with metadata (adapter-driven parser selection)
         metadata_cuda = {"backend_name": "cuda"}
-        result_with_metadata = generate_source_mappings(
-            ttir_content, "ttir", None, metadata_cuda
-        )
-        self.assertIsInstance(result_with_metadata, dict)
-        self.assertIn("4", result_with_metadata)
-        self.assertEqual(result_with_metadata["4"]["file"], "test.py")
-        self.assertEqual(result_with_metadata["4"]["line"], 20)
-        self.assertIn("ttir_line", result_with_metadata["4"])
+        try:
+            ParserRegistry.register("generic_loc", sentinel_generic_loc_parser)
 
-        # Test without metadata (fallback to hardcoded parser selection)
-        result_fallback = generate_source_mappings(ttir_content, "ttir", None, None)
-        self.assertIsInstance(result_fallback, dict)
-        self.assertIn("4", result_fallback)
-        self.assertEqual(result_fallback["4"]["file"], "test.py")
-        self.assertEqual(result_fallback["4"]["line"], 20)
-        self.assertIn("ttir_line", result_fallback["4"])
+            result_with_metadata = generate_source_mappings(
+                ttir_content, "ttir", None, metadata_cuda
+            )
+            self.assertEqual(
+                result_with_metadata,
+                sentinel_mapping,
+                "Expected metadata-driven source mapping to use the adapter-selected parser",
+            )
 
-        # Verify both paths produce similar results
-        self.assertEqual(
-            result_with_metadata["4"]["file"],
-            result_fallback["4"]["file"],
-            "Adapter-driven and fallback should produce same file",
-        )
-        self.assertEqual(
-            result_with_metadata["4"]["line"],
-            result_fallback["4"]["line"],
-            "Adapter-driven and fallback should produce same line",
-        )
+            # Empty metadata simulates legacy traces after payload.setdefault("metadata", {}).
+            result_empty_metadata = generate_source_mappings(
+                ttir_content, "ttir", None, {}
+            )
+            self.assertIsInstance(result_empty_metadata, dict)
+            self.assertIn("4", result_empty_metadata)
+            self.assertEqual(result_empty_metadata["4"]["file"], "test.py")
+            self.assertEqual(result_empty_metadata["4"]["line"], 20)
+            self.assertIn("ttir_line", result_empty_metadata["4"])
+
+            result_fallback = generate_source_mappings(ttir_content, "ttir", None, None)
+            self.assertIsInstance(result_fallback, dict)
+            self.assertIn("4", result_fallback)
+            self.assertEqual(result_fallback["4"]["file"], "test.py")
+            self.assertEqual(result_fallback["4"]["line"], 20)
+            self.assertIn("ttir_line", result_fallback["4"])
+        finally:
+            ParserRegistry.register("generic_loc", original_generic_parser)
+
+    def test_adapter_parser_execution_errors_are_not_silently_swallowed(self):
+        """Adapter-selected parser execution failures should propagate instead of falling back."""
+        registry = PipelineAdapterRegistry()
+        registry.register(NvidiaTritonAdapter)
+        registry.register(AmdTritonAdapter)
+
+        ttir_content = """
+            #loc = loc("test.py":10:5)
+            #loc1 = loc("test.py":20:10)
+            %0 = arith.constant 42 loc(#loc1)
+            """
+
+        metadata_cuda = {"backend_name": "cuda"}
+
+        def failing_generic_loc_parser(*args, **kwargs):
+            raise RuntimeError("parser execution failed")
+
+        original_generic_parser = ParserRegistry.get_parser("generic_loc")
+        self.assertIsNotNone(original_generic_parser)
+
+        try:
+            ParserRegistry.register("generic_loc", failing_generic_loc_parser)
+
+            with self.assertRaisesRegex(RuntimeError, "parser execution failed"):
+                generate_source_mappings(ttir_content, "ttir", None, metadata_cuda)
+        finally:
+            ParserRegistry.register("generic_loc", original_generic_parser)
 
 
 if __name__ == "__main__":

--- a/tests/cpu/test_multi_backend_stage.py
+++ b/tests/cpu/test_multi_backend_stage.py
@@ -6,7 +6,11 @@ from tritonparse.backend import (
     NvidiaTritonAdapter,
     PipelineAdapterRegistry,
 )
-from tritonparse.parse.trace_processor import _resolve_source_mappable_stage_keys
+from tritonparse.parse.ir_parser import ParserRegistry
+from tritonparse.parse.trace_processor import (
+    _resolve_source_mappable_stage_keys,
+    generate_source_mappings,
+)
 
 
 def make_event(file_content: dict, stage_descriptors: list | None = None):
@@ -162,6 +166,103 @@ class TestMultiBackendStage(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             deserialize_stage_descriptors_from_event(event)
+
+    def test_parser_registry_and_layered_registration(self):
+        """Test ParserRegistry and layered parser registration (common + backend-specific)."""
+        # Step 1: Verify common parsers are pre-registered
+        common_parsers = {"generic_loc", "none"}
+        for parser_id in common_parsers:
+            parser = ParserRegistry.get_parser(parser_id)
+            self.assertIsNotNone(
+                parser, f"Common parser '{parser_id}' should be pre-registered"
+            )
+
+        # Step 2: Create adapters (triggers backend-specific parser registration)
+        registry = PipelineAdapterRegistry()
+        registry.register(NvidiaTritonAdapter)
+        registry.register(AmdTritonAdapter)
+
+        # Step 3: Verify all parsers are listed (check registry list functionality)
+        all_parsers = ParserRegistry.list_parsers()
+        self.assertIn("generic_loc", all_parsers)
+        self.assertIn("none", all_parsers)
+        self.assertIn("ptx_loc", all_parsers)
+        self.assertIn("sass_loc", all_parsers)
+        self.assertIn("amdgcn_loc", all_parsers)
+
+    def test_adapter_get_parser_method(self):
+        """Test adapter.get_parser() method with both common and backend-specific parsers."""
+        registry = PipelineAdapterRegistry()
+        registry.register(NvidiaTritonAdapter)
+        registry.register(AmdTritonAdapter)
+
+        # Get NVIDIA adapter
+        nvidia_adapter = registry.resolve(adapter_name="cuda_triton")
+
+        # Test getting common parser (generic_loc)
+        generic_parser = nvidia_adapter.get_parser("generic_loc")
+        self.assertIsNotNone(generic_parser)
+
+        # Test getting NVIDIA-specific parser
+        ptx_parser = nvidia_adapter.get_parser("ptx_loc")
+        self.assertIsNotNone(ptx_parser)
+
+        # Test getting AMD parser (also works because parsers are globally registered)
+        amdgcn_parser = nvidia_adapter.get_parser("amdgcn_loc")
+        self.assertIsNotNone(amdgcn_parser)
+
+        # Get AMD adapter and test NVIDIA parser (also works for symmetrical access)
+        amd_adapter = registry.resolve(adapter_name="hip_triton")
+        ptx_parser_amd = amd_adapter.get_parser("ptx_loc")
+        self.assertIsNotNone(ptx_parser_amd)
+
+        # Test getting unknown parser should raise ValueError
+        with self.assertRaises(ValueError):
+            nvidia_adapter.get_parser("unknown_parser")
+
+    def test_adapter_driven_parser_selection_and_fallback(self):
+        """Test adapter-driven parser selection with backward compatibility fallback."""
+        registry = PipelineAdapterRegistry()
+        registry.register(NvidiaTritonAdapter)
+        registry.register(AmdTritonAdapter)
+
+        # Test content (TTIR with #loc directives)
+        ttir_content = """
+            #loc = loc("test.py":10:5)
+            #loc1 = loc("test.py":20:10)
+            %0 = arith.constant 42 loc(#loc1)
+            """
+
+        # Test with metadata (adapter-driven parser selection)
+        metadata_cuda = {"backend_name": "cuda"}
+        result_with_metadata = generate_source_mappings(
+            ttir_content, "ttir", None, metadata_cuda
+        )
+        self.assertIsInstance(result_with_metadata, dict)
+        self.assertIn("4", result_with_metadata)
+        self.assertEqual(result_with_metadata["4"]["file"], "test.py")
+        self.assertEqual(result_with_metadata["4"]["line"], 20)
+        self.assertIn("ttir_line", result_with_metadata["4"])
+
+        # Test without metadata (fallback to hardcoded parser selection)
+        result_fallback = generate_source_mappings(ttir_content, "ttir", None, None)
+        self.assertIsInstance(result_fallback, dict)
+        self.assertIn("4", result_fallback)
+        self.assertEqual(result_fallback["4"]["file"], "test.py")
+        self.assertEqual(result_fallback["4"]["line"], 20)
+        self.assertIn("ttir_line", result_fallback["4"])
+
+        # Verify both paths produce similar results
+        self.assertEqual(
+            result_with_metadata["4"]["file"],
+            result_fallback["4"]["file"],
+            "Adapter-driven and fallback should produce same file",
+        )
+        self.assertEqual(
+            result_with_metadata["4"]["line"],
+            result_fallback["4"]["line"],
+            "Adapter-driven and fallback should produce same line",
+        )
 
 
 if __name__ == "__main__":

--- a/tritonparse/backend.py
+++ b/tritonparse/backend.py
@@ -109,22 +109,60 @@ class CompilationPipelineAdapter(ABC):
     def normalize_device_string(self, device: str) -> str:
         return device
 
+    def get_parser(self, parser_id: str):
+        """
+        Get parser function by parser_id from the parser registry.
+
+        This is a generic implementation that works for most backends.
+        Subclasses can override this method if they need custom parser resolution.
+
+        Args:
+            parser_id: The parser identifier (e.g., "generic_loc", "ptx_loc")
+
+        Returns:
+            The parser function for the given parser_id
+
+        Raises:
+            ValueError: If the parser_id is not found in the registry
+        """
+        from tritonparse.parse.ir_parser import ParserRegistry
+
+        parser = ParserRegistry.get_parser(parser_id)
+        if parser is None:
+            available_parsers = ParserRegistry.list_parsers()
+            raise ValueError(
+                f"Parser '{parser_id}' not found. "
+                f"Available parsers: {available_parsers}"
+            )
+        return parser
+
+    def register_backend_parser(self, parser_id: str, parser_func) -> None:
+        """
+        Register a backend-specific parser to the parser registry.
+
+        This allows adapters to register custom parsers for backend-specific
+        IR formats that are not part of the common parser registry.
+
+        Args:
+            parser_id: The parser identifier (e.g., "ascend_ir")
+            parser_func: The parser function
+        """
+        from tritonparse.parse.ir_parser import ParserRegistry
+
+        ParserRegistry.register(parser_id, parser_func)
+
 
 class NvidiaTritonAdapter(CompilationPipelineAdapter):
-    @property
-    def adapter_name(self) -> str:
-        return "cuda_triton"
+    def __init__(self):
+        """Initialize and register backend-specific parsers and stage descriptors."""
+        from tritonparse.parse.ir_parser import _parse_ptx_loc, _parse_sass_loc
 
-    @property
-    def runtime_backend(self) -> str:
-        return "cuda"
+        # Register NVIDIA-specific parsers
+        self.register_backend_parser("ptx_loc", _parse_ptx_loc)
+        self.register_backend_parser("sass_loc", _parse_sass_loc)
 
-    @property
-    def pytorch_module(self) -> str:
-        return "torch.cuda"
-
-    def get_ir_stages(self) -> list[IRStageDescriptor]:
-        return [
+        # Pre-initialize stage descriptors (immutable objects, can be reused)
+        self._stages = [
             IRStageDescriptor(
                 "ttir", ".ttir", "TTIR", 10, True, True, "generic_loc", "mlir"
             ),
@@ -146,22 +184,32 @@ class NvidiaTritonAdapter(CompilationPipelineAdapter):
             ),
         ]
 
-
-class AmdTritonAdapter(CompilationPipelineAdapter):
     @property
     def adapter_name(self) -> str:
-        return "hip_triton"
+        return "cuda_triton"
 
     @property
     def runtime_backend(self) -> str:
-        return "hip"
+        return "cuda"
 
     @property
     def pytorch_module(self) -> str:
         return "torch.cuda"
 
     def get_ir_stages(self) -> list[IRStageDescriptor]:
-        return [
+        return self._stages
+
+
+class AmdTritonAdapter(CompilationPipelineAdapter):
+    def __init__(self):
+        """Initialize and register backend-specific parsers and stage descriptors."""
+        from tritonparse.parse.ir_parser import _parse_amdgcn_loc
+
+        # Register AMD-specific parsers
+        self.register_backend_parser("amdgcn_loc", _parse_amdgcn_loc)
+
+        # Pre-initialize stage descriptors (immutable objects, can be reused)
+        self._stages = [
             IRStageDescriptor(
                 "ttir", ".ttir", "TTIR", 10, True, True, "generic_loc", "mlir"
             ),
@@ -178,6 +226,21 @@ class AmdTritonAdapter(CompilationPipelineAdapter):
                 "json", ".json", "JSON", 100, True, False, "none", "json"
             ),
         ]
+
+    @property
+    def adapter_name(self) -> str:
+        return "hip_triton"
+
+    @property
+    def runtime_backend(self) -> str:
+        return "hip"
+
+    @property
+    def pytorch_module(self) -> str:
+        return "torch.cuda"
+
+    def get_ir_stages(self) -> list[IRStageDescriptor]:
+        return self._stages
 
 
 class PipelineAdapterRegistry:

--- a/tritonparse/backend.py
+++ b/tritonparse/backend.py
@@ -248,30 +248,34 @@ class PipelineAdapterRegistry:
 
     Provides registration and resolution methods for different backend adapters.
     Adapters can be looked up by name or inferred from trace metadata.
+
+    Note: Adapters are instantiated once during registration and reused for all
+    subsequent resolutions. This ensures parsers are registered only once and
+    stage descriptors are initialized only once.
     """
 
     def __init__(self) -> None:
-        self._adapter_types: dict[str, type[CompilationPipelineAdapter]] = {}
+        self._adapters: dict[str, CompilationPipelineAdapter] = {}
 
     def register(self, adapter_cls: type[CompilationPipelineAdapter]) -> None:
         adapter = adapter_cls()
-        self._adapter_types[adapter.adapter_name.lower()] = adapter_cls
+        self._adapters[adapter.adapter_name.lower()] = adapter
 
     def create_all(self) -> list[CompilationPipelineAdapter]:
-        return [adapter_cls() for adapter_cls in self._adapter_types.values()]
+        return list(self._adapters.values())
 
     def resolve(
         self,
         *,
         adapter_name: str,
     ) -> CompilationPipelineAdapter:
-        adapter_cls = self._adapter_types.get(adapter_name.lower())
-        if adapter_cls is None:
+        adapter = self._adapters.get(adapter_name.lower())
+        if adapter is None:
             raise ValueError(
                 "Unable to resolve adapter from adapter_name: "
                 f"adapter_name={adapter_name!r}"
             )
-        return adapter_cls()
+        return adapter
 
     def resolve_from_trace(
         self,

--- a/tritonparse/backend.py
+++ b/tritonparse/backend.py
@@ -89,7 +89,13 @@ class CompilationPipelineAdapter(ABC):
     def get_ir_stages(self) -> list[IRStageDescriptor]:
         raise NotImplementedError
 
-    def classify_artifact(self, artifact_name: str) -> IRStageDescriptor | None:
+    def get_stage_by_name(self, stage_name: str) -> IRStageDescriptor | None:
+        for stage in self.get_ir_stages():
+            if stage.name == stage_name:
+                return stage
+        return None
+
+    def get_stage_by_artifact(self, artifact_name: str) -> IRStageDescriptor | None:
         artifact_suffix = Path(artifact_name).suffix
         for stage in self.get_ir_stages():
             if stage.extension == artifact_suffix:

--- a/tritonparse/parse/ir_parser.py
+++ b/tritonparse/parse/ir_parser.py
@@ -3,7 +3,7 @@
 import os
 import re
 from collections import defaultdict
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List, Optional
 
 from tritonparse.tp_logger import get_logger
 
@@ -60,6 +60,64 @@ ALIAS_SIMPLE_PATTERN = re.compile(r"#loc(\d+)\s*=\s*loc\(\s*#loc(\d*)\s*\)")
 CALLSITE_PATTERN = re.compile(
     r"#loc(\d+)\s*=\s*loc\(\s*callsite\(\s*#loc(\d*)\s+at\s+#loc(\d*)\s*\)\s*\)"
 )
+
+
+# =============================================================================
+# PARSER REGISTRY
+# =============================================================================
+class ParserRegistry:
+    """
+    Registry for managing IR parser functions.
+
+    This registry allows adapters to register and retrieve parser functions
+    by parser_id. It supports both common parsers (shared across backends)
+    and backend-specific parsers.
+    """
+
+    _parsers: Dict[str, Callable] = {}
+
+    @classmethod
+    def register(cls, parser_id: str, parser_func: Callable) -> None:
+        """
+        Register a parser function with the given parser_id.
+
+        Args:
+            parser_id: The parser identifier (e.g., "generic_loc", "ptx_loc")
+            parser_func: The parser function
+
+        Raises:
+            ValueError: If parser_id is already registered
+        """
+        if parser_id in cls._parsers:
+            logger.warning(
+                f"Parser '{parser_id}' is already registered. "
+                f"Overwriting with new parser function."
+            )
+        cls._parsers[parser_id] = parser_func
+        logger.debug(f"Registered parser: {parser_id}")
+
+    @classmethod
+    def get_parser(cls, parser_id: str) -> Optional[Callable]:
+        """
+        Get a parser function by parser_id.
+
+        Args:
+            parser_id: The parser identifier
+
+        Returns:
+            The parser function, or None if not found
+        """
+        return cls._parsers.get(parser_id)
+
+    @classmethod
+    def list_parsers(cls) -> List[str]:
+        """
+        List all registered parser IDs.
+
+        Returns:
+            List of parser IDs
+        """
+        return list(cls._parsers.keys())
 
 
 def extract_loc_definitions(ir_content: str) -> Dict[str, Dict[str, Any]]:
@@ -486,3 +544,193 @@ def extract_ptx_amdgcn_mappings(
             logger.error(f"Line content: {line}")
             raise e
     return mappings
+
+
+# =============================================================================
+# PARSER WRAPPER FUNCTIONS
+# =============================================================================
+# These wrapper functions serve two purposes:
+# 1. Unify the parser signatures to match the (content, mappings, ir_type) interface
+# 2. Preserve the original logic from generate_source_mappings (which combined
+#    extract_loc_definitions + extract_code_locations for generic IR types)
+#
+# Note: We use wrappers instead of modifying existing function signatures to
+# maintain backward compatibility with other code that may call these functions.
+# =============================================================================
+
+
+def _parse_generic_loc(
+    ir_content: str,
+    other_mappings: Optional[List[Any]] = None,
+    ir_type: Optional[str] = None,
+) -> Dict[str, Dict[str, Any]]:
+    """
+    Parser for generic IR formats (TTIR/TTGIR/LLIR) with #loc directives.
+
+    This combines extract_loc_definitions + extract_code_locations to preserve
+    the original generate_source_mappings behavior for these IR types.
+
+    Args:
+        ir_content: The IR content
+        other_mappings: Other mappings (not used for generic_loc)
+        ir_type: The IR type (e.g., "ttir", "ttgir", "llir")
+
+    Returns:
+        Dictionary mapping line numbers to source locations
+    """
+
+    loc_defs = extract_loc_definitions(ir_content)
+    logger.debug(f"Found {len(loc_defs)} #loc definitions")
+
+    loc_refs = extract_code_locations(ir_content)
+    logger.debug(f"Found {len(loc_refs)} loc references")
+
+    mappings: Dict[str, Dict[str, Any]] = {}
+    for ln, loc_id in loc_refs.items():
+        if loc_id.startswith("direct:"):
+            _, file_path, line, col = loc_id.split(":", 3)
+            mappings[str(ln)] = {
+                "file": file_path,
+                "line": int(line),
+                "column": int(col),
+                f"{ir_type}_line": ln,
+            }
+        elif loc_id in loc_defs:
+            info = loc_defs[loc_id]
+            entry = {
+                "file": info["file"],
+                "line": info["line"],
+                "column": info["column"],
+                f"{ir_type}_line": ln,
+            }
+            # Propagate callsite metadata if present
+            if info.get("is_callsite"):
+                entry["is_callsite"] = True
+                entry["callsite_callee"] = info["callsite_callee"]
+                entry["callsite_caller"] = info["callsite_caller"]
+            # Propagate alias metadata if present
+            if "alias_name" in info:
+                entry["alias_name"] = info["alias_name"]
+            if "alias_of" in info:
+                entry["loc_id"] = loc_id
+            mappings[str(ln)] = entry
+
+    # Add separate entries for loc definition lines
+    for loc_id, info in loc_defs.items():
+        if "def_line" not in info:
+            continue
+        def_ln = info["def_line"]
+        # Only create mapping if this line doesn't already have one
+        if str(def_ln) not in mappings:
+            entry = {
+                "file": info["file"],
+                "line": info["line"],
+                "column": info["column"],
+                f"{ir_type}_line": def_ln,
+                "kind": "loc_def",
+            }
+            if "alias_name" in info:
+                entry["alias_name"] = info["alias_name"]
+            if "alias_of" in info:
+                entry["loc_id"] = loc_id
+            mappings[str(def_ln)] = entry
+
+    return mappings
+
+
+def _parse_ptx_loc(
+    ir_content: str,
+    other_mappings: Optional[List[Any]] = None,
+    ir_type: Optional[str] = None,
+) -> Dict[str, Dict[str, Any]]:
+    """
+    Parser for PTX IR format.
+
+    Args:
+        ir_content: The PTX content
+        other_mappings: Other mappings for file path resolution (from TTIR/TTGIR)
+        ir_type: The IR type (not used, kept for signature consistency)
+
+    Returns:
+        Dictionary mapping line numbers to source locations
+    """
+    return extract_ptx_amdgcn_mappings(ir_content, other_mappings, "ptx")
+
+
+def _parse_amdgcn_loc(
+    ir_content: str,
+    other_mappings: Optional[List[Any]] = None,
+    ir_type: Optional[str] = None,
+) -> Dict[str, Dict[str, Any]]:
+    """
+    Parser for AMDGCN assembly format.
+
+    Args:
+        ir_content: The AMDGCN content
+        other_mappings: Other mappings for file path resolution (from TTIR/TTGIR)
+        ir_type: The IR type (not used, kept for signature consistency)
+
+    Returns:
+        Dictionary mapping line numbers to source locations
+    """
+    return extract_ptx_amdgcn_mappings(ir_content, other_mappings, "amdgcn")
+
+
+def _parse_sass_loc(
+    ir_content: str,
+    other_mappings: Optional[List[Any]] = None,
+    ir_type: Optional[str] = None,
+) -> Dict[str, Dict[str, Any]]:
+    """
+    Parser for NVIDIA SASS assembly format.
+
+    Args:
+        ir_content: The SASS content
+        other_mappings: Other mappings (not used for SASS, kept for signature consistency)
+        ir_type: The IR type (not used, kept for signature consistency)
+
+    Returns:
+        Dictionary mapping line numbers to source locations
+    """
+    return extract_sass_mappings(ir_content)
+
+
+def _parse_none(
+    ir_content: str,
+    other_mappings: Optional[List[Any]] = None,
+    ir_type: Optional[str] = None,
+) -> Dict[str, Dict[str, Any]]:
+    """
+    Placeholder parser for stages that don't support source mapping (e.g., CUBIN).
+
+    Args:
+        ir_content: The content (not used)
+        other_mappings: Other mappings (not used)
+        ir_type: The IR type (not used)
+
+    Returns:
+        Empty dictionary
+    """
+    return {}
+
+
+# =============================================================================
+# REGISTER COMMON PARSERS
+# =============================================================================
+def _initialize_common_parsers() -> None:
+    """
+    Register common parsers that are shared across all backends.
+
+    Common parsers are those that work across all backends (e.g., TTIR/TTGIR/LLIR
+    which use generic #loc directives).
+
+    Backend-specific parsers (PTX, SASS, AMDGCN) are registered by their
+    respective adapters.
+    """
+    ParserRegistry.register("generic_loc", _parse_generic_loc)
+    ParserRegistry.register("none", _parse_none)
+    logger.debug("Common parsers registered successfully")
+
+
+# Initialize parsers at module import time
+_initialize_common_parsers()

--- a/tritonparse/parse/ir_parser.py
+++ b/tritonparse/parse/ir_parser.py
@@ -85,8 +85,8 @@ class ParserRegistry:
             parser_id: The parser identifier (e.g., "generic_loc", "ptx_loc")
             parser_func: The parser function
 
-        Raises:
-            ValueError: If parser_id is already registered
+        If parser_id is already registered, the existing parser is overwritten
+        and a warning is logged.
         """
         if parser_id in cls._parsers:
             logger.warning(

--- a/tritonparse/parse/trace_processor.py
+++ b/tritonparse/parse/trace_processor.py
@@ -15,8 +15,7 @@ from tritonparse.tp_logger import get_logger
 from .event_diff import _generate_autotune_analysis_events, _generate_launch_diff
 from .ir_analysis import _generate_ir_analysis
 from .ir_parser import (
-    extract_code_locations,
-    extract_loc_definitions,
+    _parse_generic_loc,
     extract_ptx_amdgcn_mappings,
 )
 from .mapper import create_bidirectional_mapping, create_python_mapping
@@ -209,8 +208,9 @@ def generate_source_mappings(
     if other_mappings is None:
         other_mappings = []
 
-    # Try to use adapter-based parser if metadata is available
-    if metadata is not None:
+    # Only enter adapter-driven resolution when trace metadata can identify a backend.
+    if metadata is not None and isinstance(metadata.get("backend_name"), str):
+        parser = None
         try:
             from tritonparse.backend import get_backend_registry
 
@@ -222,15 +222,16 @@ def generate_source_mappings(
             if stage_descriptor is not None and stage_descriptor.parser_id != "none":
                 parser_id = stage_descriptor.parser_id
                 parser = adapter.get_parser(parser_id)
-
-                # Call the parser with standardized signature
-                return parser(ir_content, other_mappings, ir_type)
-        except Exception as e:
+        except ValueError as e:
             # Fallback to old hardcoded logic if adapter resolution fails
             logger.debug(
                 f"Adapter-based parser resolution failed for ir_type={ir_type}: {e}. "
                 f"Falling back to hardcoded parser selection."
             )
+
+        if parser is not None:
+            # Parser execution errors should surface rather than silently falling back.
+            return parser(ir_content, other_mappings, ir_type)
 
     # Fallback: hardcoded parser selection (for backward compatibility)
     if ir_type == "ptx" or ir_type == "amdgcn":
@@ -240,63 +241,7 @@ def generate_source_mappings(
 
         return extract_sass_mappings(ir_content)
 
-    loc_defs = extract_loc_definitions(ir_content)
-    logger.debug(f"Found {len(loc_defs)} #loc definitions")
-
-    loc_refs = extract_code_locations(ir_content)
-    logger.debug(f"Found {len(loc_refs)} loc references")
-
-    mappings = {}
-    for ln, loc_id in loc_refs.items():
-        if loc_id.startswith("direct:"):
-            _, file_path, line, col = loc_id.split(":", 3)
-            mappings[str(ln)] = {
-                "file": file_path,
-                "line": int(line),
-                "column": int(col),
-                f"{ir_type}_line": ln,
-            }
-        elif loc_id in loc_defs:
-            info = loc_defs[loc_id]
-            entry = {
-                "file": info["file"],
-                "line": info["line"],
-                "column": info["column"],
-                f"{ir_type}_line": ln,
-            }
-            # Propagate callsite metadata if present
-            if info.get("is_callsite"):
-                entry["is_callsite"] = True
-                entry["callsite_callee"] = info["callsite_callee"]
-                entry["callsite_caller"] = info["callsite_caller"]
-            # Propagate alias metadata if present
-            if "alias_name" in info:
-                entry["alias_name"] = info["alias_name"]
-            if "alias_of" in info:
-                entry["loc_id"] = loc_id
-            mappings[str(ln)] = entry
-
-    # Add separate entries for loc definition lines
-    for loc_id, info in loc_defs.items():
-        if "def_line" not in info:
-            continue
-        def_ln = info["def_line"]
-        # Only create mapping if this line doesn't already have one
-        if str(def_ln) not in mappings:
-            entry = {
-                "file": info["file"],
-                "line": info["line"],
-                "column": info["column"],
-                f"{ir_type}_line": def_ln,
-                "kind": "loc_def",
-            }
-            if "alias_name" in info:
-                entry["alias_name"] = info["alias_name"]
-            if "alias_of" in info:
-                entry["loc_id"] = loc_id
-            mappings[str(def_ln)] = entry
-
-    return mappings
+    return _parse_generic_loc(ir_content, other_mappings, ir_type)
 
 
 def _resolve_source_mappable_stage_keys(

--- a/tritonparse/parse/trace_processor.py
+++ b/tritonparse/parse/trace_processor.py
@@ -176,7 +176,10 @@ def get_procedure_checks() -> List[Dict[str, Any]]:
 
 
 def generate_source_mappings(
-    ir_content: str, ir_type: str, other_mappings: List[Any] | None = None
+    ir_content: str,
+    ir_type: str,
+    other_mappings: List[Any] | None = None,
+    metadata: Dict[str, Any] | None = None,
 ) -> Dict[str, Dict[str, Any]]:
     """
     Generate source mappings from intermediate representation (IR) content to the source file.
@@ -197,6 +200,7 @@ def generate_source_mappings(
         ir_content (str): The content of the intermediate representation.
         ir_type (str): The type of the intermediate representation (e.g., 'ttir').
         other_mappings (List[Any]): A collection of additional mappings, primarily utilized for PTX mappings since PTX's location annotations reference the file name instead of the complete path.
+        metadata (Dict[str, Any]): Optional metadata for resolving backend-specific parsers.
 
     Returns:
         Dict[str, Dict[str, Any]]: A dictionary mapping line numbers to their corresponding source file,
@@ -204,6 +208,31 @@ def generate_source_mappings(
     """
     if other_mappings is None:
         other_mappings = []
+
+    # Try to use adapter-based parser if metadata is available
+    if metadata is not None:
+        try:
+            from tritonparse.backend import get_backend_registry
+
+            registry = get_backend_registry()
+            adapter = registry.resolve_from_trace(metadata)
+
+            # Find the stage descriptor for this ir_type
+            stage_descriptor = adapter.classify_artifact(f"kernel.{ir_type}")
+            if stage_descriptor is not None and stage_descriptor.parser_id != "none":
+                parser_id = stage_descriptor.parser_id
+                parser = adapter.get_parser(parser_id)
+
+                # Call the parser with standardized signature
+                return parser(ir_content, other_mappings, ir_type)
+        except Exception as e:
+            # Fallback to old hardcoded logic if adapter resolution fails
+            logger.debug(
+                f"Adapter-based parser resolution failed for ir_type={ir_type}: {e}. "
+                f"Falling back to hardcoded parser selection."
+            )
+
+    # Fallback: hardcoded parser selection (for backward compatibility)
     if ir_type == "ptx" or ir_type == "amdgcn":
         return extract_ptx_amdgcn_mappings(ir_content, other_mappings, ir_type)
     elif ir_type == "sass":
@@ -364,11 +393,13 @@ def process_ir(
     file_content: Dict[str, str],
     file_path: Dict[str, str],
     other_mappings: List[Any] | None = None,
+    metadata: Dict[str, Any] | None = None,
 ):
     ir_content = load_ir_contents(key, file_content, file_path)
     if not ir_content:
         return {}
-    mapping = generate_source_mappings(ir_content, key.split(".")[1], other_mappings)
+    ir_type = key.split(".")[1]
+    mapping = generate_source_mappings(ir_content, ir_type, other_mappings, metadata)
     logger.debug(f"Generated source mapping for {key}")
     return mapping
 
@@ -540,6 +571,7 @@ def parse_single_trace_content(trace_content: str) -> str:
                 file_content,
                 file_path,
                 other_mappings if other_mappings else None,
+                metadata,
             )
             if stage_map:
                 stage_maps[stage_name] = stage_map

--- a/tritonparse/parse/trace_processor.py
+++ b/tritonparse/parse/trace_processor.py
@@ -14,10 +14,7 @@ from tritonparse.tp_logger import get_logger
 
 from .event_diff import _generate_autotune_analysis_events, _generate_launch_diff
 from .ir_analysis import _generate_ir_analysis
-from .ir_parser import (
-    _parse_generic_loc,
-    extract_ptx_amdgcn_mappings,
-)
+from .ir_parser import _parse_generic_loc, extract_ptx_amdgcn_mappings
 from .mapper import create_bidirectional_mapping, create_python_mapping
 from .sourcemap_utils import (
     _is_autotune_benchmark_launch,
@@ -217,8 +214,8 @@ def generate_source_mappings(
             registry = get_backend_registry()
             adapter = registry.resolve_from_trace(metadata)
 
-            # Find the stage descriptor for this ir_type
-            stage_descriptor = adapter.classify_artifact(f"kernel.{ir_type}")
+            # Resolve the stage descriptor directly by stage name.
+            stage_descriptor = adapter.get_stage_by_name(ir_type)
             if stage_descriptor is not None and stage_descriptor.parser_id != "none":
                 parser_id = stage_descriptor.parser_id
                 parser = adapter.get_parser(parser_id)


### PR DESCRIPTION
## Context

- **RFC**: https://github.com/meta-pytorch/tritonparse/issues/367
- **Previous PR**: https://github.com/meta-pytorch/tritonparse/pull/387 (Reader-side Infrastructure and Generic Parsing Flow Refactoring)

## Summary

This is the **second PR in Flexible Backend Support RFC Phase 1** (Phase 1 is split into 3 PRs).

**What this PR does**: Refactor the hardcoded parser selection logic in `generate_source_mappings()` into an adapter-driven parser registration and selection mechanism. This enables layered parser registration (common parsers + backend-specific parsers) and dynamic parser dispatch.

---

## Core Changes

### 1. Parser Registry (`tritonparse/parse/ir_parser.py` - New)

**New ParserRegistry class**:

```python
class ParserRegistry:
    """
    Registry for managing IR parser functions.
    
    Allows adapters to register and retrieve parser functions by parser_id.
    Supports both common parsers (shared across backends) and backend-specific parsers.
    """

    @classmethod
    def register(cls, parser_id: str, parser_func: Callable) -> None: ...

    @classmethod
    def get_parser(cls, parser_id: str) -> Optional[Callable]: ...

    @classmethod
    def list_parsers(cls) -> List[str]: ...
```

**Key design**:
- **Layered registration**:
  - Common parsers (`generic_loc`, `none`) pre-registered at module initialization
  - Backend-specific parsers (`ptx_loc`, `sass_loc`, `amdgcn_loc`) registered by respective adapters during initialization
- **Unified interface**: All parsers follow the same signature `(ir_content, other_mappings, ir_type) -> Dict`

### 2. Parser Wrapper Functions (`tritonparse/parse/ir_parser.py` - New)

**5 standardized parser functions**:

```python
def _parse_generic_loc(ir_content, other_mappings, ir_type):
    """Common IR format parser (TTIR/TTGIR/LLIR)"""

def _parse_ptx_loc(ir_content, other_mappings, ir_type):
    """PTX IR format parser"""

def _parse_amdgcn_loc(ir_content, other_mappings, ir_type):
    """AMDGCN assembly format parser"""

def _parse_sass_loc(ir_content, other_mappings, ir_type):
    """NVIDIA SASS assembly format parser"""

def _parse_none(ir_content, other_mappings, ir_type):
    """Placeholder parser for stages without source mapping (e.g., CUBIN)"""
```

**Design points**:
- **Preserve existing logic**: Wrappers call existing functions like `extract_loc_definitions`, `extract_ptx_amdgcn_mappings`
- **Unified signature**: All parsers follow `(ir_content, other_mappings, ir_type) -> Dict` interface
- **Backward compatible**: Don't break existing function calls, unify at registry level

### 3. Adapter Extension (`tritonparse/backend.py` - Refactor)

**New CompilationPipelineAdapter methods**:

```python
class CompilationPipelineAdapter(ABC):
    def get_parser(self, parser_id: str):
        """
        Get parser function by parser_id from the parser registry.
        
        Generic implementation that works for most backends.
        Subclasses can override if needed.
        
        Raises:
            ValueError: If parser_id is not found in registry
        """

    def register_backend_parser(self, parser_id: str, parser_func) -> None:
        """
        Register a backend-specific parser to the parser registry.
        
        Allows adapters to register custom parsers for backend-specific
        IR formats not in the common parser registry.
        """
```

**Adapter implementation**:

```python
class NvidiaTritonAdapter(CompilationPipelineAdapter):
    def __init__(self):
        """Initialize and register backend-specific parsers."""
        # Register NVIDIA-specific parsers
        self.register_backend_parser("ptx_loc", _parse_ptx_loc)
        self.register_backend_parser("sass_loc", _parse_sass_loc)
        
        # Pre-initialize stage descriptors (immutable objects, reusable)
        self._stages = [
            IRStageDescriptor("ttir", ".ttir", "TTIR", 10, True, True, "generic_loc", "mlir"),
            IRStageDescriptor("ttgir", ".ttgir", "TTGIR", 20, True, True, "generic_loc", "mlir"),
            IRStageDescriptor("llir", ".llir", "LLIR", 30, True, True, "generic_loc", "llvm"),
            IRStageDescriptor("ptx", ".ptx", "PTX", 40, True, True, "ptx_loc", "ptx"),
            IRStageDescriptor("cubin", ".cubin", "CUBIN", 50, False, False, "none", "plaintext"),
            IRStageDescriptor("sass", ".sass", "SASS", 60, True, True, "sass_loc", "asm"),
            IRStageDescriptor("json", ".json", "JSON", 100, True, False, "none", "json"),
        ]
```

**Key improvements**:
- **Adapter as parser registration entry point**: Each adapter registers its backend-specific parsers
- **Decoupled stage descriptors from parsers**: `parser_id` field specifies which parser to use
- **Object reuse optimization**: `_stages` pre-initialized in `__init__`, `get_ir_stages()` returns cached instance

### 4. generate_source_mappings Refactor (`tritonparse/parse/trace_processor.py` - Refactor)

**Before (hardcoded parser selection)**:

```python
def generate_source_mappings(ir_content, ir_type, other_mappings):
    # Hardcoded parser selection
    if ir_type == "ptx" or ir_type == "amdgcn":
        return extract_ptx_amdgcn_mappings(ir_content, other_mappings, ir_type)
    elif ir_type == "sass":
        return extract_sass_mappings(ir_content)
    else:
        # TTIR/TTGIR/LLIR: complex hardcoded logic
        loc_defs = extract_loc_definitions(ir_content)
        loc_refs = extract_code_locations(ir_content)
        # ... manual mapping construction
```

**After (adapter-driven parser selection)**:

```python
def generate_source_mappings(ir_content, ir_type, other_mappings, metadata=None):
    # Step 1: Try adapter-based parser selection (new path)
    if metadata is not None:
        try:
            from tritonparse.backend import get_backend_registry
            
            registry = get_backend_registry()
            adapter = registry.resolve_from_trace(metadata)
            
            # Find stage descriptor for this ir_type
            stage_descriptor = adapter.classify_artifact(f"kernel.{ir_type}")
            if stage_descriptor is not None and stage_descriptor.parser_id != "none":
                parser_id = stage_descriptor.parser_id
                parser = adapter.get_parser(parser_id)
                
                # Call parser with standardized signature
                return parser(ir_content, other_mappings, ir_type)
        except Exception as e:
            # Fallback to old hardcoded logic if adapter resolution fails
            logger.debug(f"Adapter-based parser resolution failed for ir_type={ir_type}: {e}. "
                        f"Falling back to hardcoded parser selection.")
    
    # Step 2: Fallback to hardcoded parser selection (backward compatibility)
    if ir_type == "ptx" or ir_type == "amdgcn":
        return extract_ptx_amdgcn_mappings(ir_content, other_mappings, ir_type)
    elif ir_type == "sass":
        return extract_sass_mappings(ir_content)
    else:
        # ... original hardcoded logic for TTIR/TTGIR/LLIR
```

**Key improvements**:
- **Two-level dispatch mechanism**:
  1. Priority: Adapter-driven parser selection (from stage descriptor's parser_id)
  2. Fallback: Hardcoded parser selection (backward compatibility)
- **Metadata-driven**: New traces trigger adapter-based parser selection via `metadata`
- **Backward compatible**: Old traces (without metadata) continue using hardcoded logic

### 5. process_ir Signature Extension (`tritonparse/parse/trace_processor.py` - Refactor)

```python
def process_ir(
    key: str,
    file_content: Dict[str, str],
    file_path: Dict[str, str],
    other_mappings: List[Any] | None = None,
    metadata: Dict[str, Any] | None = None,  # ← New parameter
):
    ir_content = load_ir_contents(key, file_content, file_path)
    if not ir_content:
        return {}
    ir_type = key.split(".")[1]
    mapping = generate_source_mappings(ir_content, ir_type, other_mappings, metadata)
    return mapping
```

**Data flow**: `metadata` → `process_ir()` → `generate_source_mappings()`

---

## Architecture Improvements

### Parser Dispatch Flow Comparison

```mermaid
flowchart LR
    subgraph Before ["Before (Hardcoded)"]
        A1[generate_source_mappings<br/>ir_type=ptx] --> B1[Hardcoded if-elif check]
        B1 --> C1[Directly call<br/>extract_ptx_amdgcn_mappings]
    end

    subgraph After ["After (Adapter-Driven)"]
        A2[generate_source_mappings<br/>ir_type=ptx, metadata] --> B2[get_backend_registry]
        B2 --> C2[resolve_from_trace<br/>→ NvidiaTritonAdapter]
        C2 --> D2[adapter.classify_artifact<br/>→ IRStageDescriptor<br/>parser_id=ptx_loc]
        D2 --> E2[adapter.get_parser<br/>→ _parse_ptx_loc function]
        E2 --> F2[parser ir_content<br/>other_mappings ir_type]
    end

    style After fill:#e1f5e1,stroke:#4caf50,stroke-width:2px
    style Before fill:#ffe1e1,stroke:#f44336,stroke-width:2px
```

**Key improvements**:
- ✅ **Dynamic dispatch**: Parser selection driven by adapter + stage descriptor
- ✅ **Extensible**: Add new parsers by registering in adapter.__init__
- ✅ **Decoupled**: Parser logic in `ir_parser.py`, adapters only handle registration
- ✅ **Backward compatible**: Fallback strategy ensures old traces still work

---

## Testing

### Compatibility Testing
Verified that the current parse path works for both new and old traces. Built the trace adaptation logic and generated new trace files for validation. Both new and old traces can be parsed correctly.

- old trace
<img width="1276" height="377" alt="image" src="https://github.com/user-attachments/assets/7686cf91-62e9-4044-ae23-6eee4a4aade7" />

- new trace
<img width="1279" height="340" alt="image" src="https://github.com/user-attachments/assets/48d65bcd-db24-46e3-a803-668ab6b7765c" />

### Format Checking
The result of `make format-check`:
<img width="1173" height="304" alt="image" src="https://github.com/user-attachments/assets/81eb7e60-e8ac-4da2-9e59-effeaf513d66" />


### Functional Testing
The result of `make test-cuda`:
<img width="1381" height="471" alt="image" src="https://github.com/user-attachments/assets/90313cbc-b800-44eb-8c57-48559eaa14d8" />


The result of `make test`:
<img width="1380" height="478" alt="image" src="https://github.com/user-attachments/assets/0c4de49d-852b-45bf-a54d-cd164e81db65" />


### Multi-Backend Testing
The parse function also works properly in the Ascend backend.
<img width="1341" height="360" alt="image" src="https://github.com/user-attachments/assets/e44b1691-23d8-4a03-8a07-45654e761b2c" />

---

## Summary

This PR completes **Parser Distribution System Refactoring** for Flexible Backend Support RFC Phase 1, refactoring hardcoded parser selection into an adapter-driven dynamic dispatch mechanism.

**Core implementation**: Added `ParserRegistry` for unified parser management and query; implemented layered registration for common parsers and backend-specific parsers; provided 5 standardized parser wrapper functions for IR formats (TTIR/TTGIR/LLIR, PTX, AMDGCN, SASS, CUBIN); extended `CompilationPipelineAdapter` with `get_parser()` and `register_backend_parser()` methods, where adapters register backend-specific parsers during initialization; refactored `generate_source_mappings()` to implement two-level dispatch (priority: adapter-driven, fallback: hardcoded) ensuring full compatibility with both new and old traces.

**Key improvements**:
- **Layered registration**: Common parsers pre-registered, backend parsers lazy-registered
- **Unified interface**: All parsers follow same signature for easy dispatch
- **Fallback strategy**: Compatible with both new and old traces
- **Object reuse**: `get_ir_stages()` returns pre-initialized object, avoids repeated instantiation

---

## RFC Phase 1 Status & Next Steps

### ✅ PR 1 (Completed): Reader-side Infrastructure and Generic Parsing Flow Refactor
- Adapter infrastructure + generic parse scheduling refactor in `trace_processor.py`
- Added `tritonparse/backend.py`: IRStageDescriptor, CompilationPipelineAdapter, NvidiaTritonAdapter, AmdTritonAdapter, PipelineAdapterRegistry
- Refactored `trace_processor.py`: dynamic stage discovery (with fallback), dynamic stage processing loop, dynamic mapping construction

### ✅ PR 2 (This PR): Parser Distribution System Refactoring
- ParserRegistry infrastructure + 5 standardized parser wrapper functions
- Adapter extension: `get_parser()`, `register_backend_parser()`
- Refactored `generate_source_mappings()`: adapter-driven + hardcoded fallback
- Comprehensive test coverage

### 🔜 PR 3: Analysis and Reproducer
- Migration of `ir_analysis.py` and `reproducer/` modules to adapter architecture
