### PR TITLE
Reproducer Migration — Move Backend Hardcodes to Adapter-Driven Logic

### DIFF
--- a/tests/cpu/test_multi_backend_stage.py
+++ b/tests/cpu/test_multi_backend_stage.py
@@ -479,24 +479,31 @@ class TestAnalysisAdapterDriven(unittest.TestCase):
             set_runtime_sass_dump_override(None)
 
 
-class TestNormalizeDeviceString(unittest.TestCase):
-    """Tests for adapter.normalize_device_string()."""
+class TestDeviceStringHelpers(unittest.TestCase):
+    """Tests for device-string normalization helpers."""
 
-    def test_cuda_no_index_gets_index(self):
+    def test_adapter_returns_canonical_cuda_device(self):
         adapter = NvidiaTritonAdapter()
-        self.assertEqual(adapter.normalize_device_string("cuda"), "cuda:0")
+        self.assertEqual(adapter.get_canonical_device_string(), "cuda:0")
 
-    def test_cpu_unchanged(self):
-        adapter = NvidiaTritonAdapter()
-        self.assertEqual(adapter.normalize_device_string("cpu"), "cpu")
-
-    def test_hip_with_index_forced_to_zero(self):
+    def test_adapter_returns_canonical_hip_device(self):
         adapter = AmdTritonAdapter()
-        self.assertEqual(adapter.normalize_device_string("hip:3"), "hip:0")
+        self.assertEqual(adapter.get_canonical_device_string(), "cuda:0")
 
-    def test_empty_string_returns_cpu(self):
-        adapter = NvidiaTritonAdapter()
-        self.assertEqual(adapter.normalize_device_string(""), "cpu")
+    def test_public_helper_keeps_cpu(self):
+        from tritonparse.backend import normalize_accelerator_device_string
+
+        self.assertEqual(normalize_accelerator_device_string("cpu"), "cpu")
+
+    def test_public_helper_normalizes_indexed_device(self):
+        from tritonparse.backend import normalize_accelerator_device_string
+
+        self.assertEqual(normalize_accelerator_device_string("hip:3"), "hip:0")
+
+    def test_public_helper_maps_empty_to_cpu(self):
+        from tritonparse.backend import normalize_accelerator_device_string
+
+        self.assertEqual(normalize_accelerator_device_string(""), "cpu")
 
 
 if __name__ == "__main__":

--- a/tests/cpu/test_multi_backend_stage.py
+++ b/tests/cpu/test_multi_backend_stage.py
@@ -479,5 +479,25 @@ class TestAnalysisAdapterDriven(unittest.TestCase):
             set_runtime_sass_dump_override(None)
 
 
+class TestNormalizeDeviceString(unittest.TestCase):
+    """Tests for adapter.normalize_device_string()."""
+
+    def test_cuda_no_index_gets_index(self):
+        adapter = NvidiaTritonAdapter()
+        self.assertEqual(adapter.normalize_device_string("cuda"), "cuda:0")
+
+    def test_cpu_unchanged(self):
+        adapter = NvidiaTritonAdapter()
+        self.assertEqual(adapter.normalize_device_string("cpu"), "cpu")
+
+    def test_hip_with_index_forced_to_zero(self):
+        adapter = AmdTritonAdapter()
+        self.assertEqual(adapter.normalize_device_string("hip:3"), "hip:0")
+
+    def test_empty_string_returns_cpu(self):
+        adapter = NvidiaTritonAdapter()
+        self.assertEqual(adapter.normalize_device_string(""), "cpu")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/cpu/test_placeholder_replacer.py
+++ b/tests/cpu/test_placeholder_replacer.py
@@ -86,6 +86,7 @@ def _make_context_bundle(
     function_name="test_kernel",
     source_code="@triton.jit\ndef test_kernel(): pass",
     file_path="/tmp/test.py",
+    backend=None,
 ):
     """Helper to build a minimal ContextBundle for testing."""
     kernel_info = KernelInfo(
@@ -99,6 +100,8 @@ def _make_context_bundle(
         "num_stages": 2,
         "global_scratch_size": global_scratch_size,
     }
+    if backend is not None:
+        compile_block["backend"] = backend
     launch_block = {"grid": [1, 1, 1], "kwargs": {}}
     return ContextBundle(
         kernel_info=kernel_info,
@@ -410,6 +413,46 @@ class InterleavedConstexprInvocationTest(unittest.TestCase):
         self.assertIn('args_dict["is_predict"]', fallback_branch)
         self.assertIn('args_dict["FUSED_QKV"]', fallback_branch)
         self.assertIn('args_dict["BLOCK_M"]', fallback_branch)
+
+
+class TestReproducerAdapterDriven(unittest.TestCase):
+    """Tests for adapter-driven device/sync in reproducer generation."""
+
+    def test_sync_call_uses_adapter_pytorch_module(self):
+        """Verify sync call is derived from adapter.pytorch_module, not hardcoded."""
+        from unittest.mock import patch
+
+        replacer = DefaultPlaceholderReplacer()
+        ctx = _make_context_bundle(backend="cuda")
+        template = "# {{SYNC_CALL_PLACEHOLDER}}"
+
+        with patch(
+            "tritonparse.backend.NvidiaTritonAdapter.pytorch_module",
+            new_callable=lambda: property(lambda self: "example"),
+        ):
+            result = replacer._replace_sync_call(template, ctx)
+            self.assertEqual(result, "torch.example.synchronize()")
+
+    def test_allocator_uses_adapter_pytorch_module(self):
+        """Verify allocator device is derived from adapter.pytorch_module."""
+        from unittest.mock import patch
+
+        replacer = DefaultPlaceholderReplacer()
+        ctx = _make_context_bundle(global_scratch_size="1024", backend="cuda")
+        template = "# {{LAUNCH_KERNEL_BODY_PLACEHOLDER}}"
+
+        with patch(
+            "tritonparse.backend.NvidiaTritonAdapter.pytorch_module",
+            new_callable=lambda: property(lambda self: "example"),
+        ):
+            result = replacer._replace_launch_kernel_body(
+                template,
+                ctx,
+                embed_context=False,
+                temp_json_path=MagicMock(name="ctx.json"),
+            )
+            self.assertIn("device='example'", result)
+            self.assertNotIn("device='cuda'", result)
 
 
 if __name__ == "__main__":

--- a/tests/cpu/test_placeholder_replacer.py
+++ b/tests/cpu/test_placeholder_replacer.py
@@ -420,39 +420,32 @@ class TestReproducerAdapterDriven(unittest.TestCase):
 
     def test_sync_call_uses_adapter_pytorch_module(self):
         """Verify sync call is derived from adapter.pytorch_module, not hardcoded."""
-        from unittest.mock import patch
-
         replacer = DefaultPlaceholderReplacer()
         ctx = _make_context_bundle(backend="cuda")
         template = "# {{SYNC_CALL_PLACEHOLDER}}"
 
-        with patch(
-            "tritonparse.backend.NvidiaTritonAdapter.pytorch_module",
-            new_callable=lambda: property(lambda self: "example"),
-        ):
-            result = replacer._replace_sync_call(template, ctx)
-            self.assertEqual(result, "torch.example.synchronize()")
+        result = replacer._replace_sync_call(
+            template,
+            ctx,
+            pytorch_module="example",
+        )
+        self.assertEqual(result, "torch.example.synchronize()")
 
     def test_allocator_uses_adapter_pytorch_module(self):
         """Verify allocator device is derived from adapter.pytorch_module."""
-        from unittest.mock import patch
-
         replacer = DefaultPlaceholderReplacer()
         ctx = _make_context_bundle(global_scratch_size="1024", backend="cuda")
         template = "# {{LAUNCH_KERNEL_BODY_PLACEHOLDER}}"
 
-        with patch(
-            "tritonparse.backend.NvidiaTritonAdapter.pytorch_module",
-            new_callable=lambda: property(lambda self: "example"),
-        ):
-            result = replacer._replace_launch_kernel_body(
-                template,
-                ctx,
-                embed_context=False,
-                temp_json_path=MagicMock(name="ctx.json"),
-            )
-            self.assertIn("device='example'", result)
-            self.assertNotIn("device='cuda'", result)
+        result = replacer._replace_launch_kernel_body(
+            template,
+            ctx,
+            embed_context=False,
+            temp_json_path=MagicMock(name="ctx.json"),
+            pytorch_module="example",
+        )
+        self.assertIn("device='example'", result)
+        self.assertNotIn("device='cuda'", result)
 
 
 if __name__ == "__main__":

--- a/tritonparse/backend.py
+++ b/tritonparse/backend.py
@@ -9,6 +9,19 @@ from typing import Any, Callable
 from tritonparse.tp_logger import logger
 
 
+def normalize_accelerator_device_string(device: str) -> str:
+    """Normalize accelerator device strings to index 0, preserving CPU."""
+    if not isinstance(device, str):
+        return "cpu"
+
+    normalized = device.strip()
+    if not normalized or normalized == "cpu":
+        return "cpu"
+
+    prefix = normalized.split(":")[0]
+    return f"{prefix}:0"
+
+
 @dataclass(frozen=True)
 class IRStageDescriptor:
     """Describes an IR stage in the compilation pipeline.
@@ -111,6 +124,12 @@ class CompilationPipelineAdapter(ABC):
     @property
     @abstractmethod
     def pytorch_module(self) -> str:
+        """Device-family prefix used for torch device strings and sync calls.
+
+        Examples: "cuda", "xpu", "mps".
+        Used as f"{prefix}:0" for device strings and
+        f"torch.{prefix}.synchronize()" for synchronization.
+        """
         raise NotImplementedError
 
     @abstractmethod
@@ -289,11 +308,9 @@ class CompilationPipelineAdapter(ABC):
             analyzer_id, analyzer_func, required_stages, adapter_affinity
         )
 
-    def normalize_device_string(self, device: str) -> str:
-        if not isinstance(device, str) or not device or device == "cpu":
-            return "cpu"
-        prefix = device.split(":")[0]
-        return f"{prefix}:0"
+    def get_canonical_device_string(self) -> str:
+        """Return the adapter's canonical accelerator device string."""
+        return normalize_accelerator_device_string(self.pytorch_module)
 
     def get_parser(self, parser_id: str):
         """

--- a/tritonparse/backend.py
+++ b/tritonparse/backend.py
@@ -290,7 +290,10 @@ class CompilationPipelineAdapter(ABC):
         )
 
     def normalize_device_string(self, device: str) -> str:
-        return device
+        if not isinstance(device, str) or not device or device == "cpu":
+            return "cpu"
+        prefix = device.split(":")[0]
+        return f"{prefix}:0"
 
     def get_parser(self, parser_id: str):
         """
@@ -382,7 +385,7 @@ class NvidiaTritonAdapter(CompilationPipelineAdapter):
 
     @property
     def pytorch_module(self) -> str:
-        return "torch.cuda"
+        return "cuda"
 
     def get_ir_stages(self) -> list[IRStageDescriptor]:
         return self._stages
@@ -433,7 +436,7 @@ class AmdTritonAdapter(CompilationPipelineAdapter):
 
     @property
     def pytorch_module(self) -> str:
-        return "torch.cuda"
+        return "cuda"
 
     def get_ir_stages(self) -> list[IRStageDescriptor]:
         return self._stages

--- a/tritonparse/reproducer/orchestrator.py
+++ b/tritonparse/reproducer/orchestrator.py
@@ -87,6 +87,18 @@ def reproduce(
     context_bundle = build_context_bundle(events, line_index)
     context_bundle.source_repo_dir = source_repo_dir
 
+    # Adapter-driven device normalization: set device strings in tensor args
+    # based on the adapter's pytorch_module prefix, covering both file mode
+    # and embed mode. GPU args are normalized to {prefix}:0; CPU args stay.
+    from tritonparse.backend import get_backend_registry
+
+    _backend = context_bundle.compile.get("backend") or "cuda"
+    _adapter = get_backend_registry().resolve(adapter_name=f"{_backend}_triton")
+    _normalized_device = f"{_adapter.pytorch_module}:0"
+    for _arg in context_bundle.raw_launch_event.get("extracted_args", {}).values():
+        if isinstance(_arg, dict) and _arg.get("device", "cpu") != "cpu":
+            _arg["device"] = _normalized_device
+
     logger.debug(
         f"Built context bundle for kernel: {context_bundle.kernel_info.function_name}"
     )

--- a/tritonparse/reproducer/orchestrator.py
+++ b/tritonparse/reproducer/orchestrator.py
@@ -87,18 +87,6 @@ def reproduce(
     context_bundle = build_context_bundle(events, line_index)
     context_bundle.source_repo_dir = source_repo_dir
 
-    # Adapter-driven device normalization: set device strings in tensor args
-    # based on the adapter's pytorch_module prefix, covering both file mode
-    # and embed mode. GPU args are normalized to {prefix}:0; CPU args stay.
-    from tritonparse.backend import get_backend_registry
-
-    _backend = context_bundle.compile.get("backend") or "cuda"
-    _adapter = get_backend_registry().resolve(adapter_name=f"{_backend}_triton")
-    _normalized_device = f"{_adapter.pytorch_module}:0"
-    for _arg in context_bundle.raw_launch_event.get("extracted_args", {}).values():
-        if isinstance(_arg, dict) and _arg.get("device", "cpu") != "cpu":
-            _arg["device"] = _normalized_device
-
     logger.debug(
         f"Built context bundle for kernel: {context_bundle.kernel_info.function_name}"
     )
@@ -125,6 +113,11 @@ def reproduce(
     logger.debug("Loading reproducer template.")
     template_code = load_template_code(template)
 
+    from tritonparse.backend import get_backend_registry
+
+    backend = context_bundle.compile.get("backend") or "cuda"
+    adapter = get_backend_registry().resolve_from_backend_name(backend)
+
     # Use PlaceholderReplacer to replace all placeholders
     # If no custom replacer provided, use the default one
     if replacer is None:
@@ -138,6 +131,7 @@ def reproduce(
         embed_context=embed_context,
         input_path=input_path,
         line_index=line_index,
+        pytorch_module=adapter.pytorch_module,
         template=template,
     )
 

--- a/tritonparse/reproducer/placeholder_replacer.py
+++ b/tritonparse/reproducer/placeholder_replacer.py
@@ -193,6 +193,8 @@ class DefaultPlaceholderReplacer(PlaceholderReplacer):
     VERBOSE_ARGS_PRINT_PLACEHOLDER = "# {{VERBOSE_ARGS_PRINT_PLACEHOLDER}}"
     # Placeholder for reproducer metadata in docstring
     REPRODUCER_METADATA_PLACEHOLDER = "{{REPRODUCER_METADATA_PLACEHOLDER}}"
+    # Placeholder for backend-specific synchronize call
+    SYNC_CALL_PLACEHOLDER = "# {{SYNC_CALL_PLACEHOLDER}}"
 
     def __init__(self, preserve_autotune: bool = False):
         super().__init__()
@@ -224,6 +226,8 @@ class DefaultPlaceholderReplacer(PlaceholderReplacer):
         self.register(
             self.REPRODUCER_METADATA_PLACEHOLDER, self._replace_reproducer_metadata
         )
+        # Register handler for backend-specific synchronize call
+        self.register(self.SYNC_CALL_PLACEHOLDER, self._replace_sync_call)
 
     def _replace_kernel_name(
         self, code: str, context_bundle: ContextBundle, **kwargs
@@ -755,13 +759,18 @@ class DefaultPlaceholderReplacer(PlaceholderReplacer):
         # without one the kernel launch will fail or hang.
         global_scratch_size = context_bundle.compile.get("global_scratch_size")
         if global_scratch_size and int(global_scratch_size) > 0:
+            from tritonparse.backend import get_backend_registry
+
+            _backend = context_bundle.compile.get("backend") or "cuda"
+            _adapter = get_backend_registry().resolve(adapter_name=f"{_backend}_triton")
+            _device_prefix = _adapter.pytorch_module
             body_lines.extend(
                 [
                     f"# This kernel requires scratch memory (global_scratch_size={global_scratch_size}).",
                     "# A default allocator is provided below. If the kernel hangs or produces",
                     "# incorrect results, replace this with the allocator from the original application.",
                     "def _alloc_fn(size: int, align: int, stream):",
-                    "    return torch.empty(size, dtype=torch.int8, device='cuda')",
+                    f"    return torch.empty(size, dtype=torch.int8, device='{_device_prefix}')",
                     "triton.set_allocator(_alloc_fn)",
                     "",
                 ]
@@ -848,6 +857,17 @@ To regenerate this reproducer:
     python -m tritonparse reproduce <ndjson_file> --line {line_index} --out-dir <output_dir>"""
 
         return code.replace(self.REPRODUCER_METADATA_PLACEHOLDER, metadata)
+
+    def _replace_sync_call(
+        self, code: str, context_bundle: ContextBundle, **kwargs
+    ) -> str:
+        """Replace the sync call placeholder with backend-appropriate synchronize."""
+        from tritonparse.backend import get_backend_registry
+
+        backend = context_bundle.compile.get("backend") or "cuda"
+        adapter = get_backend_registry().resolve(adapter_name=f"{backend}_triton")
+        sync_call = f"torch.{adapter.pytorch_module}.synchronize()"
+        return code.replace(self.SYNC_CALL_PLACEHOLDER, sync_call)
 
 
 @dataclass

--- a/tritonparse/reproducer/placeholder_replacer.py
+++ b/tritonparse/reproducer/placeholder_replacer.py
@@ -759,18 +759,14 @@ class DefaultPlaceholderReplacer(PlaceholderReplacer):
         # without one the kernel launch will fail or hang.
         global_scratch_size = context_bundle.compile.get("global_scratch_size")
         if global_scratch_size and int(global_scratch_size) > 0:
-            from tritonparse.backend import get_backend_registry
-
-            _backend = context_bundle.compile.get("backend") or "cuda"
-            _adapter = get_backend_registry().resolve(adapter_name=f"{_backend}_triton")
-            _device_prefix = _adapter.pytorch_module
+            device_prefix = kwargs.get("pytorch_module")
             body_lines.extend(
                 [
                     f"# This kernel requires scratch memory (global_scratch_size={global_scratch_size}).",
                     "# A default allocator is provided below. If the kernel hangs or produces",
                     "# incorrect results, replace this with the allocator from the original application.",
                     "def _alloc_fn(size: int, align: int, stream):",
-                    f"    return torch.empty(size, dtype=torch.int8, device='{_device_prefix}')",
+                    f"    return torch.empty(size, dtype=torch.int8, device='{device_prefix}')",
                     "triton.set_allocator(_alloc_fn)",
                     "",
                 ]
@@ -862,11 +858,8 @@ To regenerate this reproducer:
         self, code: str, context_bundle: ContextBundle, **kwargs
     ) -> str:
         """Replace the sync call placeholder with backend-appropriate synchronize."""
-        from tritonparse.backend import get_backend_registry
-
-        backend = context_bundle.compile.get("backend") or "cuda"
-        adapter = get_backend_registry().resolve(adapter_name=f"{backend}_triton")
-        sync_call = f"torch.{adapter.pytorch_module}.synchronize()"
+        pytorch_module = kwargs.get("pytorch_module")
+        sync_call = f"torch.{pytorch_module}.synchronize()"
         return code.replace(self.SYNC_CALL_PLACEHOLDER, sync_call)
 
 

--- a/tritonparse/reproducer/templates/example.py
+++ b/tritonparse/reproducer/templates/example.py
@@ -7,7 +7,6 @@ It contains a smallest testing example for a Triton kernel.
 
 import logging
 
-import torch
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +32,7 @@ def launch_kernel():
 
     # {{KERNEL_INVOCATION_PLACEHOLDER}}
 
-    torch.cuda.synchronize()
+    # {{SYNC_CALL_PLACEHOLDER}}
     print("Kernel execution finished.")
 
 

--- a/tritonparse/reproducer/utils.py
+++ b/tritonparse/reproducer/utils.py
@@ -227,8 +227,12 @@ def _create_base_tensor(arg_info) -> torch.Tensor:
     Returns:
         torch.Tensor: The created base tensor
     """
+    from tritonparse.backend import normalize_accelerator_device_string
+
+    device = normalize_accelerator_device_string(arg_info.get("device", "cpu"))
+
     if arg_info.get("blob_path"):
-        return load_tensor(arg_info.get("blob_path"), arg_info.get("device"))
+        return load_tensor(arg_info.get("blob_path"), device)
 
     # Extract basic tensor properties
     dtype_str = arg_info.get("dtype")
@@ -239,16 +243,6 @@ def _create_base_tensor(arg_info) -> torch.Tensor:
         torch_dtype = torch.float32
 
     shape = arg_info.get("shape", [])
-    device = arg_info.get("device", "cpu")
-    # Safety net: normalize accelerator device to device index 0.
-    # Primary normalization is done by the adapter at generation time.
-    if isinstance(device, str):
-        device = device.strip()
-        if not device:
-            device = "cpu"
-        elif device != "cpu":
-            prefix = device.split(":")[0]
-            device = f"{prefix}:0"
 
     # Extract statistical information if available
     mean = arg_info.get("mean")

--- a/tritonparse/reproducer/utils.py
+++ b/tritonparse/reproducer/utils.py
@@ -240,9 +240,15 @@ def _create_base_tensor(arg_info) -> torch.Tensor:
 
     shape = arg_info.get("shape", [])
     device = arg_info.get("device", "cpu")
-    # Normalize cuda device to cuda:0
-    if isinstance(device, str) and device.startswith("cuda"):
-        device = "cuda:0"
+    # Safety net: normalize accelerator device to device index 0.
+    # Primary normalization is done by the adapter at generation time.
+    if isinstance(device, str):
+        device = device.strip()
+        if not device:
+            device = "cpu"
+        elif device != "cpu":
+            prefix = device.split(":")[0]
+            device = f"{prefix}:0"
 
     # Extract statistical information if available
     mean = arg_info.get("mean")


### PR DESCRIPTION
## Background

- **RFC**: https://github.com/meta-pytorch/tritonparse/issues/367
- **Prior PRs**:
  - https://github.com/meta-pytorch/tritonparse/pull/387 (Reader-side infrastructure & generic parse logic)
  - https://github.com/meta-pytorch/tritonparse/pull/394 (Parser dispatch refactoring)
  - https://github.com/meta-pytorch/tritonparse/pull/401 (Analysis dispatch refactoring)
  - https://github.com/meta-pytorch/tritonparse/pull/403 (Derived artifact refactoring)

## Summary

This PR closes the **last gap in Flexible Backend Support RFC Phase 1** by migrating all backend hardcodes in the `reproducer/` module to adapter-driven logic.

The reproducer module had three CUDA hardcodes (device normalization, scratch allocator device, sync call) and zero references to the adapter system. `context_bundle.compile["backend"]` already captured backend info but was never consumed. This PR wires up the `backend → resolve adapter → device/sync` path so that all reproducer backend decisions go through the adapter contract.

---

## Key Changes

### 1. `pytorch_module` semantics update (`tritonparse/backend.py`)

`pytorch_module` now returns the device prefix (`"cuda"`) instead of the full module path (`"torch.cuda"`).

All PyTorch in-tree accelerator backends follow the same pattern:

| Backend | Device string | Sync call | Prefix |
|---------|--------------|-----------|--------|
| NVIDIA CUDA | `cuda:0` | `torch.cuda.synchronize()` | cuda |
| AMD ROCm | `cuda:0` | `torch.cuda.synchronize()` | cuda |
| Apple MPS | `mps:0` | `torch.mps.synchronize()` | mps |
| Intel XPU | `xpu:0` | `torch.xpu.synchronize()` | xpu |

Note: ROCm is not a separate PyTorch backend — it uses the CUDA compatibility layer (`torch.cuda` / `device="cuda:0"`), so the prefix is the same as NVIDIA.

Device prefix = the word between `torch.` and `.synchronize()` = `pytorch_module` value. One field drives both scenarios:

- Device string: `f"{adapter.pytorch_module}:0"` → `"cuda:0"`
- Sync call: `f"torch.{adapter.pytorch_module}.synchronize()"` → `"torch.cuda.synchronize()"`

### 2. Adapter-driven device normalization (`tritonparse/reproducer/orchestrator.py`)

Added adapter-driven device normalization in `orchestrator.py::reproduce()`, after `build_context_bundle` and before JSON is written:

```python
_adapter = get_backend_registry().resolve(adapter_name=f"{_backend}_triton")
_normalized_device = f"{_adapter.pytorch_module}:0"
for _arg in context_bundle.raw_launch_event.get("extracted_args", {}).values():
    if isinstance(_arg, dict) and _arg.get("device", "cpu") != "cpu":
        _arg["device"] = _normalized_device
```

- Uses the adapter's `pytorch_module` to set device strings rather than normalizing whatever the trace contains
- Covers both file mode (external JSON) and embed mode (inline JSON)
- GPU args are set to `{prefix}:0`; CPU args are left unchanged

### 3. `normalize_device_string()` default implementation (`tritonparse/backend.py`)

Changed from no-op to generic normalization:

```python
def normalize_device_string(self, device: str) -> str:
    if not isinstance(device, str) or not device or device == "cpu":
        return "cpu"
    prefix = device.split(":")[0]
    return f"{prefix}:0"
```

No override needed in `NvidiaTritonAdapter` or `AmdTritonAdapter` — the default handles both.

### 4. Scratch allocator device parameterization (`tritonparse/reproducer/placeholder_replacer.py`)

The hardcoded `device='cuda'` in `_replace_launch_kernel_body()` is now adapter-driven:

```python
_adapter = get_backend_registry().resolve(adapter_name=f"{_backend}_triton")
_device_prefix = _adapter.pytorch_module
f"    return torch.empty(size, dtype=torch.int8, device='{_device_prefix}')"
```

### 5. Sync call parameterization (`tritonparse/reproducer/placeholder_replacer.py` + `templates/example.py`)

Replaced the hardcoded `torch.cuda.synchronize()` in the template with a placeholder:

```python
# {{SYNC_CALL_PLACEHOLDER}}
```

Added `SYNC_CALL_PLACEHOLDER` constant and `_replace_sync_call` handler that resolves the adapter at generation time and emits the correct sync call.

### 6. `_create_base_tensor` runtime normalization generalized (`tritonparse/reproducer/utils.py`)

Changed from CUDA-specific check to generic logic:

```python
# Before
if isinstance(device, str) and device.startswith("cuda"):
    device = "cuda:0"

# After
if isinstance(device, str) and device != "cpu":
    prefix = device.split(":")[0]
    device = f"{prefix}:0"
```

This function is AST-extracted and embedded into the generated script, running at reproducer runtime where no adapter is available. This serves as a safety net — primary normalization is done by the orchestrator at generation time.

---

## Architecture

### Reproducer backend decision flow comparison

```mermaid
flowchart LR
    subgraph before ["Before (hardcoded)"]
        direction TB
        A1["orchestrator"] --> B1["Write JSON as-is\nno device handling"]
        A1 --> C1["placeholder_replacer\nhardcoded device='cuda'"]
        A1 --> D1["example.py template\nhardcoded torch.cuda.synchronize()"]
        A1 --> E1["_create_base_tensor\nhardcoded startswith('cuda')"]
    end

    subgraph after ["After (adapter-driven)"]
        direction TB
        A2["orchestrator"] --> B2["resolve adapter\nset device = {prefix}:0"]
        A2 --> C2["placeholder_replacer\nadapter.pytorch_module"]
        A2 --> D2["SYNC_CALL_PLACEHOLDER\ntorch.{prefix}.synchronize()"]
        A2 --> E2["_create_base_tensor\ngeneric normalization (safety net)"]
    end

    style after fill:#e1f5e1,stroke:#4caf50,stroke-width:2px
    style before fill:#ffe1e1,stroke:#f44336,stroke-width:2px
```

---

## Testing

Validation performed for this PR includes:

- `make format-check`
<img width="1091" height="231" alt="image" src="https://github.com/user-attachments/assets/8da2034a-ddc6-4eb6-809b-4be1cbc4bd92" />



- `make test-cuda`
<img width="1544" height="480" alt="image" src="https://github.com/user-attachments/assets/afb6c1e5-939a-45aa-aacf-39862668c51a" />



- `make test`
<img width="1371" height="418" alt="image" src="https://github.com/user-attachments/assets/1d57291a-71e7-4f5a-8045-cdc82637c2c8" />


---

## Files Changed

| File | Change |
|------|--------|
| `tritonparse/backend.py` | `normalize_device_string()` from no-op to generic normalization; `pytorch_module` from `"torch.cuda"` to `"cuda"` |
| `tritonparse/reproducer/orchestrator.py` | Adapter-driven device normalization before JSON write |
| `tritonparse/reproducer/placeholder_replacer.py` | Scratch allocator device parameterized; added `SYNC_CALL_PLACEHOLDER` + `_replace_sync_call` handler |
| `tritonparse/reproducer/templates/example.py` | `torch.cuda.synchronize()` → `# {{SYNC_CALL_PLACEHOLDER}}` |
| `tritonparse/reproducer/utils.py` | `_create_base_tensor` normalization from CUDA-specific to generic |
| `tests/cpu/test_multi_backend_stage.py` | Added `TestNormalizeDeviceString` |
| `tests/cpu/test_placeholder_replacer.py` | Added `TestReproducerAdapterDriven` |

---

## Summary

This PR completes the **final step of Flexible Backend Support RFC Phase 1**. All reader-side backend convergence work is now done:

- PR 1: Adapter infrastructure + `trace_processor.py` refactoring
- PR 2: Parser dispatch refactoring
- PR 3: Analysis dispatch refactoring
- PR 4: Derived artifact refactoring
- **PR 5 (this PR): Reproducer migration**

All backend hardcodes in the `reproducer/` module have been moved to the adapter contract. Device strings and sync calls are both derived from `adapter.pytorch_module`. Adding a new backend only requires implementing the corresponding adapter and defining `pytorch_module` — the reproducer adapts automatically with no changes to shared code.
