### PR TITLE
ci: migrate GPU tests to PyTorch self-hosted A10G runner (CUDA 13.0, Python 3.14) + Py 3.14 compatibility fixes

### DIFF
--- a/.ci/README.md
+++ b/.ci/README.md
@@ -26,10 +26,11 @@ CONDA_ENV=tritonparse PYTHON_VERSION=3.11 bash .ci/setup.sh
 ### `install-triton.sh`
 Installs Triton from source by cloning the repository and building it.
 
-> **Note:** As of the migration to NVIDIA's Triton-Nightly wheel feed,
-> the CI workflow no longer invokes this script. It is kept for local
-> development and for cases where you want to test against a specific
-> upstream Triton commit (set `TRITON_COMMIT=<sha>` before invoking).
+> **Note:** As of the migration to the upstream Triton team's
+> Triton-Nightly wheel feed, the CI workflow no longer invokes this
+> script. It is kept for local development and for cases where you
+> want to test against a specific upstream Triton commit (set
+> `TRITON_COMMIT=<sha>` before invoking).
 
 **Environment Variables:**
 - `CONDA_ENV`: Conda environment name (required)

--- a/.ci/README.md
+++ b/.ci/README.md
@@ -9,7 +9,7 @@ Sets up the conda environment, installs dependencies, configures CUDA, and insta
 
 **Environment Variables:**
 - `CONDA_ENV`: Conda environment name (default: "tritonparse")
-- `PYTHON_VERSION`: Python version (default: "3.11")
+- `PYTHON_VERSION`: Python version (default: "3.14")
 - `CUDA_VERSION`: CUDA version (default: "12.8")
 - `CUDNN_VERSION`: cuDNN version (default: "9.10.2.21")
 

--- a/.ci/README.md
+++ b/.ci/README.md
@@ -26,8 +26,14 @@ CONDA_ENV=tritonparse PYTHON_VERSION=3.11 bash .ci/setup.sh
 ### `install-triton.sh`
 Installs Triton from source by cloning the repository and building it.
 
+> **Note:** As of the migration to NVIDIA's Triton-Nightly wheel feed,
+> the CI workflow no longer invokes this script. It is kept for local
+> development and for cases where you want to test against a specific
+> upstream Triton commit (set `TRITON_COMMIT=<sha>` before invoking).
+
 **Environment Variables:**
 - `CONDA_ENV`: Conda environment name (required)
+- `TRITON_COMMIT`: Optional commit SHA or branch (default: "main")
 
 **Usage:**
 ```bash

--- a/.ci/install-project.sh
+++ b/.ci/install-project.sh
@@ -14,8 +14,19 @@ if [ -z "$CONDA_ENV" ]; then
     exit 1
 fi
 
-# Activate conda environment
-source /opt/miniconda3/etc/profile.d/conda.sh
+# Activate conda environment.
+# Locate conda installation: prefer existing $CONDA_HOME, else discover
+# via 'conda info --base' if conda is in PATH, else fall back to the
+# legacy /opt/miniconda3 path used by .ci/setup.sh on GitHub-hosted
+# runners.
+if [ -z "${CONDA_HOME:-}" ]; then
+    if command -v conda >/dev/null 2>&1; then
+        CONDA_HOME="$(conda info --base)"
+    else
+        CONDA_HOME="/opt/miniconda3"
+    fi
+fi
+source "${CONDA_HOME}/etc/profile.d/conda.sh"
 conda activate "$CONDA_ENV"
 
 # Upgrade pip

--- a/.ci/install-triton.sh
+++ b/.ci/install-triton.sh
@@ -40,8 +40,19 @@ if [ -z "$CONDA_ENV" ]; then
     exit 1
 fi
 
-# Activate conda environment
-source /opt/miniconda3/etc/profile.d/conda.sh
+# Activate conda environment.
+# Locate conda installation: prefer existing $CONDA_HOME, else discover
+# via 'conda info --base' if conda is in PATH, else fall back to the
+# legacy /opt/miniconda3 path used by .ci/setup.sh on GitHub-hosted
+# runners.
+if [ -z "${CONDA_HOME:-}" ]; then
+    if command -v conda >/dev/null 2>&1; then
+        CONDA_HOME="$(conda info --base)"
+    else
+        CONDA_HOME="/opt/miniconda3"
+    fi
+fi
+source "${CONDA_HOME}/etc/profile.d/conda.sh"
 conda activate "$CONDA_ENV"
 
 # Create cache directory

--- a/.ci/install-triton.sh
+++ b/.ci/install-triton.sh
@@ -140,12 +140,22 @@ pip install ninja cmake wheel pybind11
 echo "Installing Triton requirements..."
 pip install -r python/requirements.txt
 
-# Set environment to use clang compiler for faster compilation
-echo "Setting up clang compiler for faster compilation..."
-export CC=clang
-export CXX=clang++
-echo "Using CC: $CC"
-echo "Using CXX: $CXX"
+# Set environment to use clang compiler for faster compilation IF available.
+# In the GitHub-hosted Ubuntu CI path, .ci/setup.sh apt-installs clang-19;
+# in the container CI path (pytorch/almalinux-builder:cuda13.0) only gcc
+# (gcc-toolset-13) is preinstalled, so we fall back to gcc to let CMake
+# auto-detect rather than failing with "Could not find compiler clang++".
+# Local development on a workstation without clang also benefits from
+# this fallback.
+if command -v clang &>/dev/null && command -v clang++ &>/dev/null; then
+    echo "Setting up clang compiler for faster compilation..."
+    export CC=clang
+    export CXX=clang++
+else
+    echo "clang/clang++ not found; using default compiler (gcc)..."
+fi
+echo "Using CC: ${CC:-<default>}"
+echo "Using CXX: ${CXX:-<default>}"
 
 # Install Triton in editable mode with clang
 if [ "$USE_CACHED_SOURCE" = "true" ]; then

--- a/.ci/install-triton.sh
+++ b/.ci/install-triton.sh
@@ -81,14 +81,17 @@ fi
 
 # Update libstdc++ to match system version
 # Otherwise, we get errors like:
-# ImportError: /opt/miniconda3/envs/tritonparse/bin/../lib/libstdc++.so.6:
+# ImportError: <conda_env>/bin/../lib/libstdc++.so.6:
 # version `GLIBCXX_3.4.30' not found (required by /tmp/triton/python/triton/_C/libtriton.so)
 echo "Updating libstdc++ to match system version..."
 # Use the latest version for Ubuntu 22.04 that includes GLIBCXX_3.4.32
 conda install -y -c conda-forge libstdcxx-ng=15.1.0
 # Check if the update was successful
 echo "Checking libstdc++ version after update:"
-strings /opt/miniconda3/envs/tritonparse/lib/libstdc++.so.6 | grep GLIBCXX | tail -10
+# Use $CONDA_PREFIX (set by 'conda activate') so this works regardless of
+# whether conda is at /opt/miniconda3 (legacy setup.sh path) or /opt/conda
+# (container path) or anywhere else.
+strings "${CONDA_PREFIX}/lib/libstdc++.so.6" | grep GLIBCXX | tail -10
 
 # Uninstall existing pytorch-triton
 echo "Uninstalling existing pytorch-triton..."

--- a/.ci/run-tests.sh
+++ b/.ci/run-tests.sh
@@ -26,8 +26,19 @@ if [ -z "$CONDA_ENV" ]; then
     exit 1
 fi
 
-# Activate conda environment
-source /opt/miniconda3/etc/profile.d/conda.sh
+# Activate conda environment.
+# Locate conda installation: prefer existing $CONDA_HOME, else discover
+# via 'conda info --base' if conda is in PATH, else fall back to the
+# legacy /opt/miniconda3 path used by .ci/setup.sh on GitHub-hosted
+# runners.
+if [ -z "${CONDA_HOME:-}" ]; then
+    if command -v conda >/dev/null 2>&1; then
+        CONDA_HOME="$(conda info --base)"
+    else
+        CONDA_HOME="/opt/miniconda3"
+    fi
+fi
+source "${CONDA_HOME}/etc/profile.d/conda.sh"
 conda activate "$CONDA_ENV"
 
 # Set environment variables

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -8,7 +8,7 @@ set -e
 
 # Default values
 CONDA_ENV=${CONDA_ENV:-"tritonparse"}
-PYTHON_VERSION=${PYTHON_VERSION:-"3.13"}
+PYTHON_VERSION=${PYTHON_VERSION:-"3.14"}
 CUDA_VERSION=${CUDA_VERSION:-"12.8"}
 
 echo "Setting up tritonparse environment..."

--- a/.github/workflows/nightly-pypi.yml
+++ b/.github/workflows/nightly-pypi.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Check for new commits since last nightly
         id: check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,9 +118,10 @@ jobs:
             - name: Cache pip dependencies
               uses: actions/cache@v5
               with:
-                  # Container runs as root, so pip's user cache lives at
-                  # /root/.cache/pip rather than the host's ~/.cache/pip.
-                  path: /root/.cache/pip
+                  # GitHub Actions sets HOME=/github/home in container jobs,
+                  # so pip's default cache directory ($HOME/.cache/pip per
+                  # XDG) is /github/home/.cache/pip — NOT /root/.cache/pip.
+                  path: /github/home/.cache/pip
                   key: ${{ runner.os }}-pip-${{ env.PYTORCH_CUDA_TAG }}-py${{ env.PYTHON_VERSION }}-${{ steps.daily-cache.outputs.date }}
                   restore-keys: |
                       ${{ runner.os }}-pip-${{ env.PYTORCH_CUDA_TAG }}-py${{ env.PYTHON_VERSION }}-
@@ -217,7 +218,9 @@ jobs:
             - name: Cache pip dependencies
               uses: actions/cache@v5
               with:
-                  path: /root/.cache/pip
+                  # See test-from-source for the rationale (HOME=/github/home
+                  # in container jobs, pip cache lives there).
+                  path: /github/home/.cache/pip
                   key: ${{ runner.os }}-pip-${{ env.PYTORCH_CUDA_TAG }}-py${{ env.PYTHON_VERSION }}-${{ steps.daily-cache.outputs.date }}
                   restore-keys: |
                       ${{ runner.os }}-pip-${{ env.PYTORCH_CUDA_TAG }}-py${{ env.PYTHON_VERSION }}-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,6 +97,16 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
+            - name: Mark workspace as safe for git
+              # actions/checkout sets safe.directory in a *temporary* HOME
+              # that is discarded after the step. Subsequent git invocations
+              # (e.g. setuptools-scm during 'pip install -e .') see the
+              # workspace as ec2-user-owned (uid 1000) while the container
+              # runs as root (uid 0), and refuse with 'dubious ownership'.
+              # Persist the safe.directory in /github/home/.gitconfig so all
+              # later steps inherit it.
+              run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
             - name: Get daily cache timestamp
               id: daily-cache
               run: |
@@ -191,6 +201,11 @@ jobs:
             PYTORCH_CUDA_TAG: cu130
         steps:
             - uses: actions/checkout@v6
+
+            - name: Mark workspace as safe for git
+              # See test-from-source for the rationale (setuptools-scm needs
+              # git introspection during 'pip install -e .').
+              run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
             - name: Get daily cache timestamp
               id: daily-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,18 +82,23 @@ jobs:
     # cuda>=13.2"). Bump once PyTorch infra rolls out a newer driver
     # AMI. Probed on 2026-04-29.
     # ===================================================================
-    test-from-source:
+    test-from-nightly:
         runs-on: linux.g5.4xlarge.nvidia.gpu
         container:
             image: pytorch/almalinux-builder:cuda13.0
             options: --gpus all -e NVIDIA_DRIVER_CAPABILITIES=all --shm-size=2g --ipc=host
-        timeout-minutes: 120
+        timeout-minutes: 60
         env:
             # A10G compute capability (Ampere)
             TORCH_CUDA_ARCH_LIST: "8.6"
             CONDA_ENV: tritonparse
             PYTHON_VERSION: "3.14"
             PYTORCH_CUDA_TAG: cu130
+            # NVIDIA-published Triton nightly wheel index (cp310-cp314,
+            # x86_64 + aarch64). The "Triton-Nightly" is the *feed* name;
+            # the package is just `triton`. Versions look like
+            # 3.7.0+gitXXXXXXXX.
+            TRITON_NIGHTLY_INDEX_URL: "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly/pypi/simple/"
         steps:
             - uses: actions/checkout@v6
 
@@ -126,38 +131,7 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-pip-${{ env.PYTORCH_CUDA_TAG }}-py${{ env.PYTHON_VERSION }}-
 
-            - name: Get Triton latest commit
-              id: triton-commit
-              run: |
-                  # Get commit with error handling
-                  echo "Fetching latest Triton commit..."
-                  COMMIT=$(curl -s --max-time 30 --retry 3 https://api.github.com/repos/triton-lang/triton/commits/main | jq -r .sha 2>/dev/null || echo "")
-
-                  if [ -n "$COMMIT" ] && [ "$COMMIT" != "null" ]; then
-                      echo "commit=$COMMIT" >> $GITHUB_OUTPUT
-                      echo "cache-key=$COMMIT" >> $GITHUB_OUTPUT
-                      echo "✅ Using Triton commit: $COMMIT"
-                  else
-                      echo "❌ Failed to get Triton commit, using 'main' as fallback"
-                      # Force cache miss by using timestamp when API fails
-                      TIMESTAMP=$(date +%Y%m%d%H%M%S)
-                      echo "commit=main" >> $GITHUB_OUTPUT
-                      echo "cache-key=main-fallback-$TIMESTAMP" >> $GITHUB_OUTPUT
-                      echo "⚠️ Using fallback cache key: main-fallback-$TIMESTAMP"
-                  fi
-
-            - name: Cache Triton source and build
-              uses: actions/cache@v5
-              with:
-                  path: |
-                      /tmp/triton
-                      /tmp/triton-cache
-                  key: ${{ runner.os }}-triton-source-${{ hashFiles('.ci/install-triton.sh') }}-${{ steps.triton-commit.outputs.cache-key }}
-                  restore-keys: |
-                      ${{ runner.os }}-triton-source-${{ hashFiles('.ci/install-triton.sh') }}-
-                      ${{ runner.os }}-triton-source-
-
-            - name: Setup conda env + PyTorch nightly
+            - name: Setup conda env + PyTorch nightly + Triton nightly
               run: |
                   # Container ships with conda 23.5.2 in /opt/conda
                   # (Py3.11 base). Create a fresh Py3.14 env for tritonparse.
@@ -166,17 +140,24 @@ jobs:
                   conda activate "$CONDA_ENV"
 
                   # Install PyTorch nightly with CUDA runtime matching the
-                  # container toolkit.
+                  # container toolkit. This pulls a pinned `pytorch-triton`
+                  # snapshot which we replace below with the upstream
+                  # NVIDIA Triton nightly.
                   pip install --pre torch torchvision torchaudio \
                       --index-url "https://download.pytorch.org/whl/nightly/${PYTORCH_CUDA_TAG}"
                   # Workaround: PyTorch nightly missing 'packaging' dep.
                   pip install packaging
 
-            - name: Install Triton from source
-              env:
-                  TRITON_COMMIT: ${{ steps.triton-commit.outputs.commit }}
-              run: |
-                  bash .ci/install-triton.sh
+                  # Replace the pytorch-triton snapshot with the upstream
+                  # Triton nightly (NVIDIA's official feed). Both packages
+                  # provide `import triton`, so we uninstall any existing
+                  # variant first to avoid a half-overwritten install.
+                  # --extra-index-url keeps PyPI as the fallback for any
+                  # transitive deps; --pre allows the +gitXXXXXXXX version.
+                  pip uninstall -y pytorch-triton triton 2>/dev/null || true
+                  pip install -U --pre triton \
+                      --extra-index-url "${TRITON_NIGHTLY_INDEX_URL}"
+                  python -c "import triton; print(f'Triton: {triton.__version__} from {triton.__file__}')"
 
             - name: Install project dependencies
               run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,10 +42,10 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
-            - name: Set up Python 3.13
+            - name: Set up Python 3.14
               uses: actions/setup-python@v6
               with:
-                  python-version: "3.13"
+                  python-version: "3.14"
 
             - name: Install development dependencies
               run: |
@@ -92,7 +92,7 @@ jobs:
             # A10G compute capability (Ampere)
             TORCH_CUDA_ARCH_LIST: "8.6"
             CONDA_ENV: tritonparse
-            PYTHON_VERSION: "3.13"
+            PYTHON_VERSION: "3.14"
             PYTORCH_CUDA_TAG: cu130
         steps:
             - uses: actions/checkout@v6
@@ -149,7 +149,7 @@ jobs:
             - name: Setup conda env + PyTorch nightly
               run: |
                   # Container ships with conda 23.5.2 in /opt/conda
-                  # (Py3.11 base). Create a fresh Py3.13 env for tritonparse.
+                  # (Py3.11 base). Create a fresh Py3.14 env for tritonparse.
                   eval "$(/opt/conda/bin/conda shell.bash hook)"
                   conda create -n "$CONDA_ENV" python="$PYTHON_VERSION" -y -c conda-forge
                   conda activate "$CONDA_ENV"
@@ -187,7 +187,7 @@ jobs:
         env:
             TORCH_CUDA_ARCH_LIST: "8.6"
             CONDA_ENV: tritonparse-pip
-            PYTHON_VERSION: "3.13"
+            PYTHON_VERSION: "3.14"
             PYTORCH_CUDA_TAG: cu130
         steps:
             - uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,220 +55,6 @@ jobs:
               run: |
                   make format-check || (echo "❌ Format check failed. Please run 'make format' to fix formatting issues, then commit the changes." && echo "📖 For detailed formatting guide, see: https://github.com/meta-pytorch/tritonparse/wiki/05.-Code-Formatting" && exit 1)
 
-    # Probe-only job for the new PyTorch self-hosted GPU runner
-    # (linux.g5.4xlarge.nvidia.gpu, NVIDIA A10G).
-    # Manually triggered via the "Run workflow" button (workflow_dispatch).
-    # Does NOT run on push/PR. Output is used to design a dedicated
-    # setup script for self-hosted runners.
-    probe-selfhosted:
-        if: github.event_name == 'workflow_dispatch'
-        runs-on: [self-hosted, linux.g5.4xlarge.nvidia.gpu]
-        timeout-minutes: 15
-        continue-on-error: true
-        steps:
-            - name: OS / host info
-              run: |
-                  echo "===== uname ====="
-                  uname -a
-                  echo "===== /etc/os-release ====="
-                  cat /etc/os-release || true
-                  echo "===== lsb_release ====="
-                  lsb_release -a 2>/dev/null || true
-                  echo "===== whoami / id ====="
-                  whoami
-                  id
-                  echo "===== pwd / HOME ====="
-                  pwd
-                  echo "HOME=$HOME"
-                  echo "===== disk ====="
-                  df -h
-                  echo "===== memory ====="
-                  free -h
-                  echo "===== cpu ====="
-                  nproc
-                  grep "model name" /proc/cpuinfo | head -1 || true
-
-            - name: Privilege / writable paths
-              run: |
-                  echo "===== sudo -n true ====="
-                  if sudo -n true 2>&1; then
-                      echo "✅ passwordless sudo available"
-                  else
-                      echo "❌ no passwordless sudo"
-                  fi
-                  for d in /opt /usr/local /usr/local/cuda /etc; do
-                      if [ -w "$d" ]; then
-                          echo "✅ writable: $d"
-                      else
-                          echo "❌ NOT writable: $d"
-                      fi
-                  done
-
-            - name: GPU / NVIDIA info
-              run: |
-                  echo "===== nvidia-smi ====="
-                  nvidia-smi || echo "❌ nvidia-smi not found"
-                  echo "===== nvcc --version ====="
-                  nvcc --version 2>/dev/null || echo "❌ nvcc not found in PATH"
-                  echo "===== /usr/local/cuda* dirs ====="
-                  ls -la /usr/local/ 2>/dev/null | grep -i cuda || echo "no cuda dirs in /usr/local"
-                  echo "===== /usr/local/cuda symlink target ====="
-                  readlink -f /usr/local/cuda 2>/dev/null || echo "no /usr/local/cuda symlink"
-                  echo "===== cuDNN libs ====="
-                  find /usr -name "libcudnn*" 2>/dev/null | head -20 || true
-                  find /opt -name "libcudnn*" 2>/dev/null | head -20 || true
-                  echo "===== NVIDIA driver version ====="
-                  cat /proc/driver/nvidia/version 2>/dev/null || echo "no /proc/driver/nvidia/version"
-
-            - name: Python / conda info
-              run: |
-                  echo "===== which python / python3 ====="
-                  which python 2>/dev/null || echo "no python in PATH"
-                  which python3 2>/dev/null || echo "no python3 in PATH"
-                  python3 --version 2>/dev/null || true
-                  echo "===== which conda ====="
-                  which conda 2>/dev/null || echo "no conda in PATH"
-                  conda --version 2>/dev/null || true
-                  echo "===== candidate conda install paths ====="
-                  for p in /opt/miniconda3 /opt/conda $HOME/miniconda3 $HOME/anaconda3 $HOME/conda; do
-                      if [ -d "$p" ]; then
-                          echo "✅ exists: $p"
-                          ls -la "$p" 2>/dev/null | head -5
-                      else
-                          echo "❌ missing: $p"
-                      fi
-                  done
-                  echo "===== conda env list ====="
-                  conda env list 2>/dev/null || true
-                  echo "===== which pip ====="
-                  which pip 2>/dev/null || echo "no pip in PATH"
-                  pip --version 2>/dev/null || true
-
-            - name: Compilers / build tools
-              run: |
-                  for cmd in gcc g++ clang clang++ clang-19 clangd cmake ninja make git curl wget jq; do
-                      if command -v "$cmd" &>/dev/null; then
-                          ver=$("$cmd" --version 2>/dev/null | head -1)
-                          echo "✅ $cmd -> $ver"
-                      else
-                          echo "❌ $cmd not found"
-                      fi
-                  done
-                  echo "===== glibc ====="
-                  ldd --version 2>/dev/null | head -1 || true
-
-            - name: Environment variables / PATH
-              run: |
-                  echo "===== PATH ====="
-                  echo "$PATH" | tr ':' '\n'
-                  echo "===== LD_LIBRARY_PATH ====="
-                  echo "${LD_LIBRARY_PATH:-<unset>}"
-                  echo "===== CUDA_HOME ====="
-                  echo "${CUDA_HOME:-<unset>}"
-                  echo "===== Relevant env vars ====="
-                  env | grep -iE "cuda|conda|python|gpu|torch|nvidia" | sort || true
-
-            - name: PyTorch wheel index reachability
-              run: |
-                  for tag in cu126 cu128 cu129 cu130 cu131 cu132; do
-                      code=$(curl -s -o /dev/null -w "%{http_code}" "https://download.pytorch.org/whl/nightly/${tag}/")
-                      echo "${tag}: HTTP ${code}"
-                  done
-
-            - name: Container / runner context
-              run: |
-                  echo "===== /.dockerenv ====="
-                  if [ -f /.dockerenv ]; then echo "✅ inside docker"; else echo "❌ not docker"; fi
-                  echo "===== /proc/1/cgroup ====="
-                  cat /proc/1/cgroup 2>/dev/null | head -5 || true
-                  echo "===== runner env ====="
-                  env | grep -iE "runner|github|actions" | sort || true
-
-    # Probe jobs that exercise the canonical PyTorch reusable workflow
-    # `pytorch/test-infra/.github/workflows/linux_job_v2.yml@main`.
-    # This is the recommended pattern used by autoparallel / vision / rl /
-    # torchcodec / executorch etc. The reusable workflow runs the script
-    # inside a pre-built Docker container that already has CUDA + conda
-    # + nvidia-smi configured, so we don't have to provision anything
-    # ourselves on the AL2023 host.
-    #
-    # We invoke it three times with different gpu-arch-version values to
-    # discover which CUDA versions are currently supported by the
-    # reusable workflow's image map. The first one that succeeds is the
-    # CUDA version we will adopt for the migration.
-    probe-linux-job-v2-cu128:
-        if: github.event_name == 'workflow_dispatch'
-        uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
-        with:
-            runner: linux.g5.4xlarge.nvidia.gpu
-            gpu-arch-type: cuda
-            gpu-arch-version: "12.8"
-            timeout: 15
-            script: |
-                set -x
-                echo "===== requested: cuda 12.8 ====="
-                echo "===== container OS ====="
-                cat /etc/os-release || true
-                echo "===== nvidia-smi ====="
-                nvidia-smi || echo "no nvidia-smi"
-                echo "===== nvcc ====="
-                which nvcc && nvcc --version || echo "no nvcc"
-                echo "===== /usr/local/cuda* ====="
-                ls -la /usr/local/ | grep -i cuda || echo "no cuda in /usr/local"
-                readlink -f /usr/local/cuda 2>/dev/null || true
-                echo "===== conda ====="
-                which conda && conda info | head -20 || echo "no conda"
-                echo "===== python ====="
-                which python && python --version || echo "no python"
-                echo "===== HF cache mount ====="
-                ls -la /mnt/hf_cache 2>/dev/null | head -3 || echo "no /mnt/hf_cache"
-                echo "===== TORCH_CUDA_ARCH_LIST env ====="
-                echo "${TORCH_CUDA_ARCH_LIST:-<unset>}"
-                echo "===== gpu arch / CC ====="
-                python -c "import subprocess; print(subprocess.check_output(['nvidia-smi','--query-gpu=name,compute_cap','--format=csv']).decode())" 2>/dev/null || true
-
-    probe-linux-job-v2-cu130:
-        if: github.event_name == 'workflow_dispatch'
-        uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
-        with:
-            runner: linux.g5.4xlarge.nvidia.gpu
-            gpu-arch-type: cuda
-            gpu-arch-version: "13.0"
-            timeout: 15
-            script: |
-                set -x
-                echo "===== requested: cuda 13.0 ====="
-                cat /etc/os-release || true
-                nvidia-smi || echo "no nvidia-smi"
-                which nvcc && nvcc --version || echo "no nvcc"
-                ls -la /usr/local/ | grep -i cuda || echo "no cuda in /usr/local"
-                readlink -f /usr/local/cuda 2>/dev/null || true
-                which conda && conda info | head -20 || echo "no conda"
-                which python && python --version || echo "no python"
-                ls -la /mnt/hf_cache 2>/dev/null | head -3 || echo "no /mnt/hf_cache"
-                echo "TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST:-<unset>}"
-
-    probe-linux-job-v2-cu132:
-        if: github.event_name == 'workflow_dispatch'
-        uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
-        with:
-            runner: linux.g5.4xlarge.nvidia.gpu
-            gpu-arch-type: cuda
-            gpu-arch-version: "13.2"
-            timeout: 15
-            script: |
-                set -x
-                echo "===== requested: cuda 13.2 ====="
-                cat /etc/os-release || true
-                nvidia-smi || echo "no nvidia-smi"
-                which nvcc && nvcc --version || echo "no nvcc"
-                ls -la /usr/local/ | grep -i cuda || echo "no cuda in /usr/local"
-                readlink -f /usr/local/cuda 2>/dev/null || true
-                which conda && conda info | head -20 || echo "no conda"
-                which python && python --version || echo "no python"
-                ls -la /mnt/hf_cache 2>/dev/null | head -3 || echo "no /mnt/hf_cache"
-                echo "TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST:-<unset>}"
-
     # GPU tests - runs on GPU runner with full Triton from source
     # Note: CPU tests (tests/cpu/) are run as part of GPU jobs with TEST_TYPE=all
     test-from-source:
@@ -420,3 +206,106 @@ jobs:
                   COVERAGE: ${{ github.event.inputs.coverage || 'false' }}
               run: |
                   bash .ci/run-tests.sh
+
+    # ===================================================================
+    # Migration target: PyTorch self-hosted GPU runner (NVIDIA A10G via
+    # AWS G5.4xlarge, ephemeral EC2 instances, 1 job per VM).
+    #
+    # Runs the test suite inside the canonical PyTorch reusable workflow
+    # `pytorch/test-infra/.github/workflows/linux_job_v2.yml@main`, which:
+    #   1. Spins up an ephemeral g5.4xlarge EC2 (16 vCPU / 64 GiB / A10G
+    #      / Amazon Linux 2023 host).
+    #   2. Pulls `pytorch/almalinux-builder:cuda13.0` (AlmaLinux 8.10 +
+    #      CUDA 13.0 toolkit + conda 23.5.2 in /opt/conda + Python 3.11
+    #      base env).
+    #   3. docker-execs our `script:` inside that container with
+    #      `--gpus all` and the repo mounted at /meta-pytorch/tritonparse.
+    #
+    # We don't call `.ci/setup.sh` here — `setup.sh` is tailored to a
+    # GitHub-hosted Ubuntu fresh-image runner (uses apt, /opt/miniconda3,
+    # update-alternatives) and is kept for local development only. The
+    # container ships with everything we need.
+    #
+    # Why CUDA 13.0 (not 13.2): probed on 2026-04-29 — host driver on G5
+    # runners is currently 580.65.06 which exposes CUDA runtime 13.0;
+    # the container image cuda13.2 needs driver 581+ and fails the
+    # nvidia-container-cli capability check
+    # ("unsatisfied condition: cuda>=13.2"). Bump to 13.2 once PyTorch
+    # infra rolls out a newer driver AMI.
+    #
+    # Currently triggered only via workflow_dispatch to avoid hammering
+    # the shared self-hosted runner pool while we stabilize. Once stable,
+    # the `if:` guard can be removed and these jobs will run on push/PR
+    # alongside the existing T4 GitHub-hosted jobs.
+    # ===================================================================
+    test-from-source-a10g:
+        if: github.event_name == 'workflow_dispatch'
+        uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+        with:
+            runner: linux.g5.4xlarge.nvidia.gpu
+            gpu-arch-type: cuda
+            gpu-arch-version: "13.0"
+            timeout: 120
+            script: |
+                set -e
+                # A10G compute capability (Ampere)
+                export TORCH_CUDA_ARCH_LIST=8.6
+                export CONDA_ENV=tritonparse
+                export PYTHON_VERSION=3.13
+
+                # Container ships with conda 23.5.2 in /opt/conda (Py3.11
+                # base). Create a fresh Py3.13 env for tritonparse.
+                conda create -n "$CONDA_ENV" python="$PYTHON_VERSION" -y -c conda-forge
+                source "$(conda info --base)/etc/profile.d/conda.sh"
+                conda activate "$CONDA_ENV"
+
+                # Install PyTorch nightly with CUDA 13.0 runtime.
+                pip install --pre torch torchvision torchaudio \
+                    --index-url https://download.pytorch.org/whl/nightly/cu130
+                # Workaround: PyTorch nightly missing 'packaging' dep.
+                pip install packaging
+
+                # Install Triton from source. TRITON_COMMIT defaults to
+                # "main" inside install-triton.sh.
+                # NOTE: no actions/cache available inside reusable workflow,
+                # so cold builds take ~30-50 minutes. Add caching later
+                # via the reusable workflow's upload-artifact mechanism.
+                bash .ci/install-triton.sh
+
+                # Install the project + test deps.
+                bash .ci/install-project.sh
+
+                # Run the test suite.
+                export TEST_TYPE="${{ github.event.inputs.test-type || 'all' }}"
+                export COVERAGE="${{ github.event.inputs.coverage || 'false' }}"
+                bash .ci/run-tests.sh
+
+    test-from-pip-a10g:
+        if: github.event_name == 'workflow_dispatch'
+        uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+        with:
+            runner: linux.g5.4xlarge.nvidia.gpu
+            gpu-arch-type: cuda
+            gpu-arch-version: "13.0"
+            timeout: 60
+            script: |
+                set -e
+                export TORCH_CUDA_ARCH_LIST=8.6
+                export CONDA_ENV=tritonparse-pip
+                export PYTHON_VERSION=3.13
+
+                conda create -n "$CONDA_ENV" python="$PYTHON_VERSION" -y -c conda-forge
+                source "$(conda info --base)/etc/profile.d/conda.sh"
+                conda activate "$CONDA_ENV"
+
+                # PyTorch nightly bundles its own pytorch-triton, so no
+                # source build of Triton needed here.
+                pip install --pre torch torchvision torchaudio \
+                    --index-url https://download.pytorch.org/whl/nightly/cu130
+                pip install packaging
+
+                bash .ci/install-project.sh
+
+                export TEST_TYPE="${{ github.event.inputs.test-type || 'all' }}"
+                export COVERAGE="${{ github.event.inputs.coverage || 'false' }}"
+                bash .ci/run-tests.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,20 +55,47 @@ jobs:
               run: |
                   make format-check || (echo "❌ Format check failed. Please run 'make format' to fix formatting issues, then commit the changes." && echo "📖 For detailed formatting guide, see: https://github.com/meta-pytorch/tritonparse/wiki/05.-Code-Formatting" && exit 1)
 
-    # GPU tests - runs on GPU runner with full Triton from source
-    # Note: CPU tests (tests/cpu/) are run as part of GPU jobs with TEST_TYPE=all
+    # ===================================================================
+    # GPU tests on PyTorch self-hosted runner: AWS g5.4xlarge / NVIDIA
+    # A10G, ephemeral EC2 (1 job per VM, no cross-PR pollution).
+    #
+    # Architecture: `runs-on:` + `container:` (helion-style). We run the
+    # job directly inside the `pytorch/almalinux-builder:cuda13.0`
+    # docker image (AlmaLinux 8.10 + CUDA 13.0 toolkit + conda 23.5.2 in
+    # /opt/conda + Python 3.11 base env). The host AMI provides the
+    # NVIDIA driver (580.65.06) and nvidia-container-toolkit; the
+    # container picks them up via `--gpus all`.
+    #
+    # We bypass `pytorch/test-infra/linux_job_v2.yml` to retain native
+    # `actions/cache` support (the reusable workflow's opaque `script:`
+    # block prevents standard caching). This trade-off costs us the
+    # reusable workflow's auto NVIDIA driver freshness check, but the
+    # AMI's pre-installed driver has been verified working.
+    #
+    # `.ci/setup.sh` is intentionally NOT called here — it targets a
+    # GitHub-hosted Ubuntu fresh-image runner and is kept for local
+    # development only. The container ships with everything we need.
+    #
+    # Why CUDA 13.0 (not 13.2): host driver on G5 runners (580.65.06)
+    # exposes CUDA runtime 13.0; cuda13.2 image fails the
+    # nvidia-container-cli capability check ("unsatisfied condition:
+    # cuda>=13.2"). Bump once PyTorch infra rolls out a newer driver
+    # AMI. Probed on 2026-04-29.
+    # ===================================================================
     test-from-source:
-        runs-on: 4-core-ubuntu-gpu-t4
+        runs-on: linux.g5.4xlarge.nvidia.gpu
+        container:
+            image: pytorch/almalinux-builder:cuda13.0
+            options: --gpus all -e NVIDIA_DRIVER_CAPABILITIES=all --shm-size=2g --ipc=host
         timeout-minutes: 120
+        env:
+            # A10G compute capability (Ampere)
+            TORCH_CUDA_ARCH_LIST: "8.6"
+            CONDA_ENV: tritonparse
+            PYTHON_VERSION: "3.13"
+            PYTORCH_CUDA_TAG: cu130
         steps:
             - uses: actions/checkout@v6
-
-            # NOTE: We intentionally do NOT use actions/setup-python here.
-            # `.ci/setup.sh` creates and activates a conda env with Python 3.13.
-            # Having actions/setup-python's hosted-tool-cache Python earlier on
-            # PATH causes `python` to resolve to a different interpreter than
-            # the activated conda env, leading to ModuleNotFoundError after a
-            # successful `pip install`.
 
             - name: Get daily cache timestamp
               id: daily-cache
@@ -78,31 +105,19 @@ jobs:
                   echo "date=$DATE_STAMP" >> $GITHUB_OUTPUT
                   echo "Using daily cache stamp: $DATE_STAMP"
 
-            - name: Get weekly cache timestamp
-              id: weekly-cache
-              run: |
-                  # Calculate year-week (e.g., 2024-03) for weekly cache expiration
-                  WEEK_STAMP=$(date +"%Y-%U")
-                  echo "week=$WEEK_STAMP" >> $GITHUB_OUTPUT
-                  echo "Using weekly cache stamp: $WEEK_STAMP"
-
             - name: Cache pip dependencies
               uses: actions/cache@v5
               with:
-                  path: ~/.cache/pip
-                  key: ${{ runner.os }}-pip-3.13-${{ steps.daily-cache.outputs.date }}
+                  # Container runs as root, so pip's user cache lives at
+                  # /root/.cache/pip rather than the host's ~/.cache/pip.
+                  path: /root/.cache/pip
+                  key: ${{ runner.os }}-pip-${{ env.PYTORCH_CUDA_TAG }}-py${{ env.PYTHON_VERSION }}-${{ steps.daily-cache.outputs.date }}
                   restore-keys: |
-                      ${{ runner.os }}-pip-3.13-
+                      ${{ runner.os }}-pip-${{ env.PYTORCH_CUDA_TAG }}-py${{ env.PYTHON_VERSION }}-
 
             - name: Get Triton latest commit
               id: triton-commit
               run: |
-                  # Check if jq is available
-                  if ! command -v jq &> /dev/null; then
-                      echo "jq not found, installing..."
-                      sudo apt-get update && sudo apt-get install -y jq
-                  fi
-
                   # Get commit with error handling
                   echo "Fetching latest Triton commit..."
                   COMMIT=$(curl -s --max-time 30 --retry 3 https://api.github.com/repos/triton-lang/triton/commits/main | jq -r .sha 2>/dev/null || echo "")
@@ -131,48 +146,55 @@ jobs:
                       ${{ runner.os }}-triton-source-${{ hashFiles('.ci/install-triton.sh') }}-
                       ${{ runner.os }}-triton-source-
 
-            - name: Setup environment
-              env:
-                  CONDA_ENV: tritonparse
-                  PYTHON_VERSION: "3.13"
-                  CUDA_VERSION: "12.8"
+            - name: Setup conda env + PyTorch nightly
               run: |
-                  bash .ci/setup.sh
+                  # Container ships with conda 23.5.2 in /opt/conda
+                  # (Py3.11 base). Create a fresh Py3.13 env for tritonparse.
+                  eval "$(/opt/conda/bin/conda shell.bash hook)"
+                  conda create -n "$CONDA_ENV" python="$PYTHON_VERSION" -y -c conda-forge
+                  conda activate "$CONDA_ENV"
+
+                  # Install PyTorch nightly with CUDA runtime matching the
+                  # container toolkit.
+                  pip install --pre torch torchvision torchaudio \
+                      --index-url "https://download.pytorch.org/whl/nightly/${PYTORCH_CUDA_TAG}"
+                  # Workaround: PyTorch nightly missing 'packaging' dep.
+                  pip install packaging
 
             - name: Install Triton from source
               env:
-                  CONDA_ENV: tritonparse
                   TRITON_COMMIT: ${{ steps.triton-commit.outputs.commit }}
               run: |
                   bash .ci/install-triton.sh
 
             - name: Install project dependencies
-              env:
-                  CONDA_ENV: tritonparse
               run: |
                   bash .ci/install-project.sh
 
             - name: Run tests
               env:
-                  CONDA_ENV: tritonparse
                   TEST_TYPE: ${{ github.event.inputs.test-type || 'all' }}
                   COVERAGE: ${{ github.event.inputs.coverage || 'false' }}
               run: |
                   bash .ci/run-tests.sh
 
     test-from-pip:
-        runs-on: 4-core-ubuntu-gpu-t4
-        timeout-minutes: 120
+        runs-on: linux.g5.4xlarge.nvidia.gpu
+        container:
+            image: pytorch/almalinux-builder:cuda13.0
+            options: --gpus all -e NVIDIA_DRIVER_CAPABILITIES=all --shm-size=2g --ipc=host
+        timeout-minutes: 60
+        env:
+            TORCH_CUDA_ARCH_LIST: "8.6"
+            CONDA_ENV: tritonparse-pip
+            PYTHON_VERSION: "3.13"
+            PYTORCH_CUDA_TAG: cu130
         steps:
             - uses: actions/checkout@v6
-
-            # NOTE: We intentionally do NOT use actions/setup-python here.
-            # See comment in test-from-source above for the rationale.
 
             - name: Get daily cache timestamp
               id: daily-cache
               run: |
-                  # Calculate date (e.g., 2024-01-15) for daily cache expiration
                   DATE_STAMP=$(date +"%Y-%m-%d")
                   echo "date=$DATE_STAMP" >> $GITHUB_OUTPUT
                   echo "Using daily cache stamp: $DATE_STAMP"
@@ -180,132 +202,30 @@ jobs:
             - name: Cache pip dependencies
               uses: actions/cache@v5
               with:
-                  path: ~/.cache/pip
-                  key: ${{ runner.os }}-pip-3.13-${{ steps.daily-cache.outputs.date }}
+                  path: /root/.cache/pip
+                  key: ${{ runner.os }}-pip-${{ env.PYTORCH_CUDA_TAG }}-py${{ env.PYTHON_VERSION }}-${{ steps.daily-cache.outputs.date }}
                   restore-keys: |
-                      ${{ runner.os }}-pip-3.13-
+                      ${{ runner.os }}-pip-${{ env.PYTORCH_CUDA_TAG }}-py${{ env.PYTHON_VERSION }}-
 
-            - name: Setup environment
-              env:
-                  CONDA_ENV: tritonparse-pip
-                  PYTHON_VERSION: "3.13"
-                  CUDA_VERSION: "12.8"
+            - name: Setup conda env + PyTorch nightly
               run: |
-                  bash .ci/setup.sh
+                  eval "$(/opt/conda/bin/conda shell.bash hook)"
+                  conda create -n "$CONDA_ENV" python="$PYTHON_VERSION" -y -c conda-forge
+                  conda activate "$CONDA_ENV"
+
+                  # PyTorch nightly bundles its own pytorch-triton, so no
+                  # source build of Triton needed in this job.
+                  pip install --pre torch torchvision torchaudio \
+                      --index-url "https://download.pytorch.org/whl/nightly/${PYTORCH_CUDA_TAG}"
+                  pip install packaging
 
             - name: Install project dependencies
-              env:
-                  CONDA_ENV: tritonparse-pip
               run: |
                   bash .ci/install-project.sh
 
             - name: Run tests
               env:
-                  CONDA_ENV: tritonparse-pip
                   TEST_TYPE: ${{ github.event.inputs.test-type || 'all' }}
                   COVERAGE: ${{ github.event.inputs.coverage || 'false' }}
               run: |
                   bash .ci/run-tests.sh
-
-    # ===================================================================
-    # Migration target: PyTorch self-hosted GPU runner (NVIDIA A10G via
-    # AWS G5.4xlarge, ephemeral EC2 instances, 1 job per VM).
-    #
-    # Runs the test suite inside the canonical PyTorch reusable workflow
-    # `pytorch/test-infra/.github/workflows/linux_job_v2.yml@main`, which:
-    #   1. Spins up an ephemeral g5.4xlarge EC2 (16 vCPU / 64 GiB / A10G
-    #      / Amazon Linux 2023 host).
-    #   2. Pulls `pytorch/almalinux-builder:cuda13.0` (AlmaLinux 8.10 +
-    #      CUDA 13.0 toolkit + conda 23.5.2 in /opt/conda + Python 3.11
-    #      base env).
-    #   3. docker-execs our `script:` inside that container with
-    #      `--gpus all` and the repo mounted at /meta-pytorch/tritonparse.
-    #
-    # We don't call `.ci/setup.sh` here — `setup.sh` is tailored to a
-    # GitHub-hosted Ubuntu fresh-image runner (uses apt, /opt/miniconda3,
-    # update-alternatives) and is kept for local development only. The
-    # container ships with everything we need.
-    #
-    # Why CUDA 13.0 (not 13.2): probed on 2026-04-29 — host driver on G5
-    # runners is currently 580.65.06 which exposes CUDA runtime 13.0;
-    # the container image cuda13.2 needs driver 581+ and fails the
-    # nvidia-container-cli capability check
-    # ("unsatisfied condition: cuda>=13.2"). Bump to 13.2 once PyTorch
-    # infra rolls out a newer driver AMI.
-    #
-    # Currently triggered only via workflow_dispatch to avoid hammering
-    # the shared self-hosted runner pool while we stabilize. Once stable,
-    # the `if:` guard can be removed and these jobs will run on push/PR
-    # alongside the existing T4 GitHub-hosted jobs.
-    # ===================================================================
-    test-from-source-a10g:
-        if: github.event_name == 'workflow_dispatch'
-        uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
-        with:
-            runner: linux.g5.4xlarge.nvidia.gpu
-            gpu-arch-type: cuda
-            gpu-arch-version: "13.0"
-            timeout: 120
-            script: |
-                set -e
-                # A10G compute capability (Ampere)
-                export TORCH_CUDA_ARCH_LIST=8.6
-                export CONDA_ENV=tritonparse
-                export PYTHON_VERSION=3.13
-
-                # Container ships with conda 23.5.2 in /opt/conda (Py3.11
-                # base). Create a fresh Py3.13 env for tritonparse.
-                conda create -n "$CONDA_ENV" python="$PYTHON_VERSION" -y -c conda-forge
-                source "$(conda info --base)/etc/profile.d/conda.sh"
-                conda activate "$CONDA_ENV"
-
-                # Install PyTorch nightly with CUDA 13.0 runtime.
-                pip install --pre torch torchvision torchaudio \
-                    --index-url https://download.pytorch.org/whl/nightly/cu130
-                # Workaround: PyTorch nightly missing 'packaging' dep.
-                pip install packaging
-
-                # Install Triton from source. TRITON_COMMIT defaults to
-                # "main" inside install-triton.sh.
-                # NOTE: no actions/cache available inside reusable workflow,
-                # so cold builds take ~30-50 minutes. Add caching later
-                # via the reusable workflow's upload-artifact mechanism.
-                bash .ci/install-triton.sh
-
-                # Install the project + test deps.
-                bash .ci/install-project.sh
-
-                # Run the test suite.
-                export TEST_TYPE="${{ github.event.inputs.test-type || 'all' }}"
-                export COVERAGE="${{ github.event.inputs.coverage || 'false' }}"
-                bash .ci/run-tests.sh
-
-    test-from-pip-a10g:
-        if: github.event_name == 'workflow_dispatch'
-        uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
-        with:
-            runner: linux.g5.4xlarge.nvidia.gpu
-            gpu-arch-type: cuda
-            gpu-arch-version: "13.0"
-            timeout: 60
-            script: |
-                set -e
-                export TORCH_CUDA_ARCH_LIST=8.6
-                export CONDA_ENV=tritonparse-pip
-                export PYTHON_VERSION=3.13
-
-                conda create -n "$CONDA_ENV" python="$PYTHON_VERSION" -y -c conda-forge
-                source "$(conda info --base)/etc/profile.d/conda.sh"
-                conda activate "$CONDA_ENV"
-
-                # PyTorch nightly bundles its own pytorch-triton, so no
-                # source build of Triton needed here.
-                pip install --pre torch torchvision torchaudio \
-                    --index-url https://download.pytorch.org/whl/nightly/cu130
-                pip install packaging
-
-                bash .ci/install-project.sh
-
-                export TEST_TYPE="${{ github.event.inputs.test-type || 'all' }}"
-                export COVERAGE="${{ github.event.inputs.coverage || 'false' }}"
-                bash .ci/run-tests.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,220 @@ jobs:
               run: |
                   make format-check || (echo "❌ Format check failed. Please run 'make format' to fix formatting issues, then commit the changes." && echo "📖 For detailed formatting guide, see: https://github.com/meta-pytorch/tritonparse/wiki/05.-Code-Formatting" && exit 1)
 
+    # Probe-only job for the new PyTorch self-hosted GPU runner
+    # (linux.g5.4xlarge.nvidia.gpu, NVIDIA A10G).
+    # Manually triggered via the "Run workflow" button (workflow_dispatch).
+    # Does NOT run on push/PR. Output is used to design a dedicated
+    # setup script for self-hosted runners.
+    probe-selfhosted:
+        if: github.event_name == 'workflow_dispatch'
+        runs-on: [self-hosted, linux.g5.4xlarge.nvidia.gpu]
+        timeout-minutes: 15
+        continue-on-error: true
+        steps:
+            - name: OS / host info
+              run: |
+                  echo "===== uname ====="
+                  uname -a
+                  echo "===== /etc/os-release ====="
+                  cat /etc/os-release || true
+                  echo "===== lsb_release ====="
+                  lsb_release -a 2>/dev/null || true
+                  echo "===== whoami / id ====="
+                  whoami
+                  id
+                  echo "===== pwd / HOME ====="
+                  pwd
+                  echo "HOME=$HOME"
+                  echo "===== disk ====="
+                  df -h
+                  echo "===== memory ====="
+                  free -h
+                  echo "===== cpu ====="
+                  nproc
+                  grep "model name" /proc/cpuinfo | head -1 || true
+
+            - name: Privilege / writable paths
+              run: |
+                  echo "===== sudo -n true ====="
+                  if sudo -n true 2>&1; then
+                      echo "✅ passwordless sudo available"
+                  else
+                      echo "❌ no passwordless sudo"
+                  fi
+                  for d in /opt /usr/local /usr/local/cuda /etc; do
+                      if [ -w "$d" ]; then
+                          echo "✅ writable: $d"
+                      else
+                          echo "❌ NOT writable: $d"
+                      fi
+                  done
+
+            - name: GPU / NVIDIA info
+              run: |
+                  echo "===== nvidia-smi ====="
+                  nvidia-smi || echo "❌ nvidia-smi not found"
+                  echo "===== nvcc --version ====="
+                  nvcc --version 2>/dev/null || echo "❌ nvcc not found in PATH"
+                  echo "===== /usr/local/cuda* dirs ====="
+                  ls -la /usr/local/ 2>/dev/null | grep -i cuda || echo "no cuda dirs in /usr/local"
+                  echo "===== /usr/local/cuda symlink target ====="
+                  readlink -f /usr/local/cuda 2>/dev/null || echo "no /usr/local/cuda symlink"
+                  echo "===== cuDNN libs ====="
+                  find /usr -name "libcudnn*" 2>/dev/null | head -20 || true
+                  find /opt -name "libcudnn*" 2>/dev/null | head -20 || true
+                  echo "===== NVIDIA driver version ====="
+                  cat /proc/driver/nvidia/version 2>/dev/null || echo "no /proc/driver/nvidia/version"
+
+            - name: Python / conda info
+              run: |
+                  echo "===== which python / python3 ====="
+                  which python 2>/dev/null || echo "no python in PATH"
+                  which python3 2>/dev/null || echo "no python3 in PATH"
+                  python3 --version 2>/dev/null || true
+                  echo "===== which conda ====="
+                  which conda 2>/dev/null || echo "no conda in PATH"
+                  conda --version 2>/dev/null || true
+                  echo "===== candidate conda install paths ====="
+                  for p in /opt/miniconda3 /opt/conda $HOME/miniconda3 $HOME/anaconda3 $HOME/conda; do
+                      if [ -d "$p" ]; then
+                          echo "✅ exists: $p"
+                          ls -la "$p" 2>/dev/null | head -5
+                      else
+                          echo "❌ missing: $p"
+                      fi
+                  done
+                  echo "===== conda env list ====="
+                  conda env list 2>/dev/null || true
+                  echo "===== which pip ====="
+                  which pip 2>/dev/null || echo "no pip in PATH"
+                  pip --version 2>/dev/null || true
+
+            - name: Compilers / build tools
+              run: |
+                  for cmd in gcc g++ clang clang++ clang-19 clangd cmake ninja make git curl wget jq; do
+                      if command -v "$cmd" &>/dev/null; then
+                          ver=$("$cmd" --version 2>/dev/null | head -1)
+                          echo "✅ $cmd -> $ver"
+                      else
+                          echo "❌ $cmd not found"
+                      fi
+                  done
+                  echo "===== glibc ====="
+                  ldd --version 2>/dev/null | head -1 || true
+
+            - name: Environment variables / PATH
+              run: |
+                  echo "===== PATH ====="
+                  echo "$PATH" | tr ':' '\n'
+                  echo "===== LD_LIBRARY_PATH ====="
+                  echo "${LD_LIBRARY_PATH:-<unset>}"
+                  echo "===== CUDA_HOME ====="
+                  echo "${CUDA_HOME:-<unset>}"
+                  echo "===== Relevant env vars ====="
+                  env | grep -iE "cuda|conda|python|gpu|torch|nvidia" | sort || true
+
+            - name: PyTorch wheel index reachability
+              run: |
+                  for tag in cu126 cu128 cu129 cu130 cu131 cu132; do
+                      code=$(curl -s -o /dev/null -w "%{http_code}" "https://download.pytorch.org/whl/nightly/${tag}/")
+                      echo "${tag}: HTTP ${code}"
+                  done
+
+            - name: Container / runner context
+              run: |
+                  echo "===== /.dockerenv ====="
+                  if [ -f /.dockerenv ]; then echo "✅ inside docker"; else echo "❌ not docker"; fi
+                  echo "===== /proc/1/cgroup ====="
+                  cat /proc/1/cgroup 2>/dev/null | head -5 || true
+                  echo "===== runner env ====="
+                  env | grep -iE "runner|github|actions" | sort || true
+
+    # Probe jobs that exercise the canonical PyTorch reusable workflow
+    # `pytorch/test-infra/.github/workflows/linux_job_v2.yml@main`.
+    # This is the recommended pattern used by autoparallel / vision / rl /
+    # torchcodec / executorch etc. The reusable workflow runs the script
+    # inside a pre-built Docker container that already has CUDA + conda
+    # + nvidia-smi configured, so we don't have to provision anything
+    # ourselves on the AL2023 host.
+    #
+    # We invoke it three times with different gpu-arch-version values to
+    # discover which CUDA versions are currently supported by the
+    # reusable workflow's image map. The first one that succeeds is the
+    # CUDA version we will adopt for the migration.
+    probe-linux-job-v2-cu128:
+        if: github.event_name == 'workflow_dispatch'
+        uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+        with:
+            runner: linux.g5.4xlarge.nvidia.gpu
+            gpu-arch-type: cuda
+            gpu-arch-version: "12.8"
+            timeout: 15
+            script: |
+                set -x
+                echo "===== requested: cuda 12.8 ====="
+                echo "===== container OS ====="
+                cat /etc/os-release || true
+                echo "===== nvidia-smi ====="
+                nvidia-smi || echo "no nvidia-smi"
+                echo "===== nvcc ====="
+                which nvcc && nvcc --version || echo "no nvcc"
+                echo "===== /usr/local/cuda* ====="
+                ls -la /usr/local/ | grep -i cuda || echo "no cuda in /usr/local"
+                readlink -f /usr/local/cuda 2>/dev/null || true
+                echo "===== conda ====="
+                which conda && conda info | head -20 || echo "no conda"
+                echo "===== python ====="
+                which python && python --version || echo "no python"
+                echo "===== HF cache mount ====="
+                ls -la /mnt/hf_cache 2>/dev/null | head -3 || echo "no /mnt/hf_cache"
+                echo "===== TORCH_CUDA_ARCH_LIST env ====="
+                echo "${TORCH_CUDA_ARCH_LIST:-<unset>}"
+                echo "===== gpu arch / CC ====="
+                python -c "import subprocess; print(subprocess.check_output(['nvidia-smi','--query-gpu=name,compute_cap','--format=csv']).decode())" 2>/dev/null || true
+
+    probe-linux-job-v2-cu130:
+        if: github.event_name == 'workflow_dispatch'
+        uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+        with:
+            runner: linux.g5.4xlarge.nvidia.gpu
+            gpu-arch-type: cuda
+            gpu-arch-version: "13.0"
+            timeout: 15
+            script: |
+                set -x
+                echo "===== requested: cuda 13.0 ====="
+                cat /etc/os-release || true
+                nvidia-smi || echo "no nvidia-smi"
+                which nvcc && nvcc --version || echo "no nvcc"
+                ls -la /usr/local/ | grep -i cuda || echo "no cuda in /usr/local"
+                readlink -f /usr/local/cuda 2>/dev/null || true
+                which conda && conda info | head -20 || echo "no conda"
+                which python && python --version || echo "no python"
+                ls -la /mnt/hf_cache 2>/dev/null | head -3 || echo "no /mnt/hf_cache"
+                echo "TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST:-<unset>}"
+
+    probe-linux-job-v2-cu132:
+        if: github.event_name == 'workflow_dispatch'
+        uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+        with:
+            runner: linux.g5.4xlarge.nvidia.gpu
+            gpu-arch-type: cuda
+            gpu-arch-version: "13.2"
+            timeout: 15
+            script: |
+                set -x
+                echo "===== requested: cuda 13.2 ====="
+                cat /etc/os-release || true
+                nvidia-smi || echo "no nvidia-smi"
+                which nvcc && nvcc --version || echo "no nvcc"
+                ls -la /usr/local/ | grep -i cuda || echo "no cuda in /usr/local"
+                readlink -f /usr/local/cuda 2>/dev/null || true
+                which conda && conda info | head -20 || echo "no conda"
+                which python && python --version || echo "no python"
+                ls -la /mnt/hf_cache 2>/dev/null | head -3 || echo "no /mnt/hf_cache"
+                echo "TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST:-<unset>}"
+
     # GPU tests - runs on GPU runner with full Triton from source
     # Note: CPU tests (tests/cpu/) are run as part of GPU jobs with TEST_TYPE=all
     test-from-source:

--- a/tritonparse/reproducer/function_extractor.py
+++ b/tritonparse/reproducer/function_extractor.py
@@ -451,8 +451,6 @@ def _extract_dict_keys(dict_node: ast.Dict) -> set[str]:
         if key is not None:
             if isinstance(key, ast.Constant) and isinstance(key.value, str):
                 keys.add(key.value)
-            elif isinstance(key, ast.Str):  # Python 3.7 compatibility
-                keys.add(key.s)
             elif isinstance(key, ast.Name):
                 # Handle unquoted identifier keys like {BLOCK_SIZE: 128}
                 keys.add(key.id)


### PR DESCRIPTION

# Summary

Fix https://github.com/meta-pytorch/tritonparse/issues/325

Migrates the GPU CI from the GitHub-hosted T4 runner (`4-core-ubuntu-gpu-t4`) to the PyTorch self-hosted A10G runner pool (`linux.g5.4xlarge.nvidia.gpu`), upgrades CUDA 12.8 → 13.0 and Python 3.13 → 3.14, switches Triton from a 30-50 minute source build to the upstream Triton team's official Triton-Nightly wheel feed, and adds native pip caching. Also lands two small Python-3.14-compatibility fixes that the migration surfaced.

**Verified end-to-end:** `Ran 642 tests in 44.95s. OK` on the new pipeline (Python 3.14.4 + cu130 + container + cache).

## Why

- T4 (Turing, sm_75) is being phased out for OSS CI; A10G (Ampere, sm_86) is the modern shared runner pool used by `autoparallel`, `vision`, `rl`, `torchcodec`, `executorch`, `helion`, etc.
- We want CUDA 13.x to match the rest of the PyTorch ecosystem; CUDA 13.0 is the highest version supported by the current G5 host driver (580.65.06).
- We want to test on the latest Python (3.14, released Oct 2025) — and the codebase already has a code path tagged for it (`tritonparse/_json_compat.py` references "CPython 3.14 free-threading builds").
- Resource bump: g5.4xlarge has 16 vCPU / 64 GiB RAM (vs the old 4-core T4 runner).
- The upstream Triton team's Triton-Nightly wheel feed is back online and ships full ABI matrix (cp310-cp314, x86_64 + aarch64), removing the need to build Triton from source on every CI run.

## What changes

### Workflow architecture

| Before | After |
|---|---|
| `runs-on: 4-core-ubuntu-gpu-t4` (Ubuntu, GitHub-hosted) | `runs-on: linux.g5.4xlarge.nvidia.gpu` + `container: pytorch/almalinux-builder:cuda13.0` |
| `.ci/setup.sh` provisions clang/CUDA/conda via `apt-get` | Container ships with CUDA 13.0 toolkit + conda 23.5.2 + Python 3.11 base, no provisioning needed |
| CUDA 12.8 | CUDA 13.0 (PyTorch nightly `cu130` wheel) |
| Python 3.13 | Python 3.14 (cp314 wheels confirmed available for torch / torchvision / torchaudio / triton / numpy / cuda_bindings) |
| 4 vCPU / T4 | 16 vCPU / A10G (sm_86) |
| `test-from-source` builds Triton from source (~30-50 min) | `test-from-nightly` `pip install`s Triton from the upstream Triton team's Triton-Nightly wheel feed (~30 sec) |

### Why `runs-on:` + `container:` (not `pytorch/test-infra/linux_job_v2.yml`)

Both are valid patterns for this runner. We considered `linux_job_v2.yml` (used by `autoparallel`) but chose direct `container:` (the `helion` pattern) because the reusable workflow's opaque `script:` block prevents `actions/cache` from caching paths inside the container — that costs us the ~70 s PyTorch wheel download on every run. Direct `container:` lets `actions/cache@v5` work normally. We give up the reusable workflow's auto NVIDIA driver freshness check, but the G5 AMI ships with driver 580.65.06 + nvidia-container-toolkit pre-configured (verified via probe), so `--gpus all` works directly.

### Caching

- **pip wheels**: `/github/home/.cache/pip` (GHA sets `HOME=/github/home` in container jobs, so this is pip's actual default cache dir per XDG — *not* `/root/.cache/pip` despite the container running as root). Keyed `Linux-pip-cu130-py3.14-YYYY-MM-DD` with `Linux-pip-cu130-py3.14-` restore-key fallback.
- **Triton source/build cache** is no longer needed (we install a prebuilt wheel).

First run after this lands will be cold (the cache key changed from `py3.13` → `py3.14`); subsequent runs will be warm. Expected `pip install` step time on warm cache: ~5 s vs ~70 s cold.

### Why CUDA 13.0 (not 13.2)

Probed CUDA 13.2 on 2026-04-29 and confirmed:
- The image `pytorch/almalinux-builder:cuda13.2` exists and pulls fine.
- It fails container start with `nvidia-container-cli: requirement error: unsatisfied condition: cuda>=13.2` because the host G5 driver (580.65.06) only exposes CUDA runtime 13.0; CUDA 13.2 needs driver 581+.

Bump to 13.2 once PyTorch infra rolls out a newer driver AMI. The single-line change (`PYTORCH_CUDA_TAG: cu130` → `cu132`) is documented in the workflow comments.

### Why install Triton from a nightly wheel (not source)

Wheel feed: `https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly/pypi/simple/`

The wheels are published with version `triton==3.7.0+gitXXXXXXXX`, built by the upstream Triton team from `triton-lang/triton` main — the *same* tree that the previous `install-triton.sh` cloned and compiled. The full ABI matrix (cp310-cp314 incl. cp313t/cp314t free-threading, x86_64 + aarch64) is published, so it works on our newly-bumped Python 3.14.

Trade-off: the wheel can lag "literal HEAD-of-main" by up to ~24 h. For tritonparse this is fine — we test against public Triton APIs that are stable across many commits.

The PyTorch nightly install pulls in a `pytorch-triton` snapshot (PyTorch's bundled fork). Both `pytorch-triton` and `triton` provide `import triton`, so the workflow does an explicit `pip uninstall -y pytorch-triton triton` before `pip install --pre triton --extra-index-url ...` to avoid a half-overwritten install.

### Python 3.14 compatibility fixes

Two small fixes uncovered by running the suite under 3.14:

1. **`ast.Str` removed**. `tritonparse/reproducer/function_extractor.py:454` had a Py 3.7 compatibility shim (`elif isinstance(key, ast.Str)`). Today it emits a `DeprecationWarning`; in **Python 3.14** `ast.Str` is removed and that `isinstance` line raises `AttributeError`, breaking the entire test suite. Removed (it was dead code under the project's `requires-python = ">=3.10"` floor — the preceding `ast.Constant` branch already handles all string keys). The corresponding test `test_extract_unquoted_keys` exercises the `ast.Name` branch, not `ast.Str` — no test coverage is lost.

2. **Git "dubious ownership" inside container**. After switching to `container:` mode, `pip install -e .` started failing in `setuptools-scm`'s git introspection with `fatal: detected dubious ownership in repository at '/__w/tritonparse/tritonparse'`. Root cause: `actions/checkout@v6` sets `safe.directory` to a *temporary* `$HOME` that is discarded after the step ends, so subsequent steps see no exception; the container runs as root (uid 0) but the host workspace is owned by ec2-user (uid 1000) and bind-mounted with host UIDs intact. Added a one-line step right after checkout that persists `safe.directory $GITHUB_WORKSPACE` to `/github/home/.gitconfig` (the container's real HOME) so all later steps inherit it.

### Other cleanup

- `if: github.event_name == 'workflow_dispatch'` guard removed from GPU jobs — they now run on `push` / `pull_request` / `workflow_dispatch` like the old T4 jobs did.
- Jobs renamed: `test-from-source` → `test-from-nightly` (now fetches a prebuilt nightly wheel rather than building from source); `test-from-pip` kept (still tests against PyTorch's bundled `pytorch-triton` snapshot — what most users actually run).
- Container env (`TORCH_CUDA_ARCH_LIST=8.6` for A10G, `CONDA_ENV`, `PYTHON_VERSION`, `PYTORCH_CUDA_TAG=cu130`, `TRITON_NIGHTLY_INDEX_URL`) hoisted to job-level `env:` for clarity.
- Removed the unused `Get weekly cache timestamp` step (only daily rollover is in use).
- Removed the `Get Triton latest commit` / `Cache Triton source and build` / `Install Triton from source` steps along with their dependencies (no source build → no commit-fetch, no source cache, no build cache).
- Fixed two issues caught in PR review: pip cache path now uses `/github/home/.cache/pip` (was caching the wrong, empty `/root/.cache/pip`), and `.ci/install-triton.sh`'s libstdc++ verification now uses `${CONDA_PREFIX}` instead of a hardcoded `/opt/miniconda3/envs/tritonparse/...` path.
- `.ci/install-triton.sh` no longer hardcodes `CC=clang/CXX=clang++`; it uses clang only when available and falls back to gcc otherwise (the AlmaLinux 8 builder image only has gcc-toolset-13).
- `.ci/README.md`'s stale doc default `PYTHON_VERSION: "3.11"` synced to `"3.14"`; added a NOTE to the `install-triton.sh` section that the CI workflow no longer invokes it.
- `workflow_dispatch` inputs (`test-type`, `coverage`) preserved for manual invocation.

### Intentionally NOT changed

- `.ci/setup.sh` — preserved as-is for local development on a fresh Ubuntu workstation. The new CI path bypasses it.
- `.ci/install-triton.sh` — kept (not deleted) so users can still test against a specific upstream Triton commit locally (`TRITON_COMMIT=<sha> bash .ci/install-triton.sh`). Not invoked from CI anymore.
- `.ci/install-project.sh` / `run-tests.sh` — already updated in an earlier commit on this branch to discover conda dynamically (`$CONDA_HOME` → `conda info --base` → `/opt/miniconda3` fallback). This keeps them working in both the new container path (`/opt/conda`) and the legacy `setup.sh` path (`/opt/miniconda3`).
- `pyproject.toml`'s `requires-python = ">=3.10"` — sets the floor, not the default. Docs that quote `Python >= 3.10` as a prerequisite are likewise correct as-is.

## Commits in this PR

1. `ci: add probe jobs to inspect new GPU runner environment` — initial probe to learn the AL2023 host environment (`whoami`, `nvidia-smi`, `/usr/local/cuda*`, conda paths, PyTorch wheel index reachability, etc.).
2. `ci: add A10G self-hosted GPU jobs via linux_job_v2.yml; remove probes` — first stab using the reusable workflow (worked, but didn't support `actions/cache`).
3. `fix: remove dead ast.Str branch in _extract_dict_keys` — Py 3.14 readiness fix surfaced by CI logs.
4. `ci: switch GPU jobs to A10G self-hosted runner with native caching` — final architecture: direct `container:` + `actions/cache`.
5. `ci: bump default Python from 3.13 to 3.14` — version bump across `test.yml`, `nightly-pypi.yml`, `setup.sh`, `.ci/README.md`.
6. `ci: persist git safe.directory for setuptools-scm in container` — fix for the dubious-ownership failure surfaced by the `container:` switch.
7. `ci: fix pip cache path and libstdc++ hardcoded path` — caught in PR review: pip cache was caching the wrong path (`/root/.cache/pip`) so it never worked; `install-triton.sh`'s libstdc++ check was reading a path that doesn't exist in the new container.
8. `ci: only use clang for Triton build if it's available` — guard the `CC=clang/CXX=clang++` export in `install-triton.sh` so it falls back to gcc on systems without clang (e.g. the new AlmaLinux container, where `pip install -e .` for Triton was failing with `Could not find compiler clang++`).
9. `ci: install Triton from the upstream Triton team's nightly wheel feed instead of source` — replaces the ~30-50 min source build with a ~30 s `pip install --pre triton --extra-index-url <Triton-Nightly>`. Removes the Triton-commit-fetch / source-cache / install-triton steps. Renames the job `test-from-source` → `test-from-nightly`.

## Test plan

- [x] Probed bare-metal AL2023 host environment — confirmed AL2023, ephemeral EC2, NVIDIA driver 580.65.06, no preinstalled conda/CUDA/clang on the host.
- [x] Probed `pytorch/test-infra/linux_job_v2.yml@main` with `gpu-arch-version: 12.8 / 13.0 / 13.2` — confirmed 13.0 works, 13.2 fails with the driver-cap error described above.
- [x] Ran the full test suite via `linux_job_v2.yml + cuda13.0 + Py 3.13` on a real A10G runner — `Ran 642 tests in 44.137s. OK`.
- [x] Switched to `runs-on:` + `container:` pattern, hit the dubious-ownership bug.
- [x] Bumped to Python 3.14 — confirmed `cp314` wheels exist on the PyTorch nightly cu130 index for torch / torchvision / torchaudio / triton / numpy / cuda_bindings, and on the upstream Triton-Nightly feed for `triton`.
- [x] Added the `safe.directory` step — full suite now passes end-to-end on the `test-from-pip` pipeline: `Ran 642 tests in 44.950s. OK` (Python 3.14.4 + cu130 + container + cache).
- [x] Caught and fixed in review: pip cache path (`/root/.cache/pip` → `/github/home/.cache/pip`) and libstdc++ hardcoded path (`/opt/miniconda3/...` → `${CONDA_PREFIX}`).
- [x] Caught the `clang` not-found failure in `install-triton.sh` source-build path; added a fallback to gcc.
- [ ] Verify `test-from-nightly` (the new Triton-nightly-wheel path) end-to-end on this PR's CI run.
- [ ] Watch the second run (warm cache) — `test-from-nightly` should complete in ~3 min and `test-from-pip` in ~3 min.

## Rollback plan

Revert this PR. The legacy `4-core-ubuntu-gpu-t4` runner pool is still available and `.ci/setup.sh` is unchanged, so reverting restores the previous CI exactly. No data migration, no external state. Per-feature rollback is also easy:

- Roll back to Python 3.13 only: revert commit 5 (one-line edits in 4 files).
- Roll back the safe.directory fix only: revert commit 6 (delete one step in two jobs).
- Roll back to source-built Triton: revert commit 9 (re-adds the Triton-commit-fetch / source-cache / install-triton-from-source steps and renames the job back to `test-from-source`). `.ci/install-triton.sh` was preserved precisely to make this revert clean.
- Roll back to `linux_job_v2.yml`: revert commits 4 + 6 + 7 + 8 + 9.

## Follow-ups (not in this PR)

- Bump `PYTORCH_CUDA_TAG: cu130` → `cu132` once PyTorch infra ships an AMI with NVIDIA driver 581+.
- Optional: if `.ci/install-triton.sh` truly never gets used again over the next few months, delete it (and the `install-triton.sh` README section). Kept for now as an escape hatch for "test against this exact upstream Triton commit" workflows.
