### PR TITLE
Frontend Generalization — Eliminate Hardcoded Stage Names via `ir_stages`

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -401,8 +401,9 @@ function App() {
         <SingleCodeViewer
           irFile={irFile}
           title={selectedIR}
-          language={mapLanguageToHighlighter(selectedIR)}
+          language={mapLanguageToHighlighter(selectedIR, kernel?.ir_stages)}
           onBack={handleBackFromIRView}
+          irStages={kernel?.ir_stages}
         />
       );
     } else if (sess.preview.active) {

--- a/website/src/components/CodeComparisonView.tsx
+++ b/website/src/components/CodeComparisonView.tsx
@@ -6,6 +6,7 @@ import CodeViewer from "./CodeViewer";
 import CopyCodeButton from "./CopyCodeButton";
 import {
     IRFile,
+    IRStageDescriptor,
     PythonSourceCodeInfo,
     SourceMapping,
     getIRType,
@@ -31,6 +32,7 @@ interface CodeComparisonViewProps {
     py_code_info?: PythonSourceCodeInfo;
     showPythonSource?: boolean;
     pythonMapping?: Record<string, SourceMapping>;
+    irStages?: IRStageDescriptor[];
 }
 
 /**
@@ -79,6 +81,7 @@ const CodeComparisonView: React.FC<CodeComparisonViewProps> = ({
     py_code_info,
     showPythonSource = false,
     pythonMapping,
+    irStages,
 }) => {
     // ==================== State Management ====================
 
@@ -195,8 +198,8 @@ const CodeComparisonView: React.FC<CodeComparisonViewProps> = ({
         title: leftPanel.title || "TTGIR",
         content: leftPanel.content || leftPanel.code?.content || "",
         sourceMapping: leftPanel.code?.source_mapping || {},
-        displayLanguage: getDisplayLanguage(leftPanel.title || "TTGIR")
-    }), [leftPanel.title, leftPanel.content, leftPanel.code]);
+        displayLanguage: getDisplayLanguage(leftPanel.title || "TTGIR", irStages)
+    }), [leftPanel.title, leftPanel.content, leftPanel.code, irStages]);
 
     /**
      * Memoized right panel data
@@ -206,8 +209,8 @@ const CodeComparisonView: React.FC<CodeComparisonViewProps> = ({
         title: rightPanel.title || "PTX",
         content: rightPanel.content || rightPanel.code?.content || "",
         sourceMapping: rightPanel.code?.source_mapping || {},
-        displayLanguage: getDisplayLanguage(rightPanel.title || "PTX")
-    }), [rightPanel.title, rightPanel.content, rightPanel.code]);
+        displayLanguage: getDisplayLanguage(rightPanel.title || "PTX", irStages)
+    }), [rightPanel.title, rightPanel.content, rightPanel.code, irStages]);
 
     /**
      * Memoized Python source info
@@ -245,14 +248,18 @@ const CodeComparisonView: React.FC<CodeComparisonViewProps> = ({
             const sourceMapping = sourceMappings[lineKey];
             const targetIRType = getIRType(targetTitle);
 
-            const irTypesToCheck = [
-                { type: "ttgir", property: "ttgir_lines" },
-                { type: "ttir", property: "ttir_lines" },
-                { type: "ptx", property: "ptx_lines" },
-                { type: "llir", property: "llir_lines" },
-                { type: "amdgcn", property: "amdgcn_lines" },
-                { type: "sass", property: "sass_lines" }
-            ];
+            const irTypesToCheck = irStages && irStages.length > 0
+                ? irStages
+                    .filter(s => s.supports_source_mapping)
+                    .map(s => ({ type: s.name, property: `${s.name}_lines` }))
+                : [
+                    { type: "ttgir", property: "ttgir_lines" },
+                    { type: "ttir", property: "ttir_lines" },
+                    { type: "ptx", property: "ptx_lines" },
+                    { type: "llir", property: "llir_lines" },
+                    { type: "amdgcn", property: "amdgcn_lines" },
+                    { type: "sass", property: "sass_lines" }
+                ];
 
             for (const { type, property } of irTypesToCheck) {
                 if (targetIRType === type &&

--- a/website/src/components/CodeComparisonView.tsx
+++ b/website/src/components/CodeComparisonView.tsx
@@ -229,8 +229,8 @@ const CodeComparisonView: React.FC<CodeComparisonViewProps> = ({
     // ==================== Pure Utility Functions ====================
 
     /**
-     * Pure function: Calculate mapped lines from source to target IR
-     * No external dependencies - only uses parameters
+     * Calculate mapped lines from source to target IR.
+     * Depends on irStages for dynamic stage discovery.
      * @param sourceMappings Source mapping record
      * @param lineNumber Line number in source
      * @param targetTitle Target panel title (to determine IR type)
@@ -273,7 +273,7 @@ const CodeComparisonView: React.FC<CodeComparisonViewProps> = ({
 
             return [];
         },
-        [] // Empty deps - pure function, never recreated
+        [irStages]
     );
 
     /**

--- a/website/src/components/SingleCodeViewer.tsx
+++ b/website/src/components/SingleCodeViewer.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import CodeViewer from "./CodeViewer";
-import { IRFile } from "../utils/dataLoader";
+import { IRFile, IRStageDescriptor, ProcessedKernel, getGroupingAnchor } from "../utils/dataLoader";
 import { getDisplayLanguage } from "../utils/irLanguage";
 import CopyCodeButton from "./CopyCodeButton";
 import { ArrowLeftIcon } from "./icons";
@@ -14,6 +14,7 @@ interface SingleCodeViewerProps {
   title: string; // Title to display for the code view
   language?: string; // Language for syntax highlighting
   onBack: () => void; // Callback function when back button is clicked
+  irStages?: IRStageDescriptor[];
 }
 
 /**
@@ -26,13 +27,14 @@ const SingleCodeViewer: React.FC<SingleCodeViewerProps> = ({
   title,
   language = "plaintext",
   onBack,
+  irStages,
 }) => {
   // Track highlighted lines for self-referential mapping
   const [highlightedLines, setHighlightedLines] = useState<number[]>([]);
 
   // Determine content to display (either from direct content or from IRFile)
   const codeContent = irContent || (irFile ? irFile.content : "");
-  const displayLanguage = getDisplayLanguage(title);
+  const displayLanguage = getDisplayLanguage(title, irStages);
 
   // Get source mapping if available
   const sourceMapping = irFile?.source_mapping;
@@ -42,27 +44,27 @@ const SingleCodeViewer: React.FC<SingleCodeViewerProps> = ({
    * Can be used to highlight related lines within the same file
    */
   const handleLineClick = (lineNumber: number) => {
-    // Toggle highlight for the clicked line
     setHighlightedLines([lineNumber]);
 
-    // If there's source mapping available, we could highlight related lines
-    // For example lines that map to the same source code location
     if (sourceMapping) {
       const lineKey = lineNumber.toString();
-      const clickedMapping = sourceMapping[lineKey];
+      const clickedMapping = sourceMapping[lineKey] as Record<string, unknown> | undefined;
+      const anchorStage = irStages
+        ? getGroupingAnchor({ ir_stages: irStages } as ProcessedKernel)
+        : "ttgir";
+      const anchorProperty = `${anchorStage}_line`;
 
-      if (clickedMapping && clickedMapping.ttgir_line) {
-        // Find all lines that map to the same TTGIR line
+      if (clickedMapping && clickedMapping[anchorProperty] != null) {
+        const anchorValue = clickedMapping[anchorProperty];
         const relatedLines = Object.entries(sourceMapping)
           .filter(
             ([key, mapping]) =>
-              mapping.ttgir_line === clickedMapping.ttgir_line &&
-              parseInt(lineKey, 10) !== parseInt(key, 10) // Skip the clicked line itself
+              (mapping as Record<string, unknown>)[anchorProperty] === anchorValue &&
+              parseInt(lineKey, 10) !== parseInt(key, 10)
           )
           .map(([line]) => parseInt(line, 10));
 
         if (relatedLines.length > 0) {
-          // Include the clicked line and any related lines
           setHighlightedLines([lineNumber, ...relatedLines]);
         }
       }

--- a/website/src/components/SingleCodeViewer.tsx
+++ b/website/src/components/SingleCodeViewer.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import CodeViewer from "./CodeViewer";
-import { IRFile, IRStageDescriptor, ProcessedKernel, getGroupingAnchor } from "../utils/dataLoader";
+import { IRFile, IRStageDescriptor, getGroupingAnchor } from "../utils/dataLoader";
 import { getDisplayLanguage } from "../utils/irLanguage";
 import CopyCodeButton from "./CopyCodeButton";
 import { ArrowLeftIcon } from "./icons";
@@ -49,9 +49,7 @@ const SingleCodeViewer: React.FC<SingleCodeViewerProps> = ({
     if (sourceMapping) {
       const lineKey = lineNumber.toString();
       const clickedMapping = sourceMapping[lineKey] as Record<string, unknown> | undefined;
-      const anchorStage = irStages
-        ? getGroupingAnchor({ ir_stages: irStages } as ProcessedKernel)
-        : "ttgir";
+      const anchorStage = getGroupingAnchor(irStages);
       const anchorProperty = `${anchorStage}_line`;
 
       if (clickedMapping && clickedMapping[anchorProperty] != null) {

--- a/website/src/pages/CodeView.tsx
+++ b/website/src/pages/CodeView.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from "react";
-import { ProcessedKernel, getIRType } from "../utils/dataLoader";
+import { ProcessedKernel, getIRType, getDefaultPanels } from "../utils/dataLoader";
 import CodeComparisonView from "../components/CodeComparisonView";
 import { getDisplayLanguage } from "../utils/irLanguage";
 import { mapLanguageToHighlighter } from "../utils/languageUtils";
@@ -14,26 +14,27 @@ interface CodeViewProps {
 }
 
 /**
- * Helper function to find default IR files for left and right panels
+ * Helper function to find default IR files for left and right panels.
+ * Uses getDefaultPanels() to determine which stages to select, then
+ * matches stage names to actual filenames in irFiles.
+ * Falls back to legacy logic for old traces without ir_stages.
  */
-function findDefaultIRFiles(irFiles: string[]): { left: string; right: string } {
-  let left = "";
-  let right = "";
+function findDefaultIRFiles(irFiles: string[], kernel?: ProcessedKernel): { left: string; right: string } {
+  const defaultPanels = kernel ? getDefaultPanels(kernel) : { left: "ttgir", right: "ptx" };
 
-  const ttgirFile = irFiles.find(key => key.toLowerCase().includes("ttgir"));
-  if (ttgirFile) {
-    left = ttgirFile;
-  } else if (irFiles.length > 0) {
-    left = irFiles[0];
-  }
+  const leftFile = irFiles.find(key => key.toLowerCase().includes(defaultPanels.left));
+  const rightFile = irFiles.find(key => key.toLowerCase().includes(defaultPanels.right));
 
-  const ptxFile = irFiles.find(key => key.toLowerCase().includes("ptx"));
-  if (ptxFile) {
-    right = ptxFile;
-  } else if (irFiles.length > 1) {
-    right = irFiles[1];
-  } else if (irFiles.length === 1) {
-    right = irFiles[0];
+  let left = leftFile || irFiles[0] || "";
+  let right = rightFile || irFiles[1] || irFiles[0] || "";
+
+  // Legacy fallback: if ir_stages was absent and getDefaultPanels returned defaults
+  // that don't match any file, try the old ttgir/ptx heuristic
+  if (!kernel?.ir_stages) {
+    const ttgirFile = irFiles.find(key => key.toLowerCase().includes("ttgir"));
+    if (ttgirFile) left = ttgirFile;
+    const ptxFile = irFiles.find(key => key.toLowerCase().includes("ptx"));
+    if (ptxFile) right = ptxFile;
   }
 
   return { left, right };
@@ -91,7 +92,7 @@ const CodeViewInner: React.FC<{
           </select>
           {leftIR && (
             <div className="text-sm text-gray-600 mt-1">
-              Language: {getDisplayLanguage(leftIR)}
+              Language: {getDisplayLanguage(leftIR, kernel?.ir_stages)}
             </div>
           )}
         </div>
@@ -134,7 +135,7 @@ const CodeViewInner: React.FC<{
           </select>
           {rightIR && (
             <div className="text-sm text-gray-600 mt-1">
-              Language: {getDisplayLanguage(rightIR)}
+              Language: {getDisplayLanguage(rightIR, kernel?.ir_stages)}
             </div>
           )}
         </div>
@@ -175,7 +176,7 @@ const CodeViewInner: React.FC<{
                 content: kernel.irFiles[leftIR],
                 source_mapping: kernel.sourceMappings?.[getIRType(leftIR)] || {}
               },
-              language: mapLanguageToHighlighter(leftIR),
+              language: mapLanguageToHighlighter(leftIR, kernel?.ir_stages),
               title: leftIR
             }}
             rightPanel={{
@@ -183,12 +184,13 @@ const CodeViewInner: React.FC<{
                 content: kernel.irFiles[rightIR],
                 source_mapping: kernel.sourceMappings?.[getIRType(rightIR)] || {}
               },
-              language: mapLanguageToHighlighter(rightIR),
+              language: mapLanguageToHighlighter(rightIR, kernel?.ir_stages),
               title: rightIR
             }}
             py_code_info={kernel.pythonSourceInfo}
             showPythonSource={showPythonSource && hasPythonSource}
             pythonMapping={kernel.sourceMappings?.["python"] || {}}
+            irStages={kernel.ir_stages}
           />
         </div>
       ) : (
@@ -219,8 +221,8 @@ const CodeView: React.FC<CodeViewProps> = ({ kernels, selectedKernel = 0 }) => {
   // Compute default IR files
   const defaultIRFiles = useMemo(() => {
     if (irFiles.length === 0) return { left: "", right: "" };
-    return findDefaultIRFiles(irFiles);
-  }, [irFiles]);
+    return findDefaultIRFiles(irFiles, kernel ?? undefined);
+  }, [irFiles, kernel]);
 
   // Return a message if no kernel data is available
   if (!kernel) {

--- a/website/src/pages/CodeView.tsx
+++ b/website/src/pages/CodeView.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from "react";
-import { ProcessedKernel, getIRType, getDefaultPanels } from "../utils/dataLoader";
+import { ProcessedKernel, getIRType, getDefaultPanels, IRStageDescriptor } from "../utils/dataLoader";
 import CodeComparisonView from "../components/CodeComparisonView";
 import { getDisplayLanguage } from "../utils/irLanguage";
 import { mapLanguageToHighlighter } from "../utils/languageUtils";
@@ -19,23 +19,14 @@ interface CodeViewProps {
  * matches stage names to actual filenames in irFiles.
  * Falls back to legacy logic for old traces without ir_stages.
  */
-function findDefaultIRFiles(irFiles: string[], kernel?: ProcessedKernel): { left: string; right: string } {
-  const defaultPanels = kernel ? getDefaultPanels(kernel) : { left: "ttgir", right: "ptx" };
+function findDefaultIRFiles(irFiles: string[], irStages?: IRStageDescriptor[]): { left: string; right: string } {
+  const defaultPanels = getDefaultPanels(irStages);
 
   const leftFile = irFiles.find(key => key.toLowerCase().includes(defaultPanels.left));
   const rightFile = irFiles.find(key => key.toLowerCase().includes(defaultPanels.right));
 
-  let left = leftFile || irFiles[0] || "";
-  let right = rightFile || irFiles[1] || irFiles[0] || "";
-
-  // Legacy fallback: if ir_stages was absent and getDefaultPanels returned defaults
-  // that don't match any file, try the old ttgir/ptx heuristic
-  if (!kernel?.ir_stages) {
-    const ttgirFile = irFiles.find(key => key.toLowerCase().includes("ttgir"));
-    if (ttgirFile) left = ttgirFile;
-    const ptxFile = irFiles.find(key => key.toLowerCase().includes("ptx"));
-    if (ptxFile) right = ptxFile;
-  }
+  const left = leftFile || irFiles[0] || "";
+  const right = rightFile || irFiles[1] || irFiles[0] || "";
 
   return { left, right };
 }
@@ -221,8 +212,8 @@ const CodeView: React.FC<CodeViewProps> = ({ kernels, selectedKernel = 0 }) => {
   // Compute default IR files
   const defaultIRFiles = useMemo(() => {
     if (irFiles.length === 0) return { left: "", right: "" };
-    return findDefaultIRFiles(irFiles, kernel ?? undefined);
-  }, [irFiles, kernel]);
+    return findDefaultIRFiles(irFiles, kernel?.ir_stages);
+  }, [irFiles, kernel?.ir_stages]);
 
   // Return a message if no kernel data is available
   if (!kernel) {

--- a/website/src/pages/FileDiffView.tsx
+++ b/website/src/pages/FileDiffView.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import DiffComparisonView from "../components/DiffComparisonView";
 import { useFileDiffSession } from "../context/FileDiffSession";
-import { ProcessedKernel, loadLogData, loadLogDataFromFile, processKernelData, getIRType, getDefaultPanels } from "../utils/dataLoader";
+import { ProcessedKernel, loadLogData, loadLogDataFromFile, processKernelData, getIRType } from "../utils/dataLoader";
 import { normalizeDataUrl } from "../utils/urlUtils";
 import "../types/global.d.ts";
 
@@ -240,7 +240,7 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
   const leftKernel = leftArrayResolved[leftIdx];
   const rightKernel = kernelsRight[rightIdx];
 
-  const effectiveIrType = irType || (unionIrTypes.length > 0 ? unionIrTypes[0] : getDefaultPanels(leftKernel).left);
+  const effectiveIrType = irType || unionIrTypes[0];
 
   // Update URL on state changes (File Diff owns its params)
   const syncUrl = useCallback(() => {

--- a/website/src/pages/FileDiffView.tsx
+++ b/website/src/pages/FileDiffView.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import DiffComparisonView from "../components/DiffComparisonView";
 import { useFileDiffSession } from "../context/FileDiffSession";
-import { ProcessedKernel, loadLogData, loadLogDataFromFile, processKernelData, getIRType } from "../utils/dataLoader";
+import { ProcessedKernel, loadLogData, loadLogDataFromFile, processKernelData, getIRType, getDefaultPanels } from "../utils/dataLoader";
 import { normalizeDataUrl } from "../utils/urlUtils";
 import "../types/global.d.ts";
 
@@ -92,7 +92,7 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
     return (m === "single" || m === "all") ? m : "single";
   });
   const [irType, setIrType] = useState<string>(() =>
-    initialParams.get(PARAM_IR) || "ttgir"
+    initialParams.get(PARAM_IR) || ""
   );
 
   // Diff options (lazy init from URL params)
@@ -231,7 +231,16 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
     return Array.from(set);
   }, [kernelsLeft, kernelsRight, leftIdx, rightIdx, leftLoadedFromLocal, leftKernelsFromLocal, leftLoadedUrlLocal, leftKernelsFromUrl]);
 
-  const effectiveIrType = irType || (unionIrTypes.length > 0 ? unionIrTypes[0] : "ttgir");
+  // Resolve left/right kernels early for default panel computation
+  const leftArrayResolved = (sess.left?.kernels?.length || 0) > 0
+    ? sess.left.kernels
+    : (leftLoadedFromLocal
+      ? leftKernelsFromLocal
+      : (leftLoadedUrlLocal ? leftKernelsFromUrl : kernelsLeft));
+  const leftKernel = leftArrayResolved[leftIdx];
+  const rightKernel = kernelsRight[rightIdx];
+
+  const effectiveIrType = irType || (unionIrTypes.length > 0 ? unionIrTypes[0] : getDefaultPanels(leftKernel).left);
 
   // Update URL on state changes (File Diff owns its params)
   const syncUrl = useCallback(() => {
@@ -274,15 +283,6 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
     }, 200);
     return () => clearTimeout(id);
   }, [syncUrl]);
-
-  // UI builders
-  const leftArrayResolved = (sess.left?.kernels?.length || 0) > 0
-    ? sess.left.kernels
-    : (leftLoadedFromLocal
-      ? leftKernelsFromLocal
-      : (leftLoadedUrlLocal ? leftKernelsFromUrl : kernelsLeft));
-  const leftKernel = leftArrayResolved[leftIdx];
-  const rightKernel = kernelsRight[rightIdx];
 
   // When navigating away, temporarily hide diff editors to avoid Monaco dispose race
   const [hideDiff, setHideDiff] = useState<boolean>(false);

--- a/website/src/utils/dataLoader.ts
+++ b/website/src/utils/dataLoader.ts
@@ -734,8 +734,7 @@ export function processKernelData(logEntries: LogEntry[]): ProcessedKernel[] {
  * Get viewable stages sorted by display_order.
  * Viewable = is_text AND supports_source_mapping.
  */
-function getViewableStages(kernel: ProcessedKernel): IRStageDescriptor[] {
-    const stages = kernel.ir_stages;
+function getViewableStages(stages?: IRStageDescriptor[]): IRStageDescriptor[] {
     if (!stages || stages.length === 0) return [];
     return stages
         .filter(s => s.is_text && s.supports_source_mapping)
@@ -747,8 +746,8 @@ function getViewableStages(kernel: ProcessedKernel): IRStageDescriptor[] {
  * Rule: top 2 by display_order among viewable stages.
  * Fallback: legacy hardcoded values for old traces without ir_stages.
  */
-export function getDefaultPanels(kernel: ProcessedKernel): { left: string; right: string } {
-    const viewable = getViewableStages(kernel);
+export function getDefaultPanels(stages?: IRStageDescriptor[]): { left: string; right: string } {
+    const viewable = getViewableStages(stages);
     if (viewable.length >= 2) {
         return { left: viewable[0].name, right: viewable[1].name };
     }
@@ -765,8 +764,8 @@ export function getDefaultPanels(kernel: ProcessedKernel): { left: string; right
  * AMD:    [ttir, ttgir, llir, amdgcn]    → llir
  * Fallback: "ttgir" for old traces without ir_stages.
  */
-export function getGroupingAnchor(kernel: ProcessedKernel): string {
-    const viewable = getViewableStages(kernel);
+export function getGroupingAnchor(stages?: IRStageDescriptor[]): string {
+    const viewable = getViewableStages(stages);
     if (viewable.length > 0) {
         return viewable[Math.floor(viewable.length / 2)].name;
     }

--- a/website/src/utils/dataLoader.ts
+++ b/website/src/utils/dataLoader.ts
@@ -1,32 +1,35 @@
 import { ClpArchiveReader, isClpFile } from "clp-ffi-js/sfa";
 
 /**
- * Source mapping information that connects lines in IR code to source code
+ * Stage descriptor from the trace, describing one IR compilation stage.
+ * Used to eliminate hardcoded stage names in the frontend.
+ */
+export interface IRStageDescriptor {
+    name: string;
+    extension: string;
+    display_name: string;
+    display_order: number;
+    is_text: boolean;
+    supports_source_mapping: boolean;
+    syntax_id: string;
+}
+
+/**
+ * Source mapping information that connects lines in IR code to source code.
+ * Dynamic cross-reference fields follow the pattern:
+ *   {stage_name}_line (number) - self-reference
+ *   {stage_name}_lines (number[]) - cross-reference to other stages
  */
 export interface SourceMapping {
     line: number;
     file?: string;
     column?: number;
-    // The {ir_type}_line fields are the line numbers in the current IR file that corresponds to
-    // the current line in the source code. It should be same with the key in the source_mapping.
-    ttgir_line?: number;
-    ttir_line?: number;
-    ptx_line?: number;
-    amdgcn_line?: number;
-    llir_line?: number;
-    sass_line?: number;
-    ptx_lines?: number[]; // Array of corresponding PTX lines
-    ttir_lines?: number[]; // Array of corresponding TTIR lines
-    ttgir_lines?: number[]; // Array of corresponding TTGIR lines
-    llir_lines?: number[]; // Array of corresponding LLIR lines
-    amdgcn_lines?: number[]; // Array of corresponding AMDGCN lines
-    sass_lines?: number[]; // Array of corresponding SASS lines
-    // New fields for location alias support
-    type?: string; // Type of mapping entry, e.g., "loc_def" for loc definition lines
-    kind?: string; // Deprecated alias for type, kept for backward compatibility
-    loc_id?: string; // The #loc identifier (e.g., "13" for #loc13)
-    alias_name?: string; // Name of the alias (e.g., "x_ptr" in #loc13 = loc("x_ptr"(#loc)))
-    alias_of?: string; // The target #loc this alias points to
+    type?: string;
+    kind?: string;
+    loc_id?: string;
+    alias_name?: string;
+    alias_of?: string;
+    [key: string]: unknown;
 }
 
 /**
@@ -291,6 +294,7 @@ export interface LogEntry {
         file_content?: Record<string, string>; // Mapping from filename to content
         source_mappings?: Record<string, Record<string, SourceMapping>>; // Alternative field name for source_mapping
         python_source?: PythonSourceCodeInfo;
+        ir_stages?: IRStageDescriptor[];
     };
     // Fields for launch_diff event type
     hash?: string;
@@ -354,6 +358,7 @@ export interface ProcessedKernel {
     metadata?: KernelMetadata; // Compilation metadata
     launchDiff?: LogEntry; // Aggregated launch event differences
     ir_analysis?: IRAnalysisData; // Stored IR Analysis information.
+    ir_stages?: IRStageDescriptor[]; // Stage descriptors from trace (for frontend generalization).
     autotuneSessions?: AutotuneAnalysisEvent[]; // Autotune analysis sessions associated with this kernel
     winnerRunCount?: number; // Number of times this kernel was run as the autotuning winner
     // Fields for fake compilation events (inferred from launch events when no real compilation exists)
@@ -622,6 +627,7 @@ export function processKernelData(logEntries: LogEntry[]): ProcessedKernel[] {
                 sourceMappings,
                 pythonSourceInfo: entry.payload.python_source,
                 metadata: entry.payload.metadata,
+                ir_stages: entry.payload.ir_stages,
                 // Fake compilation fields
                 isFake: entry.is_fake,
                 fakeReason: entry.fake_reason,
@@ -718,4 +724,51 @@ export function processKernelData(logEntries: LogEntry[]): ProcessedKernel[] {
 
     const finalKernels = Array.from(kernelsByHash.values());
     return finalKernels;
+}
+
+// =============================================================================
+// IR Stages Utility Functions
+// =============================================================================
+
+/**
+ * Get viewable stages sorted by display_order.
+ * Viewable = is_text AND supports_source_mapping.
+ */
+function getViewableStages(kernel: ProcessedKernel): IRStageDescriptor[] {
+    const stages = kernel.ir_stages;
+    if (!stages || stages.length === 0) return [];
+    return stages
+        .filter(s => s.is_text && s.supports_source_mapping)
+        .sort((a, b) => a.display_order - b.display_order);
+}
+
+/**
+ * Get default left/right panel stage names from ir_stages.
+ * Rule: top 2 by display_order among viewable stages.
+ * Fallback: legacy hardcoded values for old traces without ir_stages.
+ */
+export function getDefaultPanels(kernel: ProcessedKernel): { left: string; right: string } {
+    const viewable = getViewableStages(kernel);
+    if (viewable.length >= 2) {
+        return { left: viewable[0].name, right: viewable[1].name };
+    }
+    if (viewable.length === 1) {
+        return { left: viewable[0].name, right: viewable[0].name };
+    }
+    return { left: "ttgir", right: "ptx" };
+}
+
+/**
+ * Get the grouping anchor stage name from ir_stages.
+ * Rule: index = Math.floor(length / 2) among viewable stages.
+ * NVIDIA: [ttir, ttgir, llir, ptx, sass] → llir
+ * AMD:    [ttir, ttgir, llir, amdgcn]    → llir
+ * Fallback: "ttgir" for old traces without ir_stages.
+ */
+export function getGroupingAnchor(kernel: ProcessedKernel): string {
+    const viewable = getViewableStages(kernel);
+    if (viewable.length > 0) {
+        return viewable[Math.floor(viewable.length / 2)].name;
+    }
+    return "ttgir";
 }

--- a/website/src/utils/irLanguage.ts
+++ b/website/src/utils/irLanguage.ts
@@ -1,30 +1,41 @@
+import type { IRStageDescriptor } from "./dataLoader";
+
 /**
  * Utility functions for IR language display
  */
 
 /**
- * Get a user-friendly display name for the IR language
- * @param irType - The type/name of IR file
- * @returns A human-readable language name
+ * Get a user-friendly display name for the IR language.
+ * When irStages is available, looks up the display_name from stage descriptors.
+ * Otherwise falls back to hardcoded legacy logic for backward compatibility.
  */
-export const getDisplayLanguage = (irType: string): string => {
-  if (irType.toLowerCase().endsWith("ttgir")) {
+export const getDisplayLanguage = (irType: string, irStages?: IRStageDescriptor[]): string => {
+  // Try dynamic lookup from ir_stages
+  if (irStages && irStages.length > 0) {
+    const type = irType.split('.').pop()?.toLowerCase() || irType.toLowerCase();
+    const stage = irStages.find(s => s.name === type);
+    if (stage) return stage.display_name;
+  }
+
+  // Fallback: legacy hardcoded logic
+  const lower = irType.toLowerCase();
+  if (lower.endsWith("ttgir")) {
     return "TTGIR (TritonGPU MLIR)";
-  } else if (irType.toLowerCase().endsWith("ttir")) {
+  } else if (lower.endsWith("ttir")) {
     return "TTIR (Triton MLIR)";
-  } else if (irType.toLowerCase().endsWith("llir")) {
+  } else if (lower.endsWith("llir")) {
     return "LLIR (LLVM IR)";
-  } else if (irType.toLowerCase().endsWith("ptx")) {
+  } else if (lower.endsWith("ptx")) {
     return "PTX (NVIDIA Parallel Thread Execution)";
-  } else if (irType.toLowerCase().endsWith("cubin")) {
+  } else if (lower.endsWith("cubin")) {
     return "CUBIN (NVIDIA CUDA Binary)";
-  } else if (irType.toLowerCase().endsWith("python")) {
+  } else if (lower.endsWith("python")) {
     return "Python";
-  } else if (irType.toLowerCase().endsWith("json")) {
+  } else if (lower.endsWith("json")) {
     return "JSON";
-  } else if (irType.toLowerCase().endsWith("amdgcn")) {
+  } else if (lower.endsWith("amdgcn")) {
     return "AMDGCN (AMD GCN Assembly)";
-  } else if (irType.toLowerCase().endsWith("sass")) {
+  } else if (lower.endsWith("sass")) {
     return "SASS (NVIDIA Shader Assembly)";
   } else {
     return irType;

--- a/website/src/utils/languageUtils.ts
+++ b/website/src/utils/languageUtils.ts
@@ -1,12 +1,20 @@
-/**
- * Maps our internal language names to syntax highlighter languages
- * @param language Internal language identifier
- * @returns Syntax highlighter language identifier
- */
-export const mapLanguageToHighlighter = (language: string): string => {
-  const lowerCaseLanguage = language.toLowerCase();
+import type { IRStageDescriptor } from "./dataLoader";
 
-  // Handle language types with endsWith for better accuracy
+/**
+ * Maps our internal language names to syntax highlighter languages.
+ * When irStages is available, looks up the syntax_id from stage descriptors.
+ * Otherwise falls back to hardcoded legacy logic for backward compatibility.
+ */
+export const mapLanguageToHighlighter = (language: string, irStages?: IRStageDescriptor[]): string => {
+  // Try dynamic lookup from ir_stages
+  if (irStages && irStages.length > 0) {
+    const type = language.split('.').pop()?.toLowerCase() || language.toLowerCase();
+    const stage = irStages.find(s => s.name === type);
+    if (stage) return stage.syntax_id;
+  }
+
+  // Fallback: legacy hardcoded logic
+  const lowerCaseLanguage = language.toLowerCase();
   if (lowerCaseLanguage.endsWith("ttgir") || lowerCaseLanguage.endsWith("ttir")) {
     return 'mlir';
   } else if (lowerCaseLanguage.endsWith("llir")) {
@@ -16,7 +24,7 @@ export const mapLanguageToHighlighter = (language: string): string => {
   } else if (lowerCaseLanguage.endsWith("amdgcn")) {
     return 'amdgcn';
   } else if (lowerCaseLanguage.endsWith("sass")) {
-    return 'asm';  // SASS is NVIDIA assembly, use generic asm highlighting
+    return 'asm';
   } else if (lowerCaseLanguage === "python") {
     return 'python';
   }


### PR DESCRIPTION
## Background

- **RFC**: https://github.com/meta-pytorch/tritonparse/issues/367
- **Prior PRs**:
  - https://github.com/meta-pytorch/tritonparse/pull/387 (Reader-side infrastructure & generic parse logic)
  - https://github.com/meta-pytorch/tritonparse/pull/394 (Parser dispatch refactoring)
  - https://github.com/meta-pytorch/tritonparse/pull/401 (Analysis dispatch refactoring)
  - https://github.com/meta-pytorch/tritonparse/pull/403 (Derived artifact refactoring)
  - https://github.com/meta-pytorch/tritonparse/pull/404 (Reproducer refactoring)
  - https://github.com/meta-pytorch/tritonparse/pull/406 (backend trace enrichment)

## Summary

This PR generalizes the frontend to consume the `ir_stages` field carried by each compilation event in the trace, removing all hardcoded GPU stage names (`ttgir`, `ptx`, `sass`, etc.). Every piece of logic that depends on stage names — display names, syntax highlighting, default panel selection, source mapping cross-references, and line grouping anchors — now derives its values dynamically from `ir_stages`.

For older traces that do not contain `ir_stages`, all change points retain the original hardcoded logic as a fallback path, preserving identical behavior to before this PR.

---

## Key Changes

### 1. Data Layer: `IRStageDescriptor` Interface and `ir_stages` Parsing (`dataLoader.ts`)

New `IRStageDescriptor` interface, matching the backend definition:

```typescript
export interface IRStageDescriptor {
    name: string;
    extension: string;
    display_name: string;
    display_order: number;
    is_text: boolean;
    supports_source_mapping: boolean;
    syntax_id: string;
}
```

- `ProcessedKernel` gains `ir_stages?: IRStageDescriptor[]`
- `LogEntry.payload` type gains the `ir_stages` field
- `processKernelData()` reads `entry.payload.ir_stages` from compilation events
- `SourceMapping` interface generalized: 12 hardcoded cross-reference fields (`ttgir_lines`, `ptx_lines`, etc.) replaced with `[key: string]: unknown` index signature, supporting dynamic fields for any stage name

### 2. Utility Functions: `getDefaultPanels()` and `getGroupingAnchor()` (`dataLoader.ts`)

Both functions filter stages by `is_text && supports_source_mapping` and sort by `display_order`:

- **`getDefaultPanels(kernel)`**: returns the first 2 stages as default left/right panels. Falls back to `{ left: "ttgir", right: "ptx" }`
- **`getGroupingAnchor(kernel)`**: returns the middle stage for line grouping. Falls back to `"ttgir"`

Examples:

| Backend | Viewable Stages | Default Panels | Grouping Anchor |
|---------|----------------|----------------|-----------------|
| NVIDIA  | ttir, ttgir, llir, ptx, sass | ttir / ttgir | llir |
| AMD     | ttir, ttgir, llir, amdgcn | ttir / ttgir | llir |

### 3. Dynamic Display Names (`irLanguage.ts`)

`getDisplayLanguage(irType, irStages?)` gains an optional `irStages` parameter. It first looks up `display_name` from `ir_stages`; if not found, falls back to the original hardcoded if-else chain.

All call sites (`CodeView.tsx`, `CodeComparisonView.tsx`, `SingleCodeViewer.tsx`, `App.tsx`) now pass `kernel?.ir_stages`.

### 4. Dynamic Syntax Highlighting (`languageUtils.ts`)

`mapLanguageToHighlighter(language, irStages?)` gains an optional `irStages` parameter. It first looks up `syntax_id` from `ir_stages`; if not found, falls back to the original hardcoded logic.

### 5. Dynamic Source Mapping Cross-References (`CodeComparisonView.tsx`)

`irTypesToCheck` in `calculateMappedLines()` changed from 6 hardcoded GPU stages to dynamic generation:

```typescript
const irTypesToCheck = irStages && irStages.length > 0
    ? irStages
        .filter(s => s.supports_source_mapping)
        .map(s => ({ type: s.name, property: `${s.name}_lines` }))
    : [/* original GPU hardcoded list */];
```

For NPU traces, cross-reference fields like `ttadapter_lines` and `bcmlir_lines` are automatically discovered with no frontend changes.

### 6. Dynamic Default Panel Selection (`CodeView.tsx`)

`findDefaultIRFiles()` no longer hardcodes `ttgir`/`ptx`. Instead, it calls `getDefaultPanels(kernel)` to get stage names and matches them against available files.

### 7. Dynamic Fallback in File Diff (`FileDiffView.tsx`)

- `irType` initial value changed from hardcoded `"ttgir"` to empty string
- `effectiveIrType` final fallback changed from `"ttgir"` to `getDefaultPanels(leftKernel).left`
- Moved `leftKernel` resolution earlier to eliminate duplicate computation

### 8. Dynamic Line Grouping Anchor (`SingleCodeViewer.tsx`)

The line grouping anchor in `handleLineClick` changed from hardcoded `ttgir_line` to `getGroupingAnchor()`, accessing the corresponding field via `${anchorStage}_line`.

---

## Fallback Strategy

All change points follow the same pattern:

```
if (kernel.ir_stages && kernel.ir_stages.length > 0) {
    // New path: derive from ir_stages dynamically
} else {
    // Fallback: keep original hardcoded logic unchanged
}
```

Old traces without `ir_stages` take the fallback path and behave exactly as before.

---

## Files Changed

| File | Change |
|------|--------|
| `website/src/utils/dataLoader.ts` | Add `IRStageDescriptor` interface; add `ir_stages` to `ProcessedKernel`; generalize `SourceMapping` with index signature; add `getDefaultPanels()` and `getGroupingAnchor()` |
| `website/src/utils/irLanguage.ts` | Add optional `irStages` param to `getDisplayLanguage()`; dynamic lookup first |
| `website/src/utils/languageUtils.ts` | Add optional `irStages` param to `mapLanguageToHighlighter()`; dynamic lookup first |
| `website/src/components/CodeComparisonView.tsx` | Dynamic `irTypesToCheck`; add `irStages` prop; update `useMemo` deps |
| `website/src/pages/CodeView.tsx` | `findDefaultIRFiles()` uses `getDefaultPanels()`; pass `irStages` to all `getDisplayLanguage`/`mapLanguageToHighlighter` calls |
| `website/src/pages/FileDiffView.tsx` | `effectiveIrType` fallback uses `getDefaultPanels()`; move kernel resolution earlier |
| `website/src/components/SingleCodeViewer.tsx` | Grouping anchor from `ttgir_line` to `getGroupingAnchor()`; add `irStages` prop |
| `website/src/App.tsx` | Pass `irStages` to `mapLanguageToHighlighter` and `SingleCodeViewer` |

---

## Testing

<img width="921" height="124" alt="image" src="https://github.com/user-attachments/assets/bd2b348e-31e9-49cc-8084-f5c98ef2f109" />


Verified on legacy traces, NVIDIA GPU traces, and NPU multi-backend traces. All frontend features work as expected.

---

## Conclusion

This PR completes frontend consumption of `ir_stages`. New backends only need to implement an adapter with stage descriptors (`name`, `display_name`, `syntax_id`, `display_order`, etc.) and the frontend adapts automatically:

- Display names, syntax highlighting, panel selection, cross-references, and line grouping — all driven by stage descriptors
- New backends (e.g., NPU with `ttadapter`, `bcmlir`) are supported with zero frontend changes
- Old traces remain fully compatible via the fallback path
