### PR TITLE
Trace Enhancement — Data Foundation for Frontend Generalization

### DIFF
--- a/tritonparse/parse/trace_processor.py
+++ b/tritonparse/parse/trace_processor.py
@@ -498,7 +498,7 @@ def parse_single_trace_content(trace_content: str) -> str:
                 for stage in adapter.get_ir_stages()
             ]
         except ValueError:
-            logger.debug("Could not resolve adapter for ir_stages; skipping")
+            logger.warning("Could not resolve adapter for ir_stages; skipping")
 
         # Extract original num_warps from TTGIR for warp-specialized kernels.
         # If upstream Triton already set num_warps_base, trust it; otherwise

--- a/tritonparse/parse/trace_processor.py
+++ b/tritonparse/parse/trace_processor.py
@@ -478,6 +478,28 @@ def parse_single_trace_content(trace_content: str) -> str:
         # Returns: {"ttir": "kernel.ttir", "ttgir": "kernel.ttgir", ...}
         stage_keys = _resolve_source_mappable_stage_keys(entry)
 
+        # Add ir_stages descriptor to payload for frontend consumption.
+        # Placed before the early return so compilations without IR files
+        # still carry stage metadata.
+        try:
+            from tritonparse.backend import get_backend_registry
+
+            adapter = get_backend_registry().resolve_from_trace(metadata)
+            payload["ir_stages"] = [
+                {
+                    "name": stage.name,
+                    "extension": stage.extension,
+                    "display_name": stage.display_name,
+                    "display_order": stage.display_order,
+                    "is_text": stage.is_text,
+                    "supports_source_mapping": stage.supports_source_mapping,
+                    "syntax_id": stage.syntax_id,
+                }
+                for stage in adapter.get_ir_stages()
+            ]
+        except ValueError:
+            logger.debug("Could not resolve adapter for ir_stages; skipping")
+
         # Extract original num_warps from TTGIR for warp-specialized kernels.
         # If upstream Triton already set num_warps_base, trust it; otherwise
         # recover the value from the TTGIR "ttg.num-warps" module attribute.

--- a/tritonparse/validation/schemas/compilation.schema.json
+++ b/tritonparse/validation/schemas/compilation.schema.json
@@ -159,6 +159,11 @@
           "type": "object",
           "description": "IR-to-source-code line mappings keyed by IR type (added during processing).",
           "additionalProperties": true
+        },
+        "ir_stages": {
+          "type": "array",
+          "description": "Ordered list of IR compilation stages for this kernel, resolved from the backend adapter.",
+          "items": { "$ref": "#/definitions/IRStage" }
         }
       }
     },
@@ -191,6 +196,43 @@
         "function_end_line": {
           "type": "integer",
           "description": "Function end line (with full-file mode)."
+        }
+      }
+    },
+    "IRStage": {
+      "type": "object",
+      "description": "Metadata for a single IR compilation stage.",
+      "required": ["name", "extension", "display_name", "display_order", "is_text", "supports_source_mapping", "syntax_id"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Internal stage identifier (e.g., 'ttir', 'ttgir', 'llir')."
+        },
+        "extension": {
+          "type": "string",
+          "description": "File extension for this stage's IR artifact (e.g., '.ttir', '.ptx')."
+        },
+        "display_name": {
+          "type": "string",
+          "description": "Human-readable stage name for UI display."
+        },
+        "display_order": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Order in which to display this stage relative to others."
+        },
+        "is_text": {
+          "type": "boolean",
+          "description": "Whether the IR content is human-readable text."
+        },
+        "supports_source_mapping": {
+          "type": "boolean",
+          "description": "Whether this stage supports source-to-IR line mapping."
+        },
+        "syntax_id": {
+          "type": "string",
+          "description": "Identifier for the syntax highlighting mode to use."
         }
       }
     },


### PR DESCRIPTION
## Background

- **RFC**: https://github.com/meta-pytorch/tritonparse/issues/367
- **Prior PRs**:
  - https://github.com/meta-pytorch/tritonparse/pull/387 (Reader-side infrastructure & generic parse logic)
  - https://github.com/meta-pytorch/tritonparse/pull/394 (Parser dispatch refactoring)
  - https://github.com/meta-pytorch/tritonparse/pull/401 (Analysis dispatch refactoring)
  - https://github.com/meta-pytorch/tritonparse/pull/403 (Derived artifact refactoring)
  - https://github.com/meta-pytorch/tritonparse/pull/404 (Reproducer refactoring)

The current frontend contains extensive hardcoded logic tied to backend IR stages (stage names, display names, syntax highlighting, default panels, etc.). To achieve frontend generalization — where the frontend does not depend on any specific backend and all backend information is dynamically read from the trace — the trace must first carry sufficient data.

**Note:** This document does not cover the generalization of the IR Analysis feature. That will be addressed in a follow-up PR.

---

## 1. What Data the Frontend Needs

The frontend hardcodes stage-related information in multiple locations:

| Frontend File | Hardcoded Content |
|---|---|
| `irLanguage.ts` | Stage → display name mapping: `"ttgir"` → `"TTGIR (TritonGPU MLIR)"` |
| `languageUtils.ts` | Stage → syntax highlighting mapping: `"ttgir"` → `"mlir"` |
| `CodeComparisonView.tsx` | Source-mappable stage list: `[{type:"ttgir"}, {type:"ptx"}, ...]` |
| `CodeView.tsx` | Default panel selection: left `"ttgir"`, right `"ptx"` |
| `CodeComparisonView.tsx` | Default panel titles: `"TTGIR"` / `"PTX"` |
| `FileDiffSession.tsx` | Default irType: `"ttgir"` |
| `FileDiffView.tsx` | `"ttgir"` fallback value |
| `SingleCodeViewer.tsx` | Intra-file line grouping anchor: `ttgir_line` |

Frontend generalization (excluding IR Analysis) requires only one additional piece of data in the trace: **a list of stage definitions per compilation event.** See Section 2 for the field specification.

---

## 2. New Trace Field: `compilation.payload.ir_stages`

### Location

In the `payload` dictionary of each `compilation` event, alongside existing fields such as `file_content` and `source_mappings`.

### Why per-compilation

Different compilations within the same trace may use different backends (e.g., CUDA and AMD kernels in the same process). Each compilation event carries its own stage descriptor.

### Format

NVIDIA backend example:

```jsonc
{
  "event_type": "compilation",
  "payload": {
    "metadata": { "...existing fields..." },
    "file_content": { "...existing fields..." },
    "source_mappings": { "...existing fields..." },

    // ========== NEW ==========
    "ir_stages": [
      {
        "name": "ttir",
        "extension": ".ttir",
        "display_name": "TTIR",
        "display_order": 10,
        "is_text": true,
        "supports_source_mapping": true,
        "syntax_id": "mlir"
      },
      {
        "name": "ttgir",
        "extension": ".ttgir",
        "display_name": "TTGIR",
        "display_order": 20,
        "is_text": true,
        "supports_source_mapping": true,
        "syntax_id": "mlir"
      },
      {
        "name": "llir",
        "extension": ".llir",
        "display_name": "LLIR",
        "display_order": 30,
        "is_text": true,
        "supports_source_mapping": true,
        "syntax_id": "llvm"
      },
      {
        "name": "ptx",
        "extension": ".ptx",
        "display_name": "PTX",
        "display_order": 40,
        "is_text": true,
        "supports_source_mapping": true,
        "syntax_id": "ptx"
      },
      {
        "name": "cubin",
        "extension": ".cubin",
        "display_name": "CUBIN",
        "display_order": 50,
        "is_text": false,
        "supports_source_mapping": false,
        "syntax_id": "plaintext"
      },
      {
        "name": "sass",
        "extension": ".sass",
        "display_name": "SASS",
        "display_order": 60,
        "is_text": true,
        "supports_source_mapping": true,
        "syntax_id": "asm"
      },
      {
        "name": "json",
        "extension": ".json",
        "display_name": "JSON",
        "display_order": 100,
        "is_text": true,
        "supports_source_mapping": false,
        "syntax_id": "json"
      }
    ]
  }
}
```

### Field Reference

| Field | Type | Description |
|---|---|---|
| `name` | string | Stage identifier. Matches keys in `source_mappings` and is used to construct cross-reference field names (`{name}_lines`, `{name}_line`) |
| `extension` | string | File extension used in `file_content` keys (e.g., `"add_kernel.ttir"` contains this extension) |
| `display_name` | string | Human-readable name for UI headers, panel titles, and tabs |
| `display_order` | int | UI display order. Lower values appear first. Convention: 10, 20, 30... with gaps for future insertion |
| `is_text` | bool | Whether the stage content is text (viewable) or binary (not viewable) |
| `supports_source_mapping` | bool | Whether this stage supports source-to-source line mapping |
| `syntax_id` | string | Syntax highlighting language identifier for the web code editor. Values: `"mlir"`, `"llvm"`, `"ptx"`, `"asm"`, `"amdgcn"`, `"json"`, `"plaintext"` |

Note: `parser_id` is intentionally excluded — it is a backend-internal concern (used to select the IR parser) and irrelevant to the frontend.

---

## 3. Backend Implementation

In `trace_processor.py`, inside `parse_single_trace_content()`, after adapter resolution, serialize `adapter._stages` into the compilation event payload:

```python
# After adapter resolution (existing code)
payload["ir_stages"] = [
    {
        "name": stage.name,
        "extension": stage.extension,
        "display_name": stage.display_name,
        "display_order": stage.display_order,
        "is_text": stage.is_text,
        "supports_source_mapping": stage.supports_source_mapping,
        "syntax_id": stage.syntax_id,
    }
    for stage in adapter._stages
]
```

The data source is the `IRStageDescriptor` dataclass. Each adapter defines its own `_stages` list in `__init__`.

## 4. Testing
- `make format-check`
<img width="1007" height="254" alt="image" src="https://github.com/user-attachments/assets/b38d953a-4a34-45ee-a109-937fa31117af" />


- `make test-cuda`
<img width="1296" height="396" alt="image" src="https://github.com/user-attachments/assets/73619449-1dd4-4029-85e7-3ad8da51cd54" />


- `make test`
<img width="1400" height="400" alt="image" src="https://github.com/user-attachments/assets/ce8fa564-a22c-4605-8337-664e10cc3d52" />
