### PR TITLE
[bisect] Cleanup $HOME/.triton as the llvm dir during build

### DIFF
--- a/tritonparse/bisect/scripts/bisect_triton.sh
+++ b/tritonparse/bisect/scripts/bisect_triton.sh
@@ -185,8 +185,10 @@ fi
 echo "" | log_output
 
 # Clean build directory to avoid stale artifacts from previous commits
+# Clean $HOME/.triton directory too
 echo "Cleaning build directory..." | log_output
 rm -rf "$TRITON_DIR/build"
+rm -rf "$HOME/.triton" || true
 rm -rf "$TRITON_DIR/python/triton.egg-info"
 echo "" | log_output
 


### PR DESCRIPTION
When the bisection range includes a LLVM bump, the old `$HOME/.triton` directory can't be used in the build because there will be build failure.

Always remove `$HOME/.triton` directory to make sure the build is fresh.