### PR TITLE
Analysis Dispatch Refactoring — From Hardcoded to Adapter-Driven Analysis Registration and Scheduling

### DIFF
--- a/docs/07.-Environment-Variables-Reference.md
+++ b/docs/07.-Environment-Variables-Reference.md
@@ -435,7 +435,7 @@ These variables control which IR analyses are performed during trace parsing.
 |----------|-------|
 | **Values** | `"all"`, `"none"`, or comma-separated analysis names (e.g. `"loop_schedules,procedure_checks"`) |
 | **Default** | `"all"` (all analyses enabled) |
-| **Available analyses** | `loop_schedules`, `procedure_checks` |
+| **Available analyses** | `loop_schedules`, `procedure_checks`, `amd_buffer_ops` (AMD only) |
 
 **Example**:
 ```bash

--- a/docs/07.-Environment-Variables-Reference.md
+++ b/docs/07.-Environment-Variables-Reference.md
@@ -62,6 +62,7 @@ tritonparse.structured_logging.init()
 | `TRITONPARSE_TENSOR_SAVE_MAX_RUNS` | Save blobs for at most N runs | `0` (unlimited) | Tensor Info |
 | `TRITON_FULL_PYTHON_SOURCE` | Full source extraction | Off | Source |
 | `TRITON_MAX_SOURCE_SIZE` | Max source file size | 10MB | Source |
+| `TRITONPARSE_ANALYSIS` | Select which analyses to run | `"all"` | Analysis |
 | `TEST_KEEP_OUTPUT` | Keep test outputs | Off | Testing |
 | `TORCHINDUCTOR_FX_GRAPH_CACHE` | PyTorch FX cache | On | Testing |
 
@@ -419,6 +420,37 @@ export TRITONPARSE_DUMP_SASS="1"
 ```
 
 > ⚠️ **Warning**: Significantly slows down compilation. Only enable when needed for low-level analysis.
+
+---
+
+## 🔬 Analysis Variables
+
+These variables control which IR analyses are performed during trace parsing.
+
+### TRITONPARSE_ANALYSIS
+
+**Description**: Select which IR analyses to run during trace parsing. Allows fine-grained control over analysis passes such as loop schedule extraction and procedure checks.
+
+| Property | Value |
+|----------|-------|
+| **Values** | `"all"`, `"none"`, or comma-separated analysis names (e.g. `"loop_schedules,procedure_checks"`) |
+| **Default** | `"all"` (all analyses enabled) |
+| **Available analyses** | `loop_schedules`, `procedure_checks` |
+
+**Example**:
+```bash
+# Run all analyses (default)
+export TRITONPARSE_ANALYSIS="all"
+
+# Disable all analyses
+export TRITONPARSE_ANALYSIS="none"
+
+# Run only specific analyses
+export TRITONPARSE_ANALYSIS="loop_schedules"
+export TRITONPARSE_ANALYSIS="loop_schedules,procedure_checks"
+```
+
+> 💡 **Use case**: Use `"none"` to skip analysis overhead when only raw trace data is needed. Use specific names to run only the analyses relevant to your debugging scenario.
 
 ---
 

--- a/tests/cpu/test_multi_backend_stage.py
+++ b/tests/cpu/test_multi_backend_stage.py
@@ -8,16 +8,13 @@ from tritonparse.backend import (
     NvidiaTritonAdapter,
     PipelineAdapterRegistry,
 )
-from tritonparse.parse.ir_analysis import (
-    _generate_ir_analysis,
-    AnalysisRegistry,
-)
-from tritonparse.shared_vars import get_enabled_analyses
+from tritonparse.parse.ir_analysis import _generate_ir_analysis, AnalysisRegistry
 from tritonparse.parse.ir_parser import ParserRegistry
 from tritonparse.parse.trace_processor import (
     _resolve_source_mappable_stage_keys,
     generate_source_mappings,
 )
+from tritonparse.shared_vars import get_enabled_analyses
 
 
 def make_event(file_content: dict, stage_descriptors: list | None = None):
@@ -364,11 +361,11 @@ class TestAnalysisAdapterDriven(unittest.TestCase):
         self.assertEqual(_generate_ir_analysis(empty_trace), {})
 
     def test_analysis_legacy_path(self):
-        """Legacy path (no backend_name): returns dict with artifacts, empty dict without."""
+        """Fallback to legacy when adapter resolution fails."""
         # With artifacts
-        old_trace = {
+        fallback_trace = {
             "payload": {
-                "metadata": {},
+                "metadata": {"backend_name": "unknown"},
                 "file_content": {
                     "kernel.ttgir": "ttgir content",
                     "kernel.amdgcn": "amdgcn content",
@@ -377,14 +374,16 @@ class TestAnalysisAdapterDriven(unittest.TestCase):
                 "source_mappings": {},
             }
         }
-        self.assertIsInstance(_generate_ir_analysis(old_trace), dict)
+        result = _generate_ir_analysis(fallback_trace)
+        self.assertIsInstance(result, dict)
+        self.assertIn("io_counts", result)
 
         # Without artifacts
         self.assertEqual(
             _generate_ir_analysis(
                 {
                     "payload": {
-                        "metadata": {},
+                        "metadata": {"backend_name": "unknown"},
                         "file_content": {},
                         "file_path": {},
                         "source_mappings": {},
@@ -486,9 +485,7 @@ class TestAnalysisAdapterDriven(unittest.TestCase):
 
         # Comma-separated with spaces → trimmed set
         os.environ["TRITONPARSE_ANALYSIS"] = " amd_buffer_ops , loop_schedules "
-        self.assertEqual(
-            get_enabled_analyses(), {"amd_buffer_ops", "loop_schedules"}
-        )
+        self.assertEqual(get_enabled_analyses(), {"amd_buffer_ops", "loop_schedules"})
 
 
 if __name__ == "__main__":

--- a/tests/cpu/test_multi_backend_stage.py
+++ b/tests/cpu/test_multi_backend_stage.py
@@ -4,6 +4,7 @@ import unittest
 from tritonparse.backend import (
     AmdTritonAdapter,
     deserialize_stage_descriptors_from_event,
+    get_backend_registry,
     NvidiaTritonAdapter,
     PipelineAdapterRegistry,
 )
@@ -316,9 +317,8 @@ class TestAnalysisAdapterDriven(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        self.registry = PipelineAdapterRegistry()
-        self.registry.register(NvidiaTritonAdapter)
-        self.registry.register(AmdTritonAdapter)
+        # Use the module-level registry (same one the dispatcher uses)
+        self.registry = get_backend_registry()
 
         # Save original environment variable
         self.original_env = os.environ.get("TRITONPARSE_ANALYSIS")
@@ -441,7 +441,7 @@ class TestAnalysisAdapterDriven(unittest.TestCase):
         """Each analysis pass's required_stages should exist in the adapter."""
         amd_adapter = self.registry.resolve(adapter_name="hip_triton")
         for pass_name in amd_adapter.get_analysis_passes():
-            info = AnalysisRegistry._analyzer_infos.get(pass_name)
+            info = AnalysisRegistry.get_analyzer_info(pass_name)
             self.assertIsNotNone(info, f"Analyzer '{pass_name}' should be registered")
             for stage_name in info.required_stages:
                 self.assertIsNotNone(

--- a/tests/cpu/test_multi_backend_stage.py
+++ b/tests/cpu/test_multi_backend_stage.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 
 from tritonparse.backend import (
@@ -5,6 +6,11 @@ from tritonparse.backend import (
     deserialize_stage_descriptors_from_event,
     NvidiaTritonAdapter,
     PipelineAdapterRegistry,
+)
+from tritonparse.parse.ir_analysis import (
+    _generate_ir_analysis,
+    _get_user_enabled_analyses,
+    AnalysisRegistry,
 )
 from tritonparse.parse.ir_parser import ParserRegistry
 from tritonparse.parse.trace_processor import (
@@ -303,6 +309,186 @@ class TestMultiBackendStage(unittest.TestCase):
                 generate_source_mappings(ttir_content, "ttir", None, metadata_cuda)
         finally:
             ParserRegistry.register("generic_loc", original_generic_parser)
+
+
+class TestAnalysisAdapterDriven(unittest.TestCase):
+    """Comprehensive tests for adapter-driven IR analysis (new traces with metadata)."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.registry = PipelineAdapterRegistry()
+        self.registry.register(NvidiaTritonAdapter)
+        self.registry.register(AmdTritonAdapter)
+
+        # Save original environment variable
+        self.original_env = os.environ.get("TRITONPARSE_ANALYSIS")
+
+    def tearDown(self):
+        """Clean up after tests."""
+        # Restore original environment variable
+        if self.original_env is None:
+            os.environ.pop("TRITONPARSE_ANALYSIS", None)
+        else:
+            os.environ["TRITONPARSE_ANALYSIS"] = self.original_env
+
+    def test_analysis_adapter_driven_path(self):
+        """Adapter-driven path: returns dict with artifacts, empty dict without."""
+        # With artifacts (both backends)
+        for backend in ("hip", "cuda"):
+            trace = {
+                "payload": {
+                    "metadata": {"backend_name": backend},
+                    "file_content": {
+                        "kernel.ttir": "ttir content",
+                        "kernel.ttgir": "ttgir content",
+                    },
+                    "file_path": {},
+                    "source_mappings": {},
+                }
+            }
+            self.assertIsInstance(
+                _generate_ir_analysis(trace),
+                dict,
+                f"{backend} backend should return dict",
+            )
+
+        # Without artifacts
+        empty_trace = {
+            "payload": {
+                "metadata": {"backend_name": "hip"},
+                "file_content": {},
+                "file_path": {},
+                "source_mappings": {},
+            }
+        }
+        self.assertEqual(_generate_ir_analysis(empty_trace), {})
+
+    def test_analysis_legacy_path(self):
+        """Legacy path (no backend_name): returns dict with artifacts, empty dict without."""
+        # With artifacts
+        old_trace = {
+            "payload": {
+                "metadata": {},
+                "file_content": {
+                    "kernel.ttgir": "ttgir content",
+                    "kernel.amdgcn": "amdgcn content",
+                },
+                "file_path": {},
+                "source_mappings": {},
+            }
+        }
+        self.assertIsInstance(_generate_ir_analysis(old_trace), dict)
+
+        # Without artifacts
+        self.assertEqual(
+            _generate_ir_analysis(
+                {
+                    "payload": {
+                        "metadata": {},
+                        "file_content": {},
+                        "file_path": {},
+                        "source_mappings": {},
+                    }
+                }
+            ),
+            {},
+        )
+
+    def test_analysis_env_var_disables_all(self):
+        """TRITONPARSE_ANALYSIS='none' or '' disables all analyses."""
+        trace = {
+            "payload": {
+                "metadata": {"backend_name": "hip"},
+                "file_content": {
+                    "kernel.ttgir": "ttgir content",
+                    "kernel.amdgcn": "amdgcn content",
+                },
+                "file_path": {},
+                "source_mappings": {},
+            }
+        }
+
+        for val in ("none", ""):
+            os.environ["TRITONPARSE_ANALYSIS"] = val
+            self.assertEqual(
+                _generate_ir_analysis(trace), {}, f"env='{val}' should disable all"
+            )
+
+    def test_analysis_registry_common_and_backend_analyzers(self):
+        """Common and backend-specific analyzers are all registered after adapter init."""
+        for analyzer_id in ("loop_schedules", "procedure_checks", "amd_buffer_ops"):
+            self.assertIsNotNone(
+                AnalysisRegistry.get_analyzer(analyzer_id),
+                f"Analyzer '{analyzer_id}' should be registered",
+            )
+
+    def test_analysis_adapter_passes_differ_by_backend(self):
+        """NVIDIA only has common passes; AMD additionally has amd_buffer_ops."""
+        nvidia_passes = set(
+            self.registry.resolve(adapter_name="cuda_triton").get_analysis_passes()
+        )
+        amd_passes = set(
+            self.registry.resolve(adapter_name="hip_triton").get_analysis_passes()
+        )
+
+        self.assertIn("loop_schedules", nvidia_passes)
+        self.assertNotIn("amd_buffer_ops", nvidia_passes)
+
+        self.assertIn("loop_schedules", amd_passes)
+        self.assertIn("amd_buffer_ops", amd_passes)
+
+    def test_analysis_adapter_required_stages_consistency(self):
+        """Each analysis pass's required_stages should exist in the adapter."""
+        amd_adapter = self.registry.resolve(adapter_name="hip_triton")
+        for pass_name in amd_adapter.get_analysis_passes():
+            info = AnalysisRegistry._analyzer_infos.get(pass_name)
+            self.assertIsNotNone(info, f"Analyzer '{pass_name}' should be registered")
+            for stage_name in info.required_stages:
+                self.assertIsNotNone(
+                    amd_adapter.get_stage_by_name(stage_name),
+                    f"Required stage '{stage_name}' should exist in AMD adapter",
+                )
+
+    def test_analysis_adapter_run_analysis_pass(self):
+        """run_analysis_pass: empty artifacts → None; invalid analyzer → ValueError."""
+        amd_adapter = self.registry.resolve(adapter_name="hip_triton")
+        test_entry = {
+            "payload": {
+                "metadata": {"backend_name": "hip"},
+                "file_content": {},
+                "file_path": {},
+                "source_mappings": {},
+            }
+        }
+
+        # Empty artifacts → analyzer skips due to missing required_stages
+        self.assertIsNone(
+            amd_adapter.run_analysis_pass("amd_buffer_ops", test_entry, None)
+        )
+
+        with self.assertRaises(ValueError):
+            amd_adapter.run_analysis_pass("nonexistent_analyzer", test_entry, None)
+
+    def test_get_enabled_analyses_helper_function(self):
+        """Test _get_user_enabled_analyses() with default, ALL/none keywords, and comma list."""
+        # Default (no env var) → enable all
+        if "TRITONPARSE_ANALYSIS" in os.environ:
+            del os.environ["TRITONPARSE_ANALYSIS"]
+        self.assertIsNone(_get_user_enabled_analyses())
+
+        # "ALL" → enable all (also covers case insensitivity)
+        os.environ["TRITONPARSE_ANALYSIS"] = "ALL"
+        self.assertIsNone(_get_user_enabled_analyses())
+
+        # "none" → disable all
+        os.environ["TRITONPARSE_ANALYSIS"] = "none"
+        self.assertEqual(_get_user_enabled_analyses(), set())
+
+        # Comma-separated with spaces → trimmed set
+        os.environ["TRITONPARSE_ANALYSIS"] = " amd_buffer_ops , loop_schedules "
+        self.assertEqual(
+            _get_user_enabled_analyses(), {"amd_buffer_ops", "loop_schedules"}
+        )
 
 
 if __name__ == "__main__":

--- a/tests/cpu/test_multi_backend_stage.py
+++ b/tests/cpu/test_multi_backend_stage.py
@@ -9,9 +9,9 @@ from tritonparse.backend import (
 )
 from tritonparse.parse.ir_analysis import (
     _generate_ir_analysis,
-    _get_user_enabled_analyses,
     AnalysisRegistry,
 )
+from tritonparse.shared_vars import get_enabled_analyses
 from tritonparse.parse.ir_parser import ParserRegistry
 from tritonparse.parse.trace_processor import (
     _resolve_source_mappable_stage_keys,
@@ -470,24 +470,24 @@ class TestAnalysisAdapterDriven(unittest.TestCase):
             amd_adapter.run_analysis_pass("nonexistent_analyzer", test_entry, None)
 
     def test_get_enabled_analyses_helper_function(self):
-        """Test _get_user_enabled_analyses() with default, ALL/none keywords, and comma list."""
+        """Test get_enabled_analyses() with default, ALL/none keywords, and comma list."""
         # Default (no env var) → enable all
         if "TRITONPARSE_ANALYSIS" in os.environ:
             del os.environ["TRITONPARSE_ANALYSIS"]
-        self.assertIsNone(_get_user_enabled_analyses())
+        self.assertIsNone(get_enabled_analyses())
 
         # "ALL" → enable all (also covers case insensitivity)
         os.environ["TRITONPARSE_ANALYSIS"] = "ALL"
-        self.assertIsNone(_get_user_enabled_analyses())
+        self.assertIsNone(get_enabled_analyses())
 
         # "none" → disable all
         os.environ["TRITONPARSE_ANALYSIS"] = "none"
-        self.assertEqual(_get_user_enabled_analyses(), set())
+        self.assertEqual(get_enabled_analyses(), set())
 
         # Comma-separated with spaces → trimmed set
         os.environ["TRITONPARSE_ANALYSIS"] = " amd_buffer_ops , loop_schedules "
         self.assertEqual(
-            _get_user_enabled_analyses(), {"amd_buffer_ops", "loop_schedules"}
+            get_enabled_analyses(), {"amd_buffer_ops", "loop_schedules"}
         )
 
 

--- a/tritonparse/backend.py
+++ b/tritonparse/backend.py
@@ -147,7 +147,7 @@ class CompilationPipelineAdapter(ABC):
 
             # Check 2: Are required stages available?
             info = AnalysisRegistry.get_analyzer_info(analyzer_name)
-            if not info or not info.required_stages:
+            if not info:
                 continue
 
             stages_available = True
@@ -202,7 +202,7 @@ class CompilationPipelineAdapter(ABC):
         self,
         analyzer_id: str,
         analyzer_func,
-        required_stages: tuple[str, ...] = (),
+        required_stages: tuple[str, ...],
     ) -> None:
         """
         Register a backend-specific analyzer to the analyzer registry.

--- a/tritonparse/backend.py
+++ b/tritonparse/backend.py
@@ -49,19 +49,6 @@ class DerivedArtifactDescriptor:
     tool_name: str
 
 
-@dataclass(frozen=True)
-class AnalysisPassDescriptor:
-    """Describes an analysis pass that operates on specific compilation stages.
-
-    Fields:
-        name: Name of the analysis pass.
-        required_stages: Tuple of stage names that must be present for this pass to run.
-    """
-
-    name: str
-    required_stages: tuple[str, ...]
-
-
 class CompilationPipelineAdapter(ABC):
     """Abstract base class for compilation pipeline adapters.
 
@@ -109,8 +96,133 @@ class CompilationPipelineAdapter(ABC):
     def get_derived_artifacts(self) -> list[DerivedArtifactDescriptor]:
         return []
 
-    def get_analysis_passes(self) -> list[AnalysisPassDescriptor]:
-        return []
+    def get_analysis_passes(self) -> list[str]:
+        """
+        Return list of analysis pass names for this adapter.
+
+        Base implementation: gets analyzers from AnalysisRegistry
+        that match this adapter's affinity or are common (no affinity).
+
+        Can be overridden by subclasses for custom behavior.
+        """
+        from tritonparse.parse.ir_analysis import AnalysisRegistry
+
+        my_name = self.adapter_name
+        analyzer_names = []
+
+        for _, info in AnalysisRegistry._analyzer_infos.items():
+            # Include analyzers specific to this adapter or common analyzers
+            if info.adapter_affinity in (my_name, None):
+                analyzer_names.append(info.name)
+
+        return analyzer_names
+
+    def get_executable_analyzers(
+        self,
+        file_content: dict[str, str],
+        enabled_analyses: set[str] | None = None,
+    ) -> list[str]:
+        """
+        Get list of analyzers that can be executed based on:
+        1. User-enabled analyses (from environment variable)
+        2. Available intermediate products (file_content)
+
+        Args:
+            file_content: Dictionary mapping file keys to file content
+            enabled_analyses: User-enabled analysis names (None = all)
+
+        Returns:
+            List of executable analyzer names
+        """
+        from tritonparse.parse.ir_analysis import AnalysisRegistry
+
+        # Get declared analyzers for this adapter (already registered)
+        declared_analyzers = self.get_analysis_passes()
+        executable = []
+
+        for analyzer_name in declared_analyzers:
+            # Check 1: Is it enabled by user?
+            if enabled_analyses is not None and analyzer_name not in enabled_analyses:
+                continue
+
+            # Check 2: Are required stages available?
+            info = AnalysisRegistry.get_analyzer_info(analyzer_name)
+            if not info or not info.required_stages:
+                continue
+
+            stages_available = True
+            for stage_name in info.required_stages:
+                stage = self.get_stage_by_name(stage_name)
+                if not stage:
+                    stages_available = False
+                    break
+
+                # Check if any file in file_content has this stage's extension
+                if not any(k.endswith(stage.extension) for k in file_content):
+                    stages_available = False
+                    break
+
+            if stages_available:
+                executable.append(analyzer_name)
+
+        return executable
+
+    def run_analysis_pass(
+        self,
+        pass_name: str,
+        entry: dict,
+        procedure_checks: list | None = None,
+    ) -> dict[str, Any]:
+        """
+        Execute the specified analysis pass.
+
+        Args:
+            pass_name: Analysis name (e.g., "amd_buffer_ops", "loop_schedules")
+            entry: Trace entry (contains payload)
+            procedure_checks: Procedure checks configuration
+
+        Returns:
+            Analysis result dictionary
+
+        Raises:
+            ValueError: If the pass_name is not found in the registry
+        """
+        from tritonparse.parse.ir_analysis import AnalysisRegistry
+
+        analyzer = AnalysisRegistry.get_analyzer(pass_name)
+        if analyzer is None:
+            available = AnalysisRegistry.list_analyzers()
+            raise ValueError(
+                f"Analyzer '{pass_name}' not found. Available analyzers: {available}"
+            )
+
+        return analyzer(entry, procedure_checks)
+
+    def register_backend_analyzer(
+        self,
+        analyzer_id: str,
+        analyzer_func,
+        required_stages: tuple[str, ...] = (),
+    ) -> None:
+        """
+        Register a backend-specific analyzer to the analyzer registry.
+
+        This allows adapters to register custom analyzers for backend-specific
+        analysis passes that are not part of the common analyzer registry.
+
+        Args:
+            analyzer_id: The analyzer identifier (e.g., "amd_buffer_ops")
+            analyzer_func: The analyzer function with signature
+                          (entry, procedure_checks) -> dict | None
+            required_stages: Required stage names (e.g., ("ttgir", "amdgcn"))
+        """
+        from tritonparse.parse.ir_analysis import AnalysisRegistry
+
+        # Use this adapter's name as affinity
+        adapter_affinity = self.adapter_name
+        AnalysisRegistry.register(
+            analyzer_id, analyzer_func, required_stages, adapter_affinity
+        )
 
     def normalize_device_string(self, device: str) -> str:
         return device
@@ -208,11 +320,19 @@ class NvidiaTritonAdapter(CompilationPipelineAdapter):
 
 class AmdTritonAdapter(CompilationPipelineAdapter):
     def __init__(self):
-        """Initialize and register backend-specific parsers and stage descriptors."""
+        """Initialize and register backend-specific parsers and analyzers."""
+        from tritonparse.parse.ir_analysis import _analyze_amd_buffer_ops
         from tritonparse.parse.ir_parser import _parse_amdgcn_loc
 
         # Register AMD-specific parsers
         self.register_backend_parser("amdgcn_loc", _parse_amdgcn_loc)
+
+        # Register AMD-specific analyzers
+        self.register_backend_analyzer(
+            "amd_buffer_ops",
+            _analyze_amd_buffer_ops,
+            required_stages=("ttgir", "amdgcn"),
+        )
 
         # Pre-initialize stage descriptors (immutable objects, can be reused)
         self._stages = [

--- a/tritonparse/backend.py
+++ b/tritonparse/backend.py
@@ -110,7 +110,7 @@ class CompilationPipelineAdapter(ABC):
         my_name = self.adapter_name
         analyzer_names = []
 
-        for _, info in AnalysisRegistry._analyzer_infos.items():
+        for _, info in AnalysisRegistry.list_analyzer_infos():
             # Include analyzers specific to this adapter or common analyzers
             if info.adapter_affinity in (my_name, None):
                 analyzer_names.append(info.name)

--- a/tritonparse/parse/ir_analysis.py
+++ b/tritonparse/parse/ir_analysis.py
@@ -72,7 +72,9 @@ class AnalysisRegistry:
                            None means common/shared analyzer.
         """
         if analyzer_id in cls._analyzer_infos:
-            logger.debug(f"Analyzer '{analyzer_id}' is already registered. Overwriting.")
+            logger.debug(
+                f"Analyzer '{analyzer_id}' is already registered. Overwriting."
+            )
         info = AnalyzerInfo(
             name=analyzer_id,
             func=analyzer_func,
@@ -101,7 +103,6 @@ class AnalysisRegistry:
     def list_analyzer_infos(cls) -> list[tuple[str, AnalyzerInfo]]:
         """List all registered (analyzer_id, AnalyzerInfo) pairs."""
         return list(cls._analyzer_infos.items())
-
 
 
 # =============================================================================
@@ -1050,8 +1051,8 @@ def _generate_ir_analysis(
     Generate IR analysis results (adapter-driven with fallback).
 
     Two-level dispatch:
-    1. Priority: Adapter-driven (for traces with backend_name in metadata)
-    2. Fallback: Hardcoded logic (for traces without backend_name)
+    1. Priority: Adapter-driven
+    2. Fallback: Hardcoded legacy logic when adapter resolution fails
 
     Both paths honor the ``TRITONPARSE_ANALYSIS`` environment variable.
 
@@ -1068,22 +1069,14 @@ def _generate_ir_analysis(
         logger.debug("All analyses are disabled via TRITONPARSE_ANALYSIS env var")
         return {}
 
-    payload = entry.get("payload", {})
-    metadata = payload.get("metadata", {})
+    try:
+        return _generate_ir_analysis_adapter_driven(
+            entry, procedure_checks, enabled_analyses
+        )
+    except ValueError as e:
+        logger.warning(f"Adapter-driven analysis failed: {e}. Falling back to legacy.")
 
-    # Try adapter-driven path when backend_name is available
-    backend_name = metadata.get("backend_name")
-    if isinstance(backend_name, str):
-        try:
-            return _generate_ir_analysis_adapter_driven(
-                entry, procedure_checks, enabled_analyses
-            )
-        except ValueError as e:
-            logger.warning(
-                f"Adapter-driven analysis failed: {e}. Falling back to legacy."
-            )
-
-    # Fallback: hardcoded logic (for traces without backend_name or adapter failure)
+    # Fallback: hardcoded legacy logic when adapter resolution fails
     return _generate_ir_analysis_legacy(entry, procedure_checks, enabled_analyses)
 
 
@@ -1164,14 +1157,18 @@ def _generate_ir_analysis_legacy(
         logger.debug("No IR found")
         return {}
     ir_analysis = {}
-    if amdgcn_key and ttgir_key and (
-        enabled_analyses is None or "amd_buffer_ops" in enabled_analyses
+    if (
+        amdgcn_key
+        and ttgir_key
+        and (enabled_analyses is None or "amd_buffer_ops" in enabled_analyses)
     ):
         io_counts = _analyze_buffer_ops(ttgir_key, amdgcn_key, file_content, file_path)
         if io_counts:
             ir_analysis["io_counts"] = io_counts
-    if ttir_key and ttgir_key and (
-        enabled_analyses is None or "loop_schedules" in enabled_analyses
+    if (
+        ttir_key
+        and ttgir_key
+        and (enabled_analyses is None or "loop_schedules" in enabled_analyses)
     ):
         loop_schedule = _analyze_loop_schedules(
             ttir_key, ttgir_key, file_content, file_path, payload, source_mappings
@@ -1179,8 +1176,10 @@ def _generate_ir_analysis_legacy(
         if loop_schedule:
             ir_analysis["loop_schedules"] = loop_schedule
 
-    if procedure_checks and ttgir_key and (
-        enabled_analyses is None or "procedure_checks" in enabled_analyses
+    if (
+        procedure_checks
+        and ttgir_key
+        and (enabled_analyses is None or "procedure_checks" in enabled_analyses)
     ):
         procedure_results = find_procedures_with_patterns(
             procedure_checks,
@@ -1198,7 +1197,7 @@ def _generate_ir_analysis_legacy(
 # =============================================================================
 # STANDARDIZED ANALYZER WRAPPERS
 # =============================================================================
-# Wrappers use dot-extension lists (e.g. [".ttir"]) to match raw file_content keys; 
+# Wrappers use dot-extension lists (e.g. [".ttir"]) to match raw file_content keys;
 # adapter registration uses bare stage names (e.g. "ttir").
 def _validate_required_stages(
     file_content: dict[str, str],
@@ -1367,7 +1366,6 @@ def _analyze_procedures_generic(
     if procedure_results:
         return {"procedure_checks": procedure_results}
     return None
-
 
 
 # =============================================================================

--- a/tritonparse/parse/ir_analysis.py
+++ b/tritonparse/parse/ir_analysis.py
@@ -8,6 +8,7 @@ import tempfile
 from dataclasses import asdict, dataclass, field
 from typing import Any, Callable
 
+from tritonparse.shared_vars import get_enabled_analyses
 from tritonparse.tp_logger import get_logger
 
 from .sourcemap_utils import load_ir_contents
@@ -1045,8 +1046,10 @@ def _generate_ir_analysis(
     Generate IR analysis results (adapter-driven with fallback).
 
     Two-level dispatch:
-    1. Priority: Adapter-driven (for new traces with backend_name in metadata)
-    2. Fallback: Hardcoded logic (for old traces without backend_name)
+    1. Priority: Adapter-driven (for traces with backend_name in metadata)
+    2. Fallback: Hardcoded logic (for traces without backend_name)
+
+    Both paths honor the ``TRITONPARSE_ANALYSIS`` environment variable.
 
     Args:
         entry: Trace entry containing payload
@@ -1055,6 +1058,12 @@ def _generate_ir_analysis(
     Returns:
         Dictionary of analysis results
     """
+    # Env check — shared by both paths
+    enabled_analyses = get_enabled_analyses()
+    if enabled_analyses is not None and len(enabled_analyses) == 0:
+        logger.debug("All analyses are disabled via TRITONPARSE_ANALYSIS env var")
+        return {}
+
     payload = entry.get("payload", {})
     metadata = payload.get("metadata", {})
 
@@ -1062,31 +1071,30 @@ def _generate_ir_analysis(
     backend_name = metadata.get("backend_name")
     if isinstance(backend_name, str):
         try:
-            return _generate_ir_analysis_adapter_driven(entry, procedure_checks)
+            return _generate_ir_analysis_adapter_driven(
+                entry, procedure_checks, enabled_analyses
+            )
         except ValueError as e:
             logger.warning(
                 f"Adapter-driven analysis failed: {e}. Falling back to legacy."
             )
 
     # Fallback: hardcoded logic (for traces without backend_name or adapter failure)
-    return _generate_ir_analysis_legacy(entry, procedure_checks)
+    return _generate_ir_analysis_legacy(entry, procedure_checks, enabled_analyses)
 
 
 def _generate_ir_analysis_adapter_driven(
-    entry: dict[str, Any], procedure_checks: list[dict[str, Any]] | None = None
+    entry: dict[str, Any],
+    procedure_checks: list[dict[str, Any]] | None = None,
+    enabled_analyses: set[str] | None = None,
 ) -> dict[str, Any]:
     """
     Adapter-driven IR analysis generation.
 
-    This implements the new adapter-based analysis dispatch:
-    1. Get enabled analyses from environment variable
-    2. Resolve adapter from backend metadata
-    3. Get executable analyzers from adapter (combining registration, artifacts, user preference)
-    4. Execute each executable analysis
-
     Args:
         entry: Trace entry containing payload
         procedure_checks: Optional procedure checks configuration
+        enabled_analyses: User-enabled analysis names (from env var, resolved by caller)
 
     Returns:
         Dictionary of analysis results
@@ -1096,14 +1104,6 @@ def _generate_ir_analysis_adapter_driven(
     payload = entry.get("payload", {})
     metadata = payload.get("metadata", {})
     file_content = payload.get("file_content", {})
-
-    # Get user-enabled analysis list from environment variable
-    enabled_analyses = _get_user_enabled_analyses()
-
-    # If all analyses are disabled, return empty
-    if enabled_analyses is not None and len(enabled_analyses) == 0:
-        logger.debug("All analyses are disabled via TRITONPARSE_ANALYSIS env var")
-        return {}
 
     # Resolve adapter from backend metadata
     adapter = get_backend_registry().resolve_from_trace(metadata)
@@ -1128,7 +1128,9 @@ def _generate_ir_analysis_adapter_driven(
 
 
 def _generate_ir_analysis_legacy(
-    entry: dict[str, Any], procedure_checks: list[dict[str, Any]] | None = None
+    entry: dict[str, Any],
+    procedure_checks: list[dict[str, Any]] | None = None,
+    enabled_analyses: set[str] | None = None,
 ) -> dict[str, Any]:
     """
     Legacy IR analysis generation (backward compatibility).
@@ -1139,6 +1141,7 @@ def _generate_ir_analysis_legacy(
     Args:
         entry: Trace entry containing payload
         procedure_checks: Optional procedure checks configuration
+        enabled_analyses: User-enabled analysis names (from env var, resolved by caller)
 
     Returns:
         Dictionary of analysis results
@@ -1157,18 +1160,24 @@ def _generate_ir_analysis_legacy(
         logger.debug("No IR found")
         return {}
     ir_analysis = {}
-    if amdgcn_key and ttgir_key:
+    if amdgcn_key and ttgir_key and (
+        enabled_analyses is None or "amd_buffer_ops" in enabled_analyses
+    ):
         io_counts = _analyze_buffer_ops(ttgir_key, amdgcn_key, file_content, file_path)
         if io_counts:
             ir_analysis["io_counts"] = io_counts
-    if ttir_key and ttgir_key:
+    if ttir_key and ttgir_key and (
+        enabled_analyses is None or "loop_schedules" in enabled_analyses
+    ):
         loop_schedule = _analyze_loop_schedules(
             ttir_key, ttgir_key, file_content, file_path, payload, source_mappings
         )
         if loop_schedule:
             ir_analysis["loop_schedules"] = loop_schedule
 
-    if procedure_checks and ttgir_key:
+    if procedure_checks and ttgir_key and (
+        enabled_analyses is None or "procedure_checks" in enabled_analyses
+    ):
         procedure_results = find_procedures_with_patterns(
             procedure_checks,
             ttgir_key,
@@ -1351,28 +1360,6 @@ def _analyze_procedures_generic(
         return {"procedure_checks": procedure_results}
     return None
 
-
-# =============================================================================
-# ENVIRONMENT VARIABLE CONTROL
-# =============================================================================
-def _get_user_enabled_analyses() -> set[str] | None:
-    """
-    Get user-enabled analysis list from environment variable.
-
-    Returns:
-        None: Enable all analyses (default)
-        set: Enabled analysis name set
-        Empty set: Disable all analyses
-    """
-    env_value = os.environ.get("TRITONPARSE_ANALYSIS", "all").strip()
-
-    if not env_value or env_value.lower() == "none":
-        return set()  # Disable all
-    elif env_value.lower() == "all":
-        return None  # Enable all (default)
-    else:
-        # Comma-separated analysis list
-        return set(name.strip() for name in env_value.split(",") if name.strip())
 
 
 # =============================================================================

--- a/tritonparse/parse/ir_analysis.py
+++ b/tritonparse/parse/ir_analysis.py
@@ -6,7 +6,7 @@ import shutil
 import subprocess
 import tempfile
 from dataclasses import asdict, dataclass, field
-from typing import Any
+from typing import Any, Callable
 
 from tritonparse.tp_logger import get_logger
 
@@ -16,6 +16,87 @@ logger = get_logger("IRAnalysis")
 
 # Default timeout (in seconds) for FileCheck subprocess calls
 FILECHECK_TIMEOUT_SECONDS = 30
+
+
+# =============================================================================
+# ANALYSIS REGISTRY
+# =============================================================================
+@dataclass
+class AnalyzerInfo:
+    """
+    Information about a registered analyzer.
+
+    Attributes:
+        name: Analyzer name (e.g., "amd_buffer_ops")
+        func: Analyzer function with signature (entry, procedure_checks) -> dict | None
+        required_stages: Tuple of stage names required (e.g., ("ttgir", "amdgcn"))
+        adapter_affinity: Which backend this analyzer belongs to (e.g., "hip_triton").
+                       None means common/shared analyzer.
+    """
+
+    name: str
+    func: Callable
+    required_stages: tuple[str, ...]
+    adapter_affinity: str | None = None
+
+
+class AnalysisRegistry:
+    """
+    Registry for managing IR analysis functions and their metadata.
+
+    This registry allows adapters to register and retrieve analysis functions
+    by analysis_id. It supports both common analyzers (shared across backends)
+    and backend-specific analyzers.
+    """
+
+    _analyzer_infos: dict[str, AnalyzerInfo] = {}
+
+    @classmethod
+    def register(
+        cls,
+        analyzer_id: str,
+        analyzer_func: Callable,
+        required_stages: tuple[str, ...] = (),
+        adapter_affinity: str | None = None,
+    ) -> None:
+        """
+        Register an analyzer with its metadata.
+
+        Args:
+            analyzer_id: Analyzer identifier (e.g., "amd_buffer_ops")
+            analyzer_func: Analyzer function
+            required_stages: Required stage names (e.g., ("ttgir", "amdgcn"))
+            adapter_affinity: Which backend this analyzer belongs to (e.g., "hip_triton").
+                           None means common/shared analyzer.
+        """
+        info = AnalyzerInfo(
+            name=analyzer_id,
+            func=analyzer_func,
+            required_stages=required_stages,
+            adapter_affinity=adapter_affinity,
+        )
+        cls._analyzer_infos[analyzer_id] = info
+
+    @classmethod
+    def get_analyzer_info(cls, analyzer_id: str) -> AnalyzerInfo | None:
+        """Get analyzer info by name."""
+        return cls._analyzer_infos.get(analyzer_id)
+
+    @classmethod
+    def get_analyzer(cls, analyzer_id: str) -> Callable | None:
+        """Get the analyzer function by name."""
+        info = cls._analyzer_infos.get(analyzer_id)
+        return info.func if info else None
+
+    @classmethod
+    def list_analyzers(cls) -> list[str]:
+        """List all registered analyzer IDs."""
+        return list(cls._analyzer_infos.keys())
+
+    @classmethod
+    def clear(cls) -> None:
+        """Clear all registered analyzers (mainly for testing)."""
+        cls._analyzer_infos.clear()
 
 
 # =============================================================================
@@ -958,8 +1039,110 @@ def _analyze_loop_schedules(
 
 
 def _generate_ir_analysis(
-    entry: str, procedure_checks: list[dict[str, Any]] | None = None
-):
+    entry: dict[str, Any], procedure_checks: list[dict[str, Any]] | None = None
+) -> dict[str, Any]:
+    """
+    Generate IR analysis results (adapter-driven with fallback).
+
+    Two-level dispatch:
+    1. Priority: Adapter-driven (for new traces with backend_name in metadata)
+    2. Fallback: Hardcoded logic (for old traces without backend_name)
+
+    Args:
+        entry: Trace entry containing payload
+        procedure_checks: Optional procedure checks configuration
+
+    Returns:
+        Dictionary of analysis results
+    """
+    payload = entry.get("payload", {})
+    metadata = payload.get("metadata", {})
+
+    # Try adapter-driven path when backend_name is available
+    backend_name = metadata.get("backend_name")
+    if isinstance(backend_name, str):
+        try:
+            return _generate_ir_analysis_adapter_driven(entry, procedure_checks)
+        except ValueError as e:
+            logger.warning(
+                f"Adapter-driven analysis failed: {e}. Falling back to legacy."
+            )
+
+    # Fallback: hardcoded logic (for traces without backend_name or adapter failure)
+    return _generate_ir_analysis_legacy(entry, procedure_checks)
+
+
+def _generate_ir_analysis_adapter_driven(
+    entry: dict[str, Any], procedure_checks: list[dict[str, Any]] | None = None
+) -> dict[str, Any]:
+    """
+    Adapter-driven IR analysis generation.
+
+    This implements the new adapter-based analysis dispatch:
+    1. Get enabled analyses from environment variable
+    2. Resolve adapter from backend metadata
+    3. Get executable analyzers from adapter (combining registration, artifacts, user preference)
+    4. Execute each executable analysis
+
+    Args:
+        entry: Trace entry containing payload
+        procedure_checks: Optional procedure checks configuration
+
+    Returns:
+        Dictionary of analysis results
+    """
+    from tritonparse.backend import get_backend_registry
+
+    payload = entry.get("payload", {})
+    metadata = payload.get("metadata", {})
+    file_content = payload.get("file_content", {})
+
+    # Get user-enabled analysis list from environment variable
+    enabled_analyses = _get_user_enabled_analyses()
+
+    # If all analyses are disabled, return empty
+    if enabled_analyses is not None and len(enabled_analyses) == 0:
+        logger.debug("All analyses are disabled via TRITONPARSE_ANALYSIS env var")
+        return {}
+
+    # Resolve adapter from backend metadata
+    adapter = get_backend_registry().resolve_from_trace(metadata)
+
+    # Get executable analyzers (adapter handles all the logic)
+    executable_analyzers = adapter.get_executable_analyzers(
+        file_content, enabled_analyses
+    )
+
+    # Execute each executable analyzer
+    analysis_results = {}
+    for analyzer_name in executable_analyzers:
+        try:
+            result = adapter.run_analysis_pass(analyzer_name, entry, procedure_checks)
+            if result:
+                analysis_results.update(result)
+                logger.debug(f"Analysis '{analyzer_name}' completed successfully")
+        except Exception as e:
+            logger.warning(f"Analysis '{analyzer_name}' failed: {e}")
+
+    return analysis_results
+
+
+def _generate_ir_analysis_legacy(
+    entry: dict[str, Any], procedure_checks: list[dict[str, Any]] | None = None
+) -> dict[str, Any]:
+    """
+    Legacy IR analysis generation (backward compatibility).
+
+    This preserves the original hardcoded analysis logic for old traces
+    that don't have backend metadata.
+
+    Args:
+        entry: Trace entry containing payload
+        procedure_checks: Optional procedure checks configuration
+
+    Returns:
+        Dictionary of analysis results
+    """
     payload = entry.setdefault("payload", {})
     file_content = payload.get("file_content", {})
     file_path = payload.get("file_path", {})
@@ -985,7 +1168,6 @@ def _generate_ir_analysis(
         if loop_schedule:
             ir_analysis["loop_schedules"] = loop_schedule
 
-    # Add FileCheck-based procedure detection if procedure_checks are specified
     if procedure_checks and ttgir_key:
         procedure_results = find_procedures_with_patterns(
             procedure_checks,
@@ -998,3 +1180,219 @@ def _generate_ir_analysis(
             ir_analysis["procedure_checks"] = procedure_results
 
     return ir_analysis
+
+
+# =============================================================================
+# STANDARDIZED ANALYZER WRAPPERS
+# =============================================================================
+def _validate_required_stages(
+    file_content: dict[str, str],
+    required_extensions: list[str],
+    analysis_name: str,
+) -> dict[str, str] | None:
+    """
+    Validate that required stages exist in file_content.
+
+    This is a defensive check that provides clear error messages if required
+    stages are missing. This should not happen if called through adapter properly,
+    but provides safety for direct calls and debugging.
+
+    Args:
+        file_content: Dictionary mapping file keys to file content
+        required_extensions: List of required file extensions (e.g., [".ttgir", ".amdgcn"])
+        analysis_name: Name of the analysis (for logging)
+
+    Returns:
+        dict: {extension: stage_key} if all stages exist
+        None: if any stage is missing
+    """
+    stage_keys = {}
+    for ext in required_extensions:
+        key = next((k for k in file_content if k.endswith(ext)), None)
+        if not key:
+            logger.debug(
+                f"{analysis_name} analysis required stage '{ext}' not found in file_content. "
+                f"Available keys: {list(file_content.keys())[:5]}..."  # Show first 5 keys
+            )
+            return None
+        stage_keys[ext] = key
+
+    return stage_keys
+
+
+def _analyze_amd_buffer_ops(
+    entry: dict[str, Any],
+    procedure_checks: list | None = None,
+) -> dict[str, Any] | None:
+    """
+    AMD buffer ops analysis (standardized wrapper).
+
+    This is a standardized wrapper that adapts the existing
+    _analyze_buffer_ops function to the analyzer registry interface.
+
+    Args:
+        entry: Trace entry containing payload with file_content, file_path, etc.
+        procedure_checks: Optional procedure checks configuration (not used for this analysis)
+
+    Returns:
+        Analysis results dictionary or None if analysis cannot be performed
+    """
+    payload = entry.get("payload", {})
+    file_content = payload.get("file_content", {})
+    file_path = payload.get("file_path", {})
+
+    # Validate required stages (defensive check)
+    stage_keys = _validate_required_stages(
+        file_content, [".ttgir", ".amdgcn"], "amd_buffer_ops"
+    )
+    if not stage_keys:
+        return None
+
+    # Extract stage keys
+    ttgir_key = stage_keys[".ttgir"]
+    amdgcn_key = stage_keys[".amdgcn"]
+
+    # Call existing function (logic unchanged)
+    io_counts = _analyze_buffer_ops(ttgir_key, amdgcn_key, file_content, file_path)
+
+    if io_counts:
+        return {"io_counts": io_counts}
+    return None
+
+
+def _analyze_loop_schedules_generic(
+    entry: dict[str, Any],
+    procedure_checks: list | None = None,
+) -> dict[str, Any] | None:
+    """
+    Generic analyzer for loop schedules.
+
+    This is a standardized wrapper that adapts the existing
+    _analyze_loop_schedules function to the analyzer registry interface.
+
+    Args:
+        entry: Trace entry containing payload with file_content, file_path, etc.
+        procedure_checks: Optional procedure checks configuration (not used for this analysis)
+
+    Returns:
+        Analysis results dictionary or None if analysis cannot be performed
+    """
+    payload = entry.get("payload", {})
+    file_content = payload.get("file_content", {})
+    file_path = payload.get("file_path", {})
+    source_mappings = payload.get("source_mappings", {})
+
+    # Validate required stages (defensive check)
+    stage_keys = _validate_required_stages(
+        file_content, [".ttir", ".ttgir"], "loop_schedules"
+    )
+    if not stage_keys:
+        return None
+
+    # Extract stage keys
+    ttir_key = stage_keys[".ttir"]
+    ttgir_key = stage_keys[".ttgir"]
+
+    # Call existing function (logic unchanged)
+    loop_schedule = _analyze_loop_schedules(
+        ttir_key, ttgir_key, file_content, file_path, payload, source_mappings
+    )
+
+    if loop_schedule:
+        return {"loop_schedules": loop_schedule}
+    return None
+
+
+def _analyze_procedures_generic(
+    entry: dict[str, Any],
+    procedure_checks: list | None = None,
+) -> dict[str, Any] | None:
+    """
+    Generic analyzer for FileCheck-based procedure detection.
+
+    This is a standardized wrapper that adapts the existing
+    find_procedures_with_patterns function to the analyzer registry interface.
+
+    Args:
+        entry: Trace entry containing payload with file_content, file_path, etc.
+        procedure_checks: Procedure checks configuration (required for this analysis)
+
+    Returns:
+        Analysis results dictionary or None if analysis cannot be performed
+    """
+    if not procedure_checks:
+        return None
+
+    payload = entry.get("payload", {})
+    file_content = payload.get("file_content", {})
+    file_path = payload.get("file_path", {})
+
+    # Validate required stages (defensive check)
+    stage_keys = _validate_required_stages(file_content, [".ttgir"], "procedure_checks")
+    if not stage_keys:
+        return None
+
+    # Extract stage keys
+    ttgir_key = stage_keys[".ttgir"]
+
+    # TTIR is optional for procedure checks, but we try to get it if available
+    ttir_key = next((k for k in file_content if k.endswith(".ttir")), None)
+
+    # Call existing function (logic unchanged)
+    procedure_results = find_procedures_with_patterns(
+        procedure_checks,
+        ttgir_key,
+        file_content,
+        file_path,
+        ttir_key=ttir_key,
+    )
+
+    if procedure_results:
+        return {"procedure_checks": procedure_results}
+    return None
+
+
+# =============================================================================
+# ENVIRONMENT VARIABLE CONTROL
+# =============================================================================
+def _get_user_enabled_analyses() -> set[str] | None:
+    """
+    Get user-enabled analysis list from environment variable.
+
+    Returns:
+        None: Enable all analyses (default)
+        set: Enabled analysis name set
+        Empty set: Disable all analyses
+    """
+    env_value = os.environ.get("TRITONPARSE_ANALYSIS", "all").strip()
+
+    if not env_value or env_value.lower() == "none":
+        return set()  # Disable all
+    elif env_value.lower() == "all":
+        return None  # Enable all (default)
+    else:
+        # Comma-separated analysis list
+        return set(name.strip() for name in env_value.split(",") if name.strip())
+
+
+# =============================================================================
+# COMMON ANALYZER INITIALIZATION
+# =============================================================================
+def _initialize_common_analyzers() -> None:
+    """Register common analyzers that are shared across all backends."""
+    AnalysisRegistry.register(
+        "loop_schedules",
+        _analyze_loop_schedules_generic,
+        required_stages=("ttir", "ttgir"),
+        adapter_affinity=None,  # Common analyzer
+    )
+    AnalysisRegistry.register(
+        "procedure_checks",
+        _analyze_procedures_generic,
+        required_stages=("ttgir",),
+        adapter_affinity=None,  # Common analyzer
+    )
+
+
+# Initialize common analyzers on module load
+_initialize_common_analyzers()

--- a/tritonparse/parse/ir_analysis.py
+++ b/tritonparse/parse/ir_analysis.py
@@ -57,7 +57,7 @@ class AnalysisRegistry:
         cls,
         analyzer_id: str,
         analyzer_func: Callable,
-        required_stages: tuple[str, ...] = (),
+        required_stages: tuple[str, ...],
         adapter_affinity: str | None = None,
     ) -> None:
         """

--- a/tritonparse/parse/ir_analysis.py
+++ b/tritonparse/parse/ir_analysis.py
@@ -5,8 +5,9 @@ import re
 import shutil
 import subprocess
 import tempfile
+from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
-from typing import Any, Callable
+from typing import Any
 
 from tritonparse.shared_vars import get_enabled_analyses
 from tritonparse.tp_logger import get_logger
@@ -70,6 +71,8 @@ class AnalysisRegistry:
             adapter_affinity: Which backend this analyzer belongs to (e.g., "hip_triton").
                            None means common/shared analyzer.
         """
+        if analyzer_id in cls._analyzer_infos:
+            logger.debug(f"Analyzer '{analyzer_id}' is already registered. Overwriting.")
         info = AnalyzerInfo(
             name=analyzer_id,
             func=analyzer_func,
@@ -95,9 +98,10 @@ class AnalysisRegistry:
         return list(cls._analyzer_infos.keys())
 
     @classmethod
-    def clear(cls) -> None:
-        """Clear all registered analyzers (mainly for testing)."""
-        cls._analyzer_infos.clear()
+    def list_analyzer_infos(cls) -> list[tuple[str, AnalyzerInfo]]:
+        """List all registered (analyzer_id, AnalyzerInfo) pairs."""
+        return list(cls._analyzer_infos.items())
+
 
 
 # =============================================================================
@@ -1194,6 +1198,8 @@ def _generate_ir_analysis_legacy(
 # =============================================================================
 # STANDARDIZED ANALYZER WRAPPERS
 # =============================================================================
+# Wrappers use dot-extension lists (e.g. [".ttir"]) to match raw file_content keys; 
+# adapter registration uses bare stage names (e.g. "ttir").
 def _validate_required_stages(
     file_content: dict[str, str],
     required_extensions: list[str],
@@ -1219,9 +1225,11 @@ def _validate_required_stages(
     for ext in required_extensions:
         key = next((k for k in file_content if k.endswith(ext)), None)
         if not key:
+            keys_preview = list(file_content.keys())[:5]
+            suffix = "..." if len(file_content) > 5 else ""
             logger.debug(
                 f"{analysis_name} analysis required stage '{ext}' not found in file_content. "
-                f"Available keys: {list(file_content.keys())[:5]}..."  # Show first 5 keys
+                f"Available keys: {keys_preview}{suffix}"
             )
             return None
         stage_keys[ext] = key

--- a/tritonparse/shared_vars.py
+++ b/tritonparse/shared_vars.py
@@ -1,6 +1,10 @@
 #  Copyright (c) Meta Platforms, Inc. and affiliates.
 # We'd like to sperate structured logging module and tritonparse module as much as possible. So, put the shared variables here.
+#
+# Policy: reader-side / CLI / parse environment flags live here;
+# writer-side trace-collection flags live in structured_logging.py.
 import importlib.util
+import logging
 import os
 
 # The compilation information will be stored to /logs/DEFAULT_TRACE_FILE_PREFIX by default
@@ -32,3 +36,50 @@ def is_fbcode():
     if override is not None:
         return override in ("1", "true", "True")
     return importlib.util.find_spec("tritonparse.fb") is not None
+
+
+def get_enabled_analyses() -> set[str] | None:
+    """
+    Get user-enabled analysis list from the ``TRITONPARSE_ANALYSIS`` env var.
+
+    Returns:
+        None: enable all analyses (default).
+        set: enabled analysis names (may be empty to disable all).
+    """
+    logger = logging.getLogger("tritonparse")
+    env_value = os.environ.get("TRITONPARSE_ANALYSIS", "all").strip()
+
+    if not env_value or env_value.lower() == "none":
+        return set()
+    elif env_value.lower() == "all":
+        return None
+
+    # Comma-separated analysis list — names are case-insensitive
+    raw_names = [n.strip().lower() for n in env_value.split(",") if n.strip()]
+
+    # "all"/"none" mixed into a comma list is likely misuse
+    if "all" in raw_names:
+        logger.warning(
+            "TRITONPARSE_ANALYSIS contains 'all' mixed with other names. "
+            "Use 'all' alone to enable everything, or a plain comma list for specific analyses."
+        )
+        return None
+    if "none" in raw_names:
+        logger.warning(
+            "TRITONPARSE_ANALYSIS contains 'none' mixed with other names. "
+            "Use 'none' alone to disable everything."
+        )
+        return set()
+
+    # Validate against registered analyzers (lazy import to avoid circular deps)
+    from tritonparse.parse.ir_analysis import AnalysisRegistry
+
+    known = {name.lower() for name in AnalysisRegistry.list_analyzers()}
+    unknown = {n for n in raw_names if n not in known}
+    if unknown:
+        logger.warning(
+            f"TRITONPARSE_ANALYSIS contains unknown analyzer names: {unknown}. "
+            f"Available: {sorted(known)}"
+        )
+
+    return set(raw_names) & known if known else set(raw_names)


### PR DESCRIPTION
## Context

- RFC: https://github.com/meta-pytorch/tritonparse/issues/367
- Prerequisite PRs:
  - https://github.com/meta-pytorch/tritonparse/pull/387 (reader-side infrastructure and generic parse refactor)
  - https://github.com/meta-pytorch/tritonparse/pull/394 (parser dispatch refactor)

## Summary

This is the third PR in Phase 1 of the Flexible Backend Support RFC. Phase 1 was originally planned as 3 PRs, but during implementation it was split into 4 to keep each PR more focused and easier to review.

This PR refactors analysis dispatch. The hardcoded scheduling logic in `_generate_ir_analysis()` is replaced with an adapter-driven analysis registration and scheduling mechanism. The PR introduces layered analyzer registration for common and backend-specific analyzers, centralizes the `TRITONPARSE_ANALYSIS` entry point, and preserves a legacy fallback path when adapter resolution fails.

---

## Key Changes

### 1. Analysis registry (`tritonparse/parse/ir_analysis.py`)

New `AnalyzerInfo` dataclass:

```python
@dataclass
class AnalyzerInfo:
    """Metadata for a registered analyzer."""
    name: str                           # e.g. "amd_buffer_ops"
    func: Callable                      # (entry, procedure_checks) -> dict | None
    required_stages: tuple[str, ...]    # e.g. ("ttgir", "amdgcn")
    adapter_affinity: str | None = None # backend owner; None means common
```

New `AnalysisRegistry` class:

```python
class AnalysisRegistry:
    """
    Registry for analyzer registration, lookup, and metadata.
    Supports layered registration for common and backend-specific analyzers.
    """

    @classmethod
    def register(cls, analyzer_id, analyzer_func, required_stages, adapter_affinity=None) -> None: ...

    @classmethod
    def get_analyzer_info(cls, analyzer_id: str) -> AnalyzerInfo | None: ...

    @classmethod
    def get_analyzer(cls, analyzer_id: str) -> Callable | None: ...

    @classmethod
    def list_analyzers(cls) -> list[str]: ...

    @classmethod
    def list_analyzer_infos(cls) -> list[tuple[str, AnalyzerInfo]]: ...
```

Core design:

- Layered registration:
  - Common analyzers such as `loop_schedules` and `procedure_checks` are registered at module initialization with `adapter_affinity=None`
  - Backend-specific analyzers such as `amd_buffer_ops` are registered by the corresponding adapter with `adapter_affinity="hip_triton"`
- Unified analyzer metadata:
  - Each analyzer carries both its stage dependencies and backend affinity in `AnalyzerInfo`

### 2. Standardized analyzer wrappers (`tritonparse/parse/ir_analysis.py`)

Three standardized analyzer wrapper functions were added:

```python
def _analyze_loop_schedules_generic(entry, procedure_checks=None):
    """Generic loop schedule analyzer wrapping _analyze_loop_schedules."""

def _analyze_procedures_generic(entry, procedure_checks=None):
    """Generic FileCheck-based procedure analyzer wrapping find_procedures_with_patterns."""

def _analyze_amd_buffer_ops(entry, procedure_checks=None):
    """AMD buffer-ops analyzer wrapping _analyze_buffer_ops."""
```

Design points:

- All analyzers follow the same `(entry, procedure_checks) -> dict | None` signature
- Existing analysis logic is preserved; the wrappers only standardize registration and dispatch
- `_validate_required_stages()` is used as a defensive check before execution

### 3. Adapter extensions (`tritonparse/backend.py`)

Removal of `AnalysisPassDescriptor` / API break:

The responsibility previously carried by `AnalysisPassDescriptor` has been replaced by `AnalyzerInfo`. Analyzer metadata is now managed centrally by `AnalysisRegistry`, so a separate adapter-side public data structure is no longer needed.

`AnalysisPassDescriptor` has been removed from the public Python API. There are no callers in the current repository, so this removal does not affect current production usage, but it is still called out explicitly here because it changes the public API surface.

New and updated methods on `CompilationPipelineAdapter`:

```python
class CompilationPipelineAdapter(ABC):
    def get_analysis_passes(self) -> list[str]:
        """Return analyzer names available for this adapter, filtered by affinity."""

    def get_executable_analyzers(self, file_content, enabled_analyses=None) -> list[str]:
        """
        Determine which analyzers can run based on:
        1. User configuration via TRITONPARSE_ANALYSIS
        2. Stage availability in file_content
        """

    def run_analysis_pass(self, pass_name, entry, procedure_checks=None) -> dict[str, Any]:
        """Run a named analyzer and raise ValueError if it is not found."""

    def register_backend_analyzer(self, analyzer_id, analyzer_func, required_stages) -> None:
        """Register a backend-specific analyzer using adapter_name as affinity."""
```

Concrete adapter change:

```python
class AmdTritonAdapter(CompilationPipelineAdapter):
    def __init__(self):
        self.register_backend_analyzer(
            "amd_buffer_ops",
            _analyze_amd_buffer_ops,
            required_stages=("ttgir", "amdgcn"),
        )
```

Key improvements:

- Each adapter becomes the registration entry point for its backend-specific analyzers
- `get_analysis_passes()` filters available analyzers automatically based on `adapter_affinity`
- `get_executable_analyzers()` combines user configuration and stage availability before execution

### 4. `_generate_ir_analysis()` refactor (`tritonparse/parse/ir_analysis.py`)

Before the refactor, analysis dispatch was hardcoded:

```python
def _generate_ir_analysis(entry, procedure_checks=None):
    ttir_key = next((k for k in file_content if k.endswith(".ttir")), None)
    ttgir_key = next((k for k in file_content if k.endswith(".ttgir")), None)
    amdgcn_key = next((k for k in file_content if k.endswith(".amdgcn")), None)

    if amdgcn_key and ttgir_key:
        io_counts = _analyze_buffer_ops(ttgir_key, amdgcn_key, ...)

    if ttir_key and ttgir_key:
        loop_schedule = _analyze_loop_schedules(ttir_key, ttgir_key, ...)
```

After the refactor, the dispatcher performs a shared env check, tries the adapter-driven path first, and falls back to legacy logic only when adapter resolution fails:

```python
def _generate_ir_analysis(entry, procedure_checks=None):
    enabled_analyses = get_enabled_analyses()
    if enabled_analyses is not None and len(enabled_analyses) == 0:
        return {}

    try:
        return _generate_ir_analysis_adapter_driven(
            entry, procedure_checks, enabled_analyses
        )
    except ValueError as e:
        logger.warning(f"Adapter-driven analysis failed: {e}. Falling back to legacy.")

    return _generate_ir_analysis_legacy(
        entry, procedure_checks, enabled_analyses
    )
```

Adapter-driven path:

```python
def _generate_ir_analysis_adapter_driven(
    entry, procedure_checks=None, enabled_analyses=None
):
    adapter = get_backend_registry().resolve_from_trace(metadata)
    executable = adapter.get_executable_analyzers(file_content, enabled_analyses)

    for analyzer_name in executable:
        result = adapter.run_analysis_pass(analyzer_name, entry, procedure_checks)
```

Key improvements:

- Two-level dispatch:
  1. Try adapter-driven dispatch first
  2. Fall back to the legacy hardcoded path only if adapter resolution fails
- Backend-specific checks such as `if amdgcn_key and ttgir_key` are replaced by `adapter.get_executable_analyzers()`
- `TRITONPARSE_ANALYSIS` is now read once at the dispatcher entry point and shared by both the adapter-driven and legacy paths

### 5. Environment variable control (`tritonparse/shared_vars.py`)

`TRITONPARSE_ANALYSIS` handling was moved into `shared_vars.py` as `get_enabled_analyses()`:

```python
def get_enabled_analyses() -> set[str] | None:
    """
    Get the user-enabled analysis set from the environment.

    Returns:
        None: enable all analyses (default)
        set: enabled analysis names
        empty set: disable all analyses
    """
    env_value = os.environ.get("TRITONPARSE_ANALYSIS", "all").strip()
    if not env_value or env_value.lower() == "none":
        return set()
    elif env_value.lower() == "all":
        return None

    raw_names = [n.strip().lower() for n in env_value.split(",") if n.strip()]
    if "all" in raw_names:
        logger.warning("TRITONPARSE_ANALYSIS contains 'all' mixed with other names")
        return None
    if "none" in raw_names:
        logger.warning("TRITONPARSE_ANALYSIS contains 'none' mixed with other names")
        return set()

    known = {name.lower() for name in AnalysisRegistry.list_analyzers()}
    unknown = {n for n in raw_names if n not in known}
    if unknown:
        logger.warning(f"TRITONPARSE_ANALYSIS contains unknown analyzer names: {unknown}")

    return set(raw_names) & known if known else set(raw_names)
```

Usage examples:

```bash
# Enable all analyses (default)
export TRITONPARSE_ANALYSIS="all"

# Disable all analyses
export TRITONPARSE_ANALYSIS="none"

# Run only specific analyses
export TRITONPARSE_ANALYSIS="loop_schedules"
export TRITONPARSE_ANALYSIS="loop_schedules,procedure_checks"
```

This helper now also normalizes case, warns on invalid combinations such as `all,foo` or `none,foo`, and filters unknown analyzer names.

---

## Architecture

### Analysis dispatch flow comparison

```mermaid
flowchart LR
    subgraph before ["Before (hardcoded)"]
        direction TB
        A1["_generate_ir_analysis"] --> B1["Hardcoded artifact lookup"]
        B1 --> C1["Hardcoded condition<br/>if amdgcn_key and ttgir_key"]
        C1 --> D1["Direct analyzer calls"]
    end

    subgraph after ["After (adapter-first with fallback)"]
        direction TB
        A2["_generate_ir_analysis"] --> B2["get_enabled_analyses<br/>shared env check"]
        B2 --> C2{"adapter resolves successfully?"}
        C2 -->|Yes| D2["_generate_ir_analysis_adapter_driven"]
        C2 -->|No| E2["_generate_ir_analysis_legacy<br/>(fallback)"]
        D2 --> F2["adapter.get_executable_analyzers<br/>(user config + stage availability)"]
        F2 --> G2["adapter.run_analysis_pass<br/>(lookup from registry)"]
    end

    style after fill:#e1f5e1,stroke:#4caf50,stroke-width:2px
    style before fill:#ffe1e1,stroke:#f44336,stroke-width:2px
```

### Component responsibilities

| Component | Responsibility |
|-----------|----------------|
| `AnalysisRegistry` | Analyzer registration, lookup, and metadata |
| `AnalyzerInfo` | Analyzer metadata: function, dependencies, and ownership |
| `_validate_required_stages()` | Defensive check for required stages |
| `get_enabled_analyses()` | Parse and validate `TRITONPARSE_ANALYSIS` in `shared_vars.py` |
| `adapter.get_executable_analyzers()` | Determine which analyzers are executable |
| `adapter.run_analysis_pass()` | Execute a named analyzer |
| `adapter.register_backend_analyzer()` | Register a backend-specific analyzer |
| `AnalysisRegistry.list_analyzer_infos()` | Public enumeration API for adapter-side analyzer metadata lookup |

---

## Documentation

This PR also documents `TRITONPARSE_ANALYSIS` in `docs/07.-Environment-Variables-Reference.md`, including both the quick-reference table and the detailed section.

---

## Testing

Format checking
The result of make format-check is shown below:
<img width="875" height="202" alt="image" src="https://github.com/user-attachments/assets/308b37b1-ad1e-4ce2-a375-b2cea80eb80a" />


Functional testing
The result of make test-cuda is shown below:
<img width="1264" height="370" alt="image" src="https://github.com/user-attachments/assets/e3f4d5be-75c4-45c7-b725-fcc2c5a53c05" />



The result of make test is shown below:
<img width="1427" height="391" alt="image" src="https://github.com/user-attachments/assets/5fed3cd2-0862-45df-aca2-3b62f4a140bd" />


Multi-backend testing
The parse function also works properly in the Ascend backend.


---

## Summary

This PR completes the analysis dispatch refactor for Phase 1 of the Flexible Backend Support RFC. It replaces the hardcoded scheduling logic in `_generate_ir_analysis()` with an adapter-driven dispatch model while preserving a compatibility fallback path for legacy behavior.

The main deliverables are:

- `AnalysisRegistry` and `AnalyzerInfo` for unified analyzer registration, lookup, and metadata
- layered analyzer registration for common and backend-specific analyzers
- three standardized analyzer wrappers: `loop_schedules`, `procedure_checks`, and `amd_buffer_ops`
- adapter extensions for `get_executable_analyzers()`, `run_analysis_pass()`, and `register_backend_analyzer()`
- a shared dispatcher entry point for `TRITONPARSE_ANALYSIS`
- centralized env parsing in `shared_vars.py` with validation, normalization, and warnings

---

## RFC Phase 1 Status and Next Steps

### Phase 1 overview

The goal of RFC Phase 1 is reader-side backend convergence: move reader-side backend semantics from scattered hardcoded rules into a unified adapter contract.

The original RFC planned 3 PRs for Phase 1. During implementation, the original PR 2 and PR 3 each carried enough scope to justify splitting the phase into 4 PRs.

### PR 1 (completed): Reader-side infrastructure and generic parse refactor

- Adapter infrastructure plus generic parse scheduling in `trace_processor.py`
- New `tritonparse/backend.py`: `IRStageDescriptor`, `CompilationPipelineAdapter`, `NvidiaTritonAdapter`, `AmdTritonAdapter`, `PipelineAdapterRegistry`
- Dynamic stage discovery with fallback, dynamic stage processing, and dynamic mapping construction in `trace_processor.py`

### PR 2 (completed): Parser dispatch refactor

- `ParserRegistry` plus five standardized parser wrappers
- Adapter extensions: `get_parser()` and `register_backend_parser()`
- `generate_source_mappings()` refactored to adapter-driven dispatch with hardcoded fallback

### PR 3 (this PR): Analysis dispatch refactor

- `AnalysisRegistry` plus three standardized analyzer wrappers
- Adapter extensions: `get_executable_analyzers()`, `run_analysis_pass()`, and `register_backend_analyzer()`
- `_generate_ir_analysis()` refactored to shared env check plus adapter-first, fallback-aware dispatch
- `TRITONPARSE_ANALYSIS` centralized in `shared_vars.py`

### PR 4 (upcoming): Derived artifacts and reproducer migration

- Derived artifacts: implement `get_derived_artifacts()` and `collect_derived_artifact_contents()` in `NvidiaTritonAdapter`, and move the existing SASS dump logic (`TRITONPARSE_DUMP_SASS`) into the adapter-based derived-artifact framework
- Reproducer migration: move device normalization in `reproducer/` into `adapter.normalize_device_string()` and remove backend-specific checks from the reproducer path
- Main outcome: backend-specific derivation logic and reproducer device handling move out of shared code and into adapters

Next step: complete PR 4. Once that is done, Phase 1 is complete and the work can move on to Phase 2, the reader-side frontend migration.
