### PR TITLE
Registry Architecture Refactor — Eliminate Circular Dependencies & Introduce Instance-Level Isolation

### DIFF
--- a/tests/cpu/test_multi_backend_stage.py
+++ b/tests/cpu/test_multi_backend_stage.py
@@ -123,18 +123,18 @@ class TestMultiBackendStage(unittest.TestCase):
 
         # Common parsers present in both
         for adapter in (nvidia, amd):
-            parsers = adapter._parser_registry.list_parsers()
+            parsers = adapter.list_parsers()
             self.assertIn("generic_loc", parsers)
             self.assertIn("none", parsers)
 
         # NVIDIA-specific parsers only in NVIDIA adapter
-        nvidia_parsers = nvidia._parser_registry.list_parsers()
+        nvidia_parsers = nvidia.list_parsers()
         self.assertIn("ptx_loc", nvidia_parsers)
         self.assertIn("sass_loc", nvidia_parsers)
         self.assertNotIn("amdgcn_loc", nvidia_parsers)
 
         # AMD-specific parser only in AMD adapter
-        amd_parsers = amd._parser_registry.list_parsers()
+        amd_parsers = amd.list_parsers()
         self.assertIn("amdgcn_loc", amd_parsers)
         self.assertNotIn("ptx_loc", amd_parsers)
         self.assertNotIn("sass_loc", amd_parsers)
@@ -189,7 +189,7 @@ class TestMultiBackendStage(unittest.TestCase):
         def sentinel_generic_loc_parser(*args, **kwargs):
             return sentinel_mapping
 
-        original_generic_parser = nvidia._parser_registry.get_parser("generic_loc")
+        original_generic_parser = nvidia.get_parser("generic_loc")
         self.assertIsNotNone(original_generic_parser)
 
         # Test with metadata (adapter-driven parser selection)
@@ -241,7 +241,7 @@ class TestMultiBackendStage(unittest.TestCase):
         def failing_generic_loc_parser(*args, **kwargs):
             raise RuntimeError("parser execution failed")
 
-        original_generic_parser = nvidia._parser_registry.get_parser("generic_loc")
+        original_generic_parser = nvidia.get_parser("generic_loc")
         self.assertIsNotNone(original_generic_parser)
 
         try:
@@ -364,13 +364,13 @@ class TestAnalysisAdapterDriven(unittest.TestCase):
 
         # Common analyzers present in both
         for adapter in (nvidia, amd):
-            analyzers = adapter._analysis_registry.list_analyzers()
+            analyzers = adapter.get_analysis_passes()
             self.assertIn("loop_schedules", analyzers)
             self.assertIn("procedure_checks", analyzers)
 
         # Only AMD adapter has amd_buffer_ops
-        self.assertIn("amd_buffer_ops", amd._analysis_registry.list_analyzers())
-        self.assertNotIn("amd_buffer_ops", nvidia._analysis_registry.list_analyzers())
+        self.assertIn("amd_buffer_ops", amd.get_analysis_passes())
+        self.assertNotIn("amd_buffer_ops", nvidia.get_analysis_passes())
 
     def test_analysis_adapter_passes_differ_by_backend(self):
         """NVIDIA only has common passes; AMD additionally has amd_buffer_ops."""
@@ -391,9 +391,12 @@ class TestAnalysisAdapterDriven(unittest.TestCase):
         """Each analysis pass's required_stages should exist in the adapter."""
         amd_adapter = self.registry.resolve(adapter_name="hip_triton")
         for pass_name in amd_adapter.get_analysis_passes():
-            info = amd_adapter._analysis_registry.get_analyzer_info(pass_name)
-            self.assertIsNotNone(info, f"Analyzer '{pass_name}' should be registered")
-            for stage_name in info.required_stages:
+            required_stages = amd_adapter.get_analyzer_required_stages(pass_name)
+            self.assertIsNotNone(
+                required_stages, f"Analyzer '{pass_name}' should be registered"
+            )
+            assert required_stages is not None  # for type checker
+            for stage_name in required_stages:
                 self.assertIsNotNone(
                     amd_adapter.get_stage_by_name(stage_name),
                     f"Required stage '{stage_name}' should exist in AMD adapter",

--- a/tests/cpu/test_multi_backend_stage.py
+++ b/tests/cpu/test_multi_backend_stage.py
@@ -4,12 +4,13 @@ from unittest.mock import patch
 
 from tritonparse.backend import (
     AmdTritonAdapter,
+    AnalysisRegistry,
     get_backend_registry,
     NvidiaTritonAdapter,
+    ParserRegistry,
     PipelineAdapterRegistry,
 )
-from tritonparse.parse.ir_analysis import _generate_ir_analysis, AnalysisRegistry
-from tritonparse.parse.ir_parser import ParserRegistry
+from tritonparse.parse.ir_analysis import _generate_ir_analysis
 from tritonparse.parse.trace_processor import (
     _resolve_source_mappable_stage_keys,
     generate_source_mappings,

--- a/tests/cpu/test_multi_backend_stage.py
+++ b/tests/cpu/test_multi_backend_stage.py
@@ -4,10 +4,8 @@ from unittest.mock import patch
 
 from tritonparse.backend import (
     AmdTritonAdapter,
-    AnalysisRegistry,
     get_backend_registry,
     NvidiaTritonAdapter,
-    ParserRegistry,
     PipelineAdapterRegistry,
 )
 from tritonparse.parse.ir_analysis import _generate_ir_analysis
@@ -115,63 +113,67 @@ class TestMultiBackendStage(unittest.TestCase):
             registry.resolve_from_trace(metadata={})
 
     def test_parser_registry_and_layered_registration(self):
-        """Test ParserRegistry and layered parser registration (common + backend-specific)."""
-        # Step 1: Verify common parsers are pre-registered
-        common_parsers = {"generic_loc", "none"}
-        for parser_id in common_parsers:
-            parser = ParserRegistry.get_parser(parser_id)
-            self.assertIsNotNone(
-                parser, f"Common parser '{parser_id}' should be pre-registered"
-            )
-
-        # Step 2: Create adapters (triggers backend-specific parser registration)
+        """Test per-adapter parser isolation: each adapter has common + its own parsers."""
         registry = PipelineAdapterRegistry()
         registry.register(NvidiaTritonAdapter)
         registry.register(AmdTritonAdapter)
 
-        # Step 3: Verify all parsers are listed (check registry list functionality)
-        all_parsers = ParserRegistry.list_parsers()
-        self.assertIn("generic_loc", all_parsers)
-        self.assertIn("none", all_parsers)
-        self.assertIn("ptx_loc", all_parsers)
-        self.assertIn("sass_loc", all_parsers)
-        self.assertIn("amdgcn_loc", all_parsers)
+        nvidia = registry.resolve(adapter_name="cuda_triton")
+        amd = registry.resolve(adapter_name="hip_triton")
+
+        # Common parsers present in both
+        for adapter in (nvidia, amd):
+            parsers = adapter._parser_registry.list_parsers()
+            self.assertIn("generic_loc", parsers)
+            self.assertIn("none", parsers)
+
+        # NVIDIA-specific parsers only in NVIDIA adapter
+        nvidia_parsers = nvidia._parser_registry.list_parsers()
+        self.assertIn("ptx_loc", nvidia_parsers)
+        self.assertIn("sass_loc", nvidia_parsers)
+        self.assertNotIn("amdgcn_loc", nvidia_parsers)
+
+        # AMD-specific parser only in AMD adapter
+        amd_parsers = amd._parser_registry.list_parsers()
+        self.assertIn("amdgcn_loc", amd_parsers)
+        self.assertNotIn("ptx_loc", amd_parsers)
+        self.assertNotIn("sass_loc", amd_parsers)
 
     def test_adapter_get_parser_method(self):
-        """Test adapter.get_parser() method with both common and backend-specific parsers."""
+        """Test adapter.get_parser() with isolated per-adapter registries."""
         registry = PipelineAdapterRegistry()
         registry.register(NvidiaTritonAdapter)
         registry.register(AmdTritonAdapter)
 
-        # Get NVIDIA adapter
-        nvidia_adapter = registry.resolve(adapter_name="cuda_triton")
+        nvidia = registry.resolve(adapter_name="cuda_triton")
+        amd = registry.resolve(adapter_name="hip_triton")
 
-        # Test getting common parser (generic_loc)
-        generic_parser = nvidia_adapter.get_parser("generic_loc")
+        # Common parser works on both
+        generic_parser = nvidia.get_parser("generic_loc")
         self.assertIsNotNone(generic_parser)
+        generic_parser_amd = amd.get_parser("generic_loc")
+        self.assertIsNotNone(generic_parser_amd)
 
-        # Test getting NVIDIA-specific parser
-        ptx_parser = nvidia_adapter.get_parser("ptx_loc")
+        # Backend-specific parsers only work on their own adapter
+        ptx_parser = nvidia.get_parser("ptx_loc")
         self.assertIsNotNone(ptx_parser)
-
-        # Test getting AMD parser (also works because parsers are globally registered)
-        amdgcn_parser = nvidia_adapter.get_parser("amdgcn_loc")
+        amdgcn_parser = amd.get_parser("amdgcn_loc")
         self.assertIsNotNone(amdgcn_parser)
 
-        # Get AMD adapter and test NVIDIA parser (also works for symmetrical access)
-        amd_adapter = registry.resolve(adapter_name="hip_triton")
-        ptx_parser_amd = amd_adapter.get_parser("ptx_loc")
-        self.assertIsNotNone(ptx_parser_amd)
-
-        # Test getting unknown parser should raise ValueError
+        # Cross-backend access should fail (isolation)
         with self.assertRaises(ValueError):
-            nvidia_adapter.get_parser("unknown_parser")
+            nvidia.get_parser("amdgcn_loc")
+        with self.assertRaises(ValueError):
+            amd.get_parser("ptx_loc")
+
+        # Unknown parser
+        with self.assertRaises(ValueError):
+            nvidia.get_parser("unknown_parser")
 
     def test_adapter_driven_parser_selection_and_fallback(self):
         """Test adapter-driven parser selection with backward compatibility fallback."""
-        registry = PipelineAdapterRegistry()
-        registry.register(NvidiaTritonAdapter)
-        registry.register(AmdTritonAdapter)
+        # Use module-level registry so generate_source_mappings sees the same adapter
+        nvidia = get_backend_registry().resolve(adapter_name="cuda_triton")
 
         # Test content (TTIR with #loc directives)
         ttir_content = """
@@ -187,13 +189,13 @@ class TestMultiBackendStage(unittest.TestCase):
         def sentinel_generic_loc_parser(*args, **kwargs):
             return sentinel_mapping
 
-        original_generic_parser = ParserRegistry.get_parser("generic_loc")
+        original_generic_parser = nvidia._parser_registry.get_parser("generic_loc")
         self.assertIsNotNone(original_generic_parser)
 
         # Test with metadata (adapter-driven parser selection)
         metadata_cuda = {"backend_name": "cuda"}
         try:
-            ParserRegistry.register("generic_loc", sentinel_generic_loc_parser)
+            nvidia.register_backend_parser("generic_loc", sentinel_generic_loc_parser)
 
             result_with_metadata = generate_source_mappings(
                 ttir_content, "ttir", None, metadata_cuda
@@ -221,13 +223,12 @@ class TestMultiBackendStage(unittest.TestCase):
             self.assertEqual(result_fallback["4"]["line"], 20)
             self.assertIn("ttir_line", result_fallback["4"])
         finally:
-            ParserRegistry.register("generic_loc", original_generic_parser)
+            nvidia.register_backend_parser("generic_loc", original_generic_parser)
 
     def test_adapter_parser_execution_errors_are_not_silently_swallowed(self):
         """Adapter-selected parser execution failures should propagate instead of falling back."""
-        registry = PipelineAdapterRegistry()
-        registry.register(NvidiaTritonAdapter)
-        registry.register(AmdTritonAdapter)
+        # Use module-level registry so generate_source_mappings sees the same adapter
+        nvidia = get_backend_registry().resolve(adapter_name="cuda_triton")
 
         ttir_content = """
             #loc = loc("test.py":10:5)
@@ -240,16 +241,16 @@ class TestMultiBackendStage(unittest.TestCase):
         def failing_generic_loc_parser(*args, **kwargs):
             raise RuntimeError("parser execution failed")
 
-        original_generic_parser = ParserRegistry.get_parser("generic_loc")
+        original_generic_parser = nvidia._parser_registry.get_parser("generic_loc")
         self.assertIsNotNone(original_generic_parser)
 
         try:
-            ParserRegistry.register("generic_loc", failing_generic_loc_parser)
+            nvidia.register_backend_parser("generic_loc", failing_generic_loc_parser)
 
             with self.assertRaisesRegex(RuntimeError, "parser execution failed"):
                 generate_source_mappings(ttir_content, "ttir", None, metadata_cuda)
         finally:
-            ParserRegistry.register("generic_loc", original_generic_parser)
+            nvidia.register_backend_parser("generic_loc", original_generic_parser)
 
 
 class TestAnalysisAdapterDriven(unittest.TestCase):
@@ -357,12 +358,19 @@ class TestAnalysisAdapterDriven(unittest.TestCase):
             )
 
     def test_analysis_registry_common_and_backend_analyzers(self):
-        """Common and backend-specific analyzers are all registered after adapter init."""
-        for analyzer_id in ("loop_schedules", "procedure_checks", "amd_buffer_ops"):
-            self.assertIsNotNone(
-                AnalysisRegistry.get_analyzer(analyzer_id),
-                f"Analyzer '{analyzer_id}' should be registered",
-            )
+        """Common and backend-specific analyzers are registered in per-adapter registries."""
+        nvidia = self.registry.resolve(adapter_name="cuda_triton")
+        amd = self.registry.resolve(adapter_name="hip_triton")
+
+        # Common analyzers present in both
+        for adapter in (nvidia, amd):
+            analyzers = adapter._analysis_registry.list_analyzers()
+            self.assertIn("loop_schedules", analyzers)
+            self.assertIn("procedure_checks", analyzers)
+
+        # Only AMD adapter has amd_buffer_ops
+        self.assertIn("amd_buffer_ops", amd._analysis_registry.list_analyzers())
+        self.assertNotIn("amd_buffer_ops", nvidia._analysis_registry.list_analyzers())
 
     def test_analysis_adapter_passes_differ_by_backend(self):
         """NVIDIA only has common passes; AMD additionally has amd_buffer_ops."""
@@ -383,7 +391,7 @@ class TestAnalysisAdapterDriven(unittest.TestCase):
         """Each analysis pass's required_stages should exist in the adapter."""
         amd_adapter = self.registry.resolve(adapter_name="hip_triton")
         for pass_name in amd_adapter.get_analysis_passes():
-            info = AnalysisRegistry.get_analyzer_info(pass_name)
+            info = amd_adapter._analysis_registry.get_analyzer_info(pass_name)
             self.assertIsNotNone(info, f"Analyzer '{pass_name}' should be registered")
             for stage_name in info.required_stages:
                 self.assertIsNotNone(
@@ -431,39 +439,34 @@ class TestAnalysisAdapterDriven(unittest.TestCase):
         self.assertEqual(get_enabled_analyses(), {"amd_buffer_ops", "loop_schedules"})
 
     def test_get_enabled_derived_artifacts_env_parsing(self):
-        """Derived artifact env parsing should cover defaults, keywords, lists, compat, and unknown filtering."""
+        """Derived artifact env parsing should cover defaults, keywords, lists, and compat."""
         original_derived_artifacts_env = os.environ.get("TRITONPARSE_DERIVED_ARTIFACTS")
         original_dump_sass_env = os.environ.get("TRITONPARSE_DUMP_SASS")
 
         try:
             set_runtime_sass_dump_override(None)
 
-            with patch(
-                "tritonparse.backend.DerivedArtifactRegistry.list_target_stage_names",
-                return_value=["sass", "example"],
-            ):
-                os.environ.pop("TRITONPARSE_DERIVED_ARTIFACTS", None)
-                os.environ.pop("TRITONPARSE_DUMP_SASS", None)
-                self.assertEqual(get_enabled_derived_artifacts(), set())
+            os.environ.pop("TRITONPARSE_DERIVED_ARTIFACTS", None)
+            os.environ.pop("TRITONPARSE_DUMP_SASS", None)
+            self.assertEqual(get_enabled_derived_artifacts(), set())
 
-                os.environ["TRITONPARSE_DERIVED_ARTIFACTS"] = "all"
-                self.assertIsNone(get_enabled_derived_artifacts())
+            os.environ["TRITONPARSE_DERIVED_ARTIFACTS"] = "all"
+            self.assertIsNone(get_enabled_derived_artifacts())
 
-                os.environ["TRITONPARSE_DERIVED_ARTIFACTS"] = "none"
-                self.assertEqual(get_enabled_derived_artifacts(), set())
+            os.environ["TRITONPARSE_DERIVED_ARTIFACTS"] = "none"
+            self.assertEqual(get_enabled_derived_artifacts(), set())
 
-                os.environ["TRITONPARSE_DERIVED_ARTIFACTS"] = " example , sass "
-                self.assertEqual(get_enabled_derived_artifacts(), {"example", "sass"})
+            os.environ["TRITONPARSE_DERIVED_ARTIFACTS"] = " example , sass "
+            self.assertEqual(get_enabled_derived_artifacts(), {"example", "sass"})
 
-                os.environ.pop("TRITONPARSE_DERIVED_ARTIFACTS", None)
-                os.environ["TRITONPARSE_DUMP_SASS"] = "1"
-                self.assertEqual(get_enabled_derived_artifacts(), {"sass"})
+            os.environ.pop("TRITONPARSE_DERIVED_ARTIFACTS", None)
+            os.environ["TRITONPARSE_DUMP_SASS"] = "1"
+            self.assertEqual(get_enabled_derived_artifacts(), {"sass"})
 
-                os.environ.pop("TRITONPARSE_DUMP_SASS", None)
-                os.environ["TRITONPARSE_DERIVED_ARTIFACTS"] = "example,unknown"
-                with self.assertLogs("tritonparse", level="WARNING") as logs:
-                    self.assertEqual(get_enabled_derived_artifacts(), {"example"})
-                self.assertIn("unknown target stage names", "\n".join(logs.output))
+            # Unknown names are passed through (validated at adapter level)
+            os.environ.pop("TRITONPARSE_DUMP_SASS", None)
+            os.environ["TRITONPARSE_DERIVED_ARTIFACTS"] = "example,unknown"
+            self.assertEqual(get_enabled_derived_artifacts(), {"example", "unknown"})
         finally:
             if original_derived_artifacts_env is None:
                 os.environ.pop("TRITONPARSE_DERIVED_ARTIFACTS", None)

--- a/tritonparse/backend.py
+++ b/tritonparse/backend.py
@@ -1,9 +1,8 @@
 #  Copyright (c) Meta Platforms, Inc. and affiliates.
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
+from abc import ABC
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any, Callable
 
 from tritonparse.tp_logger import logger
@@ -67,77 +66,62 @@ class DerivedArtifactInfo:
     derive_func: Callable[[str], str | None]
 
 
+# =============================================================================
+# INSTANCE-LEVEL REGISTRIES
+# =============================================================================
 class DerivedArtifactRegistry:
-    """Registry for managing derived artifact info objects.
+    """Per-adapter registry for managing derived artifact info objects."""
 
-    Adapters register their derived artifacts here. The registry supports
-    lookup by target stage name and listing all known target stage names
-    (useful for env-var validation).
-    """
+    def __init__(self) -> None:
+        self._registry: dict[str, DerivedArtifactInfo] = {}
 
-    _registry: dict[str, DerivedArtifactInfo] = {}
-
-    @classmethod
-    def register(cls, info: DerivedArtifactInfo) -> None:
+    def register(self, info: DerivedArtifactInfo) -> None:
         key = info.target_stage_name
-        if key in cls._registry:
+        if key in self._registry:
             logger.debug(
                 f"Overwriting existing derived artifact registration for '{key}'"
             )
-        cls._registry[key] = info
+        self._registry[key] = info
 
-    @classmethod
-    def get_by_target(cls, target_stage_name: str) -> DerivedArtifactInfo | None:
-        return cls._registry.get(target_stage_name)
+    def get_by_target(self, target_stage_name: str) -> DerivedArtifactInfo | None:
+        return self._registry.get(target_stage_name)
 
-    @classmethod
-    def list_for_adapter(cls, adapter_name: str) -> list[DerivedArtifactInfo]:
-        return [
-            info
-            for info in cls._registry.values()
-            if info.adapter_affinity == adapter_name
-        ]
+    def list_all(self) -> list[DerivedArtifactInfo]:
+        return list(self._registry.values())
 
-    @classmethod
-    def list_target_stage_names(cls) -> list[str]:
-        return list(cls._registry.keys())
+    def list_target_stage_names(self) -> list[str]:
+        return list(self._registry.keys())
 
 
-# =============================================================================
-# PARSER REGISTRY
-# =============================================================================
 class ParserRegistry:
-    """Registry for managing IR parser functions.
+    """Per-adapter registry for managing IR parser functions."""
 
-    This registry allows adapters to register and retrieve parser functions
-    by parser_id. It supports both common parsers (shared across backends)
-    and backend-specific parsers.
-    """
+    def __init__(self) -> None:
+        self._parsers: dict[str, Callable] = {}
 
-    _parsers: dict[str, Callable] = {}
+    def register(self, parser_id: str, parser_func: Callable) -> None:
+        """Register a parser function with the given parser_id.
 
-    @classmethod
-    def register(cls, parser_id: str, parser_func: Callable) -> None:
-        if parser_id in cls._parsers:
+        If parser_id is already registered, the existing parser is overwritten
+        and a warning is logged.
+        """
+        if parser_id in self._parsers:
             logger.warning(
                 f"Parser '{parser_id}' is already registered. "
                 f"Overwriting with new parser function."
             )
-        cls._parsers[parser_id] = parser_func
+        self._parsers[parser_id] = parser_func
         logger.debug(f"Registered parser: {parser_id}")
 
-    @classmethod
-    def get_parser(cls, parser_id: str) -> Callable | None:
-        return cls._parsers.get(parser_id)
+    def get_parser(self, parser_id: str) -> Callable | None:
+        """Get a parser function by parser_id."""
+        return self._parsers.get(parser_id)
 
-    @classmethod
-    def list_parsers(cls) -> list[str]:
-        return list(cls._parsers.keys())
+    def list_parsers(self) -> list[str]:
+        """List all registered parser IDs."""
+        return list(self._parsers.keys())
 
 
-# =============================================================================
-# ANALYSIS REGISTRY
-# =============================================================================
 @dataclass
 class AnalyzerInfo:
     """Information about a registered analyzer.
@@ -157,24 +141,20 @@ class AnalyzerInfo:
 
 
 class AnalysisRegistry:
-    """Registry for managing IR analysis functions and their metadata.
+    """Per-adapter registry for managing IR analysis functions and their metadata."""
 
-    This registry allows adapters to register and retrieve analysis functions
-    by analysis_id. It supports both common analyzers (shared across backends)
-    and backend-specific analyzers.
-    """
+    def __init__(self) -> None:
+        self._analyzer_infos: dict[str, AnalyzerInfo] = {}
 
-    _analyzer_infos: dict[str, AnalyzerInfo] = {}
-
-    @classmethod
     def register(
-        cls,
+        self,
         analyzer_id: str,
         analyzer_func: Callable,
         required_stages: tuple[str, ...],
         adapter_affinity: str | None = None,
     ) -> None:
-        if analyzer_id in cls._analyzer_infos:
+        """Register an analyzer with its metadata."""
+        if analyzer_id in self._analyzer_infos:
             logger.debug(
                 f"Analyzer '{analyzer_id}' is already registered. Overwriting."
             )
@@ -184,58 +164,77 @@ class AnalysisRegistry:
             required_stages=required_stages,
             adapter_affinity=adapter_affinity,
         )
-        cls._analyzer_infos[analyzer_id] = info
+        self._analyzer_infos[analyzer_id] = info
 
-    @classmethod
-    def get_analyzer_info(cls, analyzer_id: str) -> AnalyzerInfo | None:
-        return cls._analyzer_infos.get(analyzer_id)
+    def get_analyzer_info(self, analyzer_id: str) -> AnalyzerInfo | None:
+        """Get analyzer info by name."""
+        return self._analyzer_infos.get(analyzer_id)
 
-    @classmethod
-    def get_analyzer(cls, analyzer_id: str) -> Callable | None:
-        info = cls._analyzer_infos.get(analyzer_id)
+    def get_analyzer(self, analyzer_id: str) -> Callable | None:
+        """Get the analyzer function by name."""
+        info = self._analyzer_infos.get(analyzer_id)
         return info.func if info else None
 
-    @classmethod
-    def list_analyzers(cls) -> list[str]:
-        return list(cls._analyzer_infos.keys())
+    def list_analyzers(self) -> list[str]:
+        """List all registered analyzer IDs."""
+        return list(self._analyzer_infos.keys())
 
-    @classmethod
-    def list_analyzer_infos(cls) -> list[tuple[str, AnalyzerInfo]]:
-        return list(cls._analyzer_infos.items())
+    def list_analyzer_infos(self) -> list[tuple[str, AnalyzerInfo]]:
+        """List all registered (analyzer_id, AnalyzerInfo) pairs."""
+        return list(self._analyzer_infos.items())
 
 
+# =============================================================================
+# ADAPTER BASE CLASS
+# =============================================================================
 class CompilationPipelineAdapter(ABC):
     """Abstract base class for compilation pipeline adapters.
 
     Adapters provide backend-specific configuration for different
     compilation pipelines (e.g., CUDA vs HIP). Each adapter defines the
     IR stages, derived artifacts, and analysis passes for its pipeline.
+
+    Each adapter instance holds its own isolated registries (parsers,
+    analyzers, derived artifacts), ensuring complete backend isolation.
     """
 
-    @property
-    @abstractmethod
-    def adapter_name(self) -> str:
-        raise NotImplementedError
+    adapter_name: str
+    runtime_backend: str
+    pytorch_module: str
 
-    @property
-    @abstractmethod
-    def runtime_backend(self) -> str:
-        raise NotImplementedError
+    def __init__(self):
+        self._stages: list[IRStageDescriptor] = []
+        self._parser_registry = ParserRegistry()
+        self._analysis_registry = AnalysisRegistry()
+        self._derived_artifact_registry = DerivedArtifactRegistry()
 
-    @property
-    @abstractmethod
-    def pytorch_module(self) -> str:
-        """Device-family prefix used for torch device strings and sync calls.
+        # Register common parsers (shared across all backends)
+        from tritonparse.parse.ir_parser import _parse_generic_loc, _parse_none
 
-        Examples: "cuda", "xpu", "mps".
-        Used as f"{prefix}:0" for device strings and
-        f"torch.{prefix}.synchronize()" for synchronization.
-        """
-        raise NotImplementedError
+        self._parser_registry.register("generic_loc", _parse_generic_loc)
+        self._parser_registry.register("none", _parse_none)
 
-    @abstractmethod
+        # Register common analyzers (shared across all backends)
+        from tritonparse.parse.ir_analysis import (
+            _analyze_loop_schedules_generic,
+            _analyze_procedures_generic,
+        )
+
+        self._analysis_registry.register(
+            "loop_schedules",
+            _analyze_loop_schedules_generic,
+            required_stages=("ttir", "ttgir"),
+            adapter_affinity=None,
+        )
+        self._analysis_registry.register(
+            "procedure_checks",
+            _analyze_procedures_generic,
+            required_stages=("ttgir",),
+            adapter_affinity=None,
+        )
+
     def get_ir_stages(self) -> list[IRStageDescriptor]:
-        raise NotImplementedError
+        return self._stages
 
     def get_stage_by_name(self, stage_name: str) -> IRStageDescriptor | None:
         for stage in self.get_ir_stages():
@@ -243,19 +242,38 @@ class CompilationPipelineAdapter(ABC):
                 return stage
         return None
 
-    def get_stage_by_artifact(self, artifact_name: str) -> IRStageDescriptor | None:
-        artifact_suffix = Path(artifact_name).suffix
-        for stage in self.get_ir_stages():
-            if stage.extension == artifact_suffix:
-                return stage
-        return None
+    def get_applicable_derived_artifacts(
+        self,
+        enabled_derived_artifacts: set[str] | None = None,
+    ) -> list[DerivedArtifactInfo]:
+        """
+        Get derived artifacts applicable to this adapter, filtered by user-enabled list.
 
-    @property
-    def known_stage_extensions(self) -> set[str]:
-        return {stage.extension for stage in self.get_ir_stages()}
+        Validates user-provided names and warns about unknowns.
 
-    def get_derived_artifacts(self) -> list[DerivedArtifactInfo]:
-        return DerivedArtifactRegistry.list_for_adapter(self.adapter_name)
+        Args:
+            enabled_derived_artifacts: User-enabled target stage names (None = all)
+
+        Returns:
+            List of applicable DerivedArtifactInfo
+        """
+        all_artifacts = self._derived_artifact_registry.list_all()
+
+        if enabled_derived_artifacts is not None:
+            known = {info.target_stage_name.lower() for info in all_artifacts}
+            unknown = {n for n in enabled_derived_artifacts if n not in known}
+            if unknown:
+                logger.warning(
+                    f"TRITONPARSE_DERIVED_ARTIFACTS contains unknown target stage names: {unknown}. "
+                    f"Available for {self.adapter_name}: {sorted(known)}"
+                )
+            return [
+                info
+                for info in all_artifacts
+                if info.target_stage_name in enabled_derived_artifacts
+            ]
+
+        return all_artifacts
 
     def register_backend_derived_artifact(
         self,
@@ -264,8 +282,8 @@ class CompilationPipelineAdapter(ABC):
         tool_name: str,
         derive_func: Callable[[str], str | None],
     ) -> None:
-        """Register a backend-specific derived artifact to the registry."""
-        DerivedArtifactRegistry.register(
+        """Register a backend-specific derived artifact to the adapter's registry."""
+        self._derived_artifact_registry.register(
             DerivedArtifactInfo(
                 source_stage_name=source_stage_name,
                 target_stage_name=target_stage_name,
@@ -275,29 +293,14 @@ class CompilationPipelineAdapter(ABC):
             )
         )
 
-    def collect_derived_artifact_contents(
-        self, source_path: str, info: DerivedArtifactInfo
-    ) -> str | None:
-        """Run the derivation tool and return the generated artifact contents."""
-        return info.derive_func(source_path)
-
     def get_analysis_passes(self) -> list[str]:
         """
         Return list of analysis pass names for this adapter.
 
-        Base implementation: gets analyzers from AnalysisRegistry
-        that match this adapter's affinity or are common (no affinity).
-
-        Can be overridden by subclasses for custom behavior.
+        All analyzers in the adapter's instance registry are included
+        (common + backend-specific).
         """
-        my_name = self.adapter_name
-        analyzer_names = []
-
-        for _, info in AnalysisRegistry.list_analyzer_infos():
-            if info.adapter_affinity in (my_name, None):
-                analyzer_names.append(info.name)
-
-        return analyzer_names
+        return self._analysis_registry.list_analyzers()
 
     def get_executable_analyzers(
         self,
@@ -309,6 +312,8 @@ class CompilationPipelineAdapter(ABC):
         1. User-enabled analyses (from environment variable)
         2. Available intermediate products (file_content)
 
+        Also validates user-provided analyzer names and warns about unknowns.
+
         Args:
             file_content: Dictionary mapping file keys to file content
             enabled_analyses: User-enabled analysis names (None = all)
@@ -316,6 +321,16 @@ class CompilationPipelineAdapter(ABC):
         Returns:
             List of executable analyzer names
         """
+        # Validate user-provided names against known analyzers
+        if enabled_analyses is not None:
+            known = {name.lower() for name in self._analysis_registry.list_analyzers()}
+            unknown = {n for n in enabled_analyses if n not in known}
+            if unknown:
+                logger.warning(
+                    f"TRITONPARSE_ANALYSIS contains unknown analyzer names: {unknown}. "
+                    f"Available for {self.adapter_name}: {sorted(known)}"
+                )
+
         declared_analyzers = self.get_analysis_passes()
         executable = []
 
@@ -325,7 +340,7 @@ class CompilationPipelineAdapter(ABC):
                 continue
 
             # Check 2: Are required stages available?
-            info = AnalysisRegistry.get_analyzer_info(analyzer_name)
+            info = self._analysis_registry.get_analyzer_info(analyzer_name)
             if not info:
                 continue
 
@@ -366,9 +381,9 @@ class CompilationPipelineAdapter(ABC):
         Raises:
             ValueError: If the pass_name is not found in the registry
         """
-        analyzer = AnalysisRegistry.get_analyzer(pass_name)
+        analyzer = self._analysis_registry.get_analyzer(pass_name)
         if analyzer is None:
-            available = AnalysisRegistry.list_analyzers()
+            available = self._analysis_registry.list_analyzers()
             raise ValueError(
                 f"Analyzer '{pass_name}' not found. Available analyzers: {available}"
             )
@@ -382,10 +397,7 @@ class CompilationPipelineAdapter(ABC):
         required_stages: tuple[str, ...],
     ) -> None:
         """
-        Register a backend-specific analyzer to the analyzer registry.
-
-        This allows adapters to register custom analyzers for backend-specific
-        analysis passes that are not part of the common analyzer registry.
+        Register a backend-specific analyzer to the adapter's registry.
 
         Args:
             analyzer_id: The analyzer identifier (e.g., "amd_buffer_ops")
@@ -393,9 +405,8 @@ class CompilationPipelineAdapter(ABC):
                           (entry, procedure_checks) -> dict | None
             required_stages: Required stage names (e.g., ("ttgir", "amdgcn"))
         """
-        adapter_affinity = self.adapter_name
-        AnalysisRegistry.register(
-            analyzer_id, analyzer_func, required_stages, adapter_affinity
+        self._analysis_registry.register(
+            analyzer_id, analyzer_func, required_stages, self.adapter_name
         )
 
     def get_canonical_device_string(self) -> str:
@@ -404,10 +415,7 @@ class CompilationPipelineAdapter(ABC):
 
     def get_parser(self, parser_id: str):
         """
-        Get parser function by parser_id from the parser registry.
-
-        This is a generic implementation that works for most backends.
-        Subclasses can override this method if they need custom parser resolution.
+        Get parser function by parser_id from the adapter's parser registry.
 
         Args:
             parser_id: The parser identifier (e.g., "generic_loc", "ptx_loc")
@@ -418,9 +426,9 @@ class CompilationPipelineAdapter(ABC):
         Raises:
             ValueError: If the parser_id is not found in the registry
         """
-        parser = ParserRegistry.get_parser(parser_id)
+        parser = self._parser_registry.get_parser(parser_id)
         if parser is None:
-            available_parsers = ParserRegistry.list_parsers()
+            available_parsers = self._parser_registry.list_parsers()
             raise ValueError(
                 f"Parser '{parser_id}' not found. "
                 f"Available parsers: {available_parsers}"
@@ -429,31 +437,41 @@ class CompilationPipelineAdapter(ABC):
 
     def register_backend_parser(self, parser_id: str, parser_func) -> None:
         """
-        Register a backend-specific parser to the parser registry.
-
-        This allows adapters to register custom parsers for backend-specific
-        IR formats that are not part of the common parser registry.
+        Register a backend-specific parser to the adapter's parser registry.
 
         Args:
             parser_id: The parser identifier (e.g., "ascend_ir")
             parser_func: The parser function
         """
-        ParserRegistry.register(parser_id, parser_func)
+        self._parser_registry.register(parser_id, parser_func)
 
 
 class NvidiaTritonAdapter(CompilationPipelineAdapter):
+    adapter_name: str = "cuda_triton"
+    runtime_backend: str = "cuda"
+    pytorch_module: str = "cuda"
+
     def __init__(self):
-        """Initialize and register backend-specific parsers and stage descriptors."""
-        from tritonparse.parse.ir_parser import _parse_ptx_loc, _parse_sass_loc
+        super().__init__()
 
         # Register NVIDIA-specific parsers
-        self.register_backend_parser("ptx_loc", _parse_ptx_loc)
-        self.register_backend_parser("sass_loc", _parse_sass_loc)
+        from tritonparse.parse.ir_parser import _parse_ptx_loc, _parse_sass_loc
+
+        self._parser_registry.register("ptx_loc", _parse_ptx_loc)
+        self._parser_registry.register("sass_loc", _parse_sass_loc)
 
         # Register NVIDIA-specific derived artifacts
         from tritonparse.tools.disasm import extract as derive_sass
 
-        self.register_backend_derived_artifact("cubin", "sass", "nvdisasm", derive_sass)
+        self._derived_artifact_registry.register(
+            DerivedArtifactInfo(
+                source_stage_name="cubin",
+                target_stage_name="sass",
+                tool_name="nvdisasm",
+                adapter_affinity=self.adapter_name,
+                derive_func=derive_sass,
+            )
+        )
 
         # Pre-initialize stage descriptors (immutable objects, can be reused)
         self._stages = [
@@ -478,36 +496,28 @@ class NvidiaTritonAdapter(CompilationPipelineAdapter):
             ),
         ]
 
-    @property
-    def adapter_name(self) -> str:
-        return "cuda_triton"
-
-    @property
-    def runtime_backend(self) -> str:
-        return "cuda"
-
-    @property
-    def pytorch_module(self) -> str:
-        return "cuda"
-
-    def get_ir_stages(self) -> list[IRStageDescriptor]:
-        return self._stages
-
 
 class AmdTritonAdapter(CompilationPipelineAdapter):
+    adapter_name: str = "hip_triton"
+    runtime_backend: str = "hip"
+    pytorch_module: str = "cuda"
+
     def __init__(self):
-        """Initialize and register backend-specific parsers and analyzers."""
-        from tritonparse.parse.ir_analysis import _analyze_amd_buffer_ops
-        from tritonparse.parse.ir_parser import _parse_amdgcn_loc
+        super().__init__()
 
         # Register AMD-specific parsers
-        self.register_backend_parser("amdgcn_loc", _parse_amdgcn_loc)
+        from tritonparse.parse.ir_parser import _parse_amdgcn_loc
+
+        self._parser_registry.register("amdgcn_loc", _parse_amdgcn_loc)
 
         # Register AMD-specific analyzers
-        self.register_backend_analyzer(
+        from tritonparse.parse.ir_analysis import _analyze_amd_buffer_ops
+
+        self._analysis_registry.register(
             "amd_buffer_ops",
             _analyze_amd_buffer_ops,
             required_stages=("ttgir", "amdgcn"),
+            adapter_affinity=self.adapter_name,
         )
 
         # Pre-initialize stage descriptors (immutable objects, can be reused)
@@ -529,53 +539,42 @@ class AmdTritonAdapter(CompilationPipelineAdapter):
             ),
         ]
 
-    @property
-    def adapter_name(self) -> str:
-        return "hip_triton"
 
-    @property
-    def runtime_backend(self) -> str:
-        return "hip"
-
-    @property
-    def pytorch_module(self) -> str:
-        return "cuda"
-
-    def get_ir_stages(self) -> list[IRStageDescriptor]:
-        return self._stages
-
-
+# =============================================================================
+# ADAPTER REGISTRY (LAZY INITIALIZATION)
+# =============================================================================
 class PipelineAdapterRegistry:
     """Registry for managing and resolving compilation pipeline adapters.
 
-    Provides registration and resolution methods for different backend adapters.
-    Adapters can be looked up by name or inferred from trace metadata.
-
-    Note: Adapters are instantiated once during registration and reused for all
-    subsequent resolutions. This ensures parsers are registered only once and
-    stage descriptors are initialized only once.
+    Adapters are registered as classes and lazily instantiated on first use.
+    This avoids importing backend-specific modules until they are needed.
     """
 
     def __init__(self) -> None:
-        self._adapters: dict[str, CompilationPipelineAdapter] = {}
+        self._adapter_classes: dict[str, type[CompilationPipelineAdapter]] = {}
+        self._adapter_instances: dict[str, CompilationPipelineAdapter] = {}
 
     def register(self, adapter_cls: type[CompilationPipelineAdapter]) -> None:
-        adapter = adapter_cls()
-        self._adapters[adapter.adapter_name.lower()] = adapter
+        key = adapter_cls.adapter_name.lower()
+        self._adapter_classes[key] = adapter_cls
 
-    def create_all(self) -> list[CompilationPipelineAdapter]:
-        return list(self._adapters.values())
+    def _ensure_initialized(self, adapter_name: str) -> None:
+        key = adapter_name.lower()
+        if key not in self._adapter_instances and key in self._adapter_classes:
+            self._adapter_instances[key] = self._adapter_classes[key]()
 
     def resolve(
         self,
         *,
         adapter_name: str,
     ) -> CompilationPipelineAdapter:
-        adapter = self._adapters.get(adapter_name.lower())
+        self._ensure_initialized(adapter_name)
+        adapter = self._adapter_instances.get(adapter_name.lower())
         if adapter is None:
+            available = list(self._adapter_classes.keys())
             raise ValueError(
                 "Unable to resolve adapter from adapter_name: "
-                f"adapter_name={adapter_name!r}"
+                f"adapter_name={adapter_name!r}. Available: {available}"
             )
         return adapter
 
@@ -600,44 +599,10 @@ class PipelineAdapterRegistry:
         )
 
 
-# =============================================================================
-# COMMON PARSER / ANALYZER INITIALIZATION
-# =============================================================================
-def _initialize_common_parsers() -> None:
-    from tritonparse.parse.ir_parser import _parse_generic_loc, _parse_none
-
-    ParserRegistry.register("generic_loc", _parse_generic_loc)
-    ParserRegistry.register("none", _parse_none)
-    logger.debug("Common parsers registered successfully")
-
-
-def _initialize_common_analyzers() -> None:
-    from tritonparse.parse.ir_analysis import (
-        _analyze_loop_schedules_generic,
-        _analyze_procedures_generic,
-    )
-
-    AnalysisRegistry.register(
-        "loop_schedules",
-        _analyze_loop_schedules_generic,
-        required_stages=("ttir", "ttgir"),
-        adapter_affinity=None,
-    )
-    AnalysisRegistry.register(
-        "procedure_checks",
-        _analyze_procedures_generic,
-        required_stages=("ttgir",),
-        adapter_affinity=None,
-    )
-    logger.debug("Common analyzers registered successfully")
-
-
-_initialize_common_parsers()
-_initialize_common_analyzers()
-
+# Module-level registration (no instantiation at import time)
 _REGISTRY = PipelineAdapterRegistry()
-for _adapter_cls in (NvidiaTritonAdapter, AmdTritonAdapter):
-    _REGISTRY.register(_adapter_cls)
+_REGISTRY.register(NvidiaTritonAdapter)
+_REGISTRY.register(AmdTritonAdapter)
 
 
 def get_backend_registry() -> PipelineAdapterRegistry:

--- a/tritonparse/backend.py
+++ b/tritonparse/backend.py
@@ -103,6 +103,107 @@ class DerivedArtifactRegistry:
         return list(cls._registry.keys())
 
 
+# =============================================================================
+# PARSER REGISTRY
+# =============================================================================
+class ParserRegistry:
+    """Registry for managing IR parser functions.
+
+    This registry allows adapters to register and retrieve parser functions
+    by parser_id. It supports both common parsers (shared across backends)
+    and backend-specific parsers.
+    """
+
+    _parsers: dict[str, Callable] = {}
+
+    @classmethod
+    def register(cls, parser_id: str, parser_func: Callable) -> None:
+        if parser_id in cls._parsers:
+            logger.warning(
+                f"Parser '{parser_id}' is already registered. "
+                f"Overwriting with new parser function."
+            )
+        cls._parsers[parser_id] = parser_func
+        logger.debug(f"Registered parser: {parser_id}")
+
+    @classmethod
+    def get_parser(cls, parser_id: str) -> Callable | None:
+        return cls._parsers.get(parser_id)
+
+    @classmethod
+    def list_parsers(cls) -> list[str]:
+        return list(cls._parsers.keys())
+
+
+# =============================================================================
+# ANALYSIS REGISTRY
+# =============================================================================
+@dataclass
+class AnalyzerInfo:
+    """Information about a registered analyzer.
+
+    Attributes:
+        name: Analyzer name (e.g., "amd_buffer_ops")
+        func: Analyzer function with signature (entry, procedure_checks) -> dict | None
+        required_stages: Tuple of stage names required (e.g., ("ttgir", "amdgcn"))
+        adapter_affinity: Which backend this analyzer belongs to (e.g., "hip_triton").
+                       None means common/shared analyzer.
+    """
+
+    name: str
+    func: Callable
+    required_stages: tuple[str, ...]
+    adapter_affinity: str | None = None
+
+
+class AnalysisRegistry:
+    """Registry for managing IR analysis functions and their metadata.
+
+    This registry allows adapters to register and retrieve analysis functions
+    by analysis_id. It supports both common analyzers (shared across backends)
+    and backend-specific analyzers.
+    """
+
+    _analyzer_infos: dict[str, AnalyzerInfo] = {}
+
+    @classmethod
+    def register(
+        cls,
+        analyzer_id: str,
+        analyzer_func: Callable,
+        required_stages: tuple[str, ...],
+        adapter_affinity: str | None = None,
+    ) -> None:
+        if analyzer_id in cls._analyzer_infos:
+            logger.debug(
+                f"Analyzer '{analyzer_id}' is already registered. Overwriting."
+            )
+        info = AnalyzerInfo(
+            name=analyzer_id,
+            func=analyzer_func,
+            required_stages=required_stages,
+            adapter_affinity=adapter_affinity,
+        )
+        cls._analyzer_infos[analyzer_id] = info
+
+    @classmethod
+    def get_analyzer_info(cls, analyzer_id: str) -> AnalyzerInfo | None:
+        return cls._analyzer_infos.get(analyzer_id)
+
+    @classmethod
+    def get_analyzer(cls, analyzer_id: str) -> Callable | None:
+        info = cls._analyzer_infos.get(analyzer_id)
+        return info.func if info else None
+
+    @classmethod
+    def list_analyzers(cls) -> list[str]:
+        return list(cls._analyzer_infos.keys())
+
+    @classmethod
+    def list_analyzer_infos(cls) -> list[tuple[str, AnalyzerInfo]]:
+        return list(cls._analyzer_infos.items())
+
+
 class CompilationPipelineAdapter(ABC):
     """Abstract base class for compilation pipeline adapters.
 
@@ -189,13 +290,10 @@ class CompilationPipelineAdapter(ABC):
 
         Can be overridden by subclasses for custom behavior.
         """
-        from tritonparse.parse.ir_analysis import AnalysisRegistry
-
         my_name = self.adapter_name
         analyzer_names = []
 
         for _, info in AnalysisRegistry.list_analyzer_infos():
-            # Include analyzers specific to this adapter or common analyzers
             if info.adapter_affinity in (my_name, None):
                 analyzer_names.append(info.name)
 
@@ -218,9 +316,6 @@ class CompilationPipelineAdapter(ABC):
         Returns:
             List of executable analyzer names
         """
-        from tritonparse.parse.ir_analysis import AnalysisRegistry
-
-        # Get declared analyzers for this adapter (already registered)
         declared_analyzers = self.get_analysis_passes()
         executable = []
 
@@ -271,8 +366,6 @@ class CompilationPipelineAdapter(ABC):
         Raises:
             ValueError: If the pass_name is not found in the registry
         """
-        from tritonparse.parse.ir_analysis import AnalysisRegistry
-
         analyzer = AnalysisRegistry.get_analyzer(pass_name)
         if analyzer is None:
             available = AnalysisRegistry.list_analyzers()
@@ -300,9 +393,6 @@ class CompilationPipelineAdapter(ABC):
                           (entry, procedure_checks) -> dict | None
             required_stages: Required stage names (e.g., ("ttgir", "amdgcn"))
         """
-        from tritonparse.parse.ir_analysis import AnalysisRegistry
-
-        # Use this adapter's name as affinity
         adapter_affinity = self.adapter_name
         AnalysisRegistry.register(
             analyzer_id, analyzer_func, required_stages, adapter_affinity
@@ -328,8 +418,6 @@ class CompilationPipelineAdapter(ABC):
         Raises:
             ValueError: If the parser_id is not found in the registry
         """
-        from tritonparse.parse.ir_parser import ParserRegistry
-
         parser = ParserRegistry.get_parser(parser_id)
         if parser is None:
             available_parsers = ParserRegistry.list_parsers()
@@ -350,8 +438,6 @@ class CompilationPipelineAdapter(ABC):
             parser_id: The parser identifier (e.g., "ascend_ir")
             parser_func: The parser function
         """
-        from tritonparse.parse.ir_parser import ParserRegistry
-
         ParserRegistry.register(parser_id, parser_func)
 
 
@@ -513,6 +599,41 @@ class PipelineAdapterRegistry:
             f"backend_name={backend_name!r}"
         )
 
+
+# =============================================================================
+# COMMON PARSER / ANALYZER INITIALIZATION
+# =============================================================================
+def _initialize_common_parsers() -> None:
+    from tritonparse.parse.ir_parser import _parse_generic_loc, _parse_none
+
+    ParserRegistry.register("generic_loc", _parse_generic_loc)
+    ParserRegistry.register("none", _parse_none)
+    logger.debug("Common parsers registered successfully")
+
+
+def _initialize_common_analyzers() -> None:
+    from tritonparse.parse.ir_analysis import (
+        _analyze_loop_schedules_generic,
+        _analyze_procedures_generic,
+    )
+
+    AnalysisRegistry.register(
+        "loop_schedules",
+        _analyze_loop_schedules_generic,
+        required_stages=("ttir", "ttgir"),
+        adapter_affinity=None,
+    )
+    AnalysisRegistry.register(
+        "procedure_checks",
+        _analyze_procedures_generic,
+        required_stages=("ttgir",),
+        adapter_affinity=None,
+    )
+    logger.debug("Common analyzers registered successfully")
+
+
+_initialize_common_parsers()
+_initialize_common_analyzers()
 
 _REGISTRY = PipelineAdapterRegistry()
 for _adapter_cls in (NvidiaTritonAdapter, AmdTritonAdapter):

--- a/tritonparse/backend.py
+++ b/tritonparse/backend.py
@@ -54,7 +54,6 @@ class DerivedArtifactInfo:
         source_stage_name: Name of the source stage (e.g., "cubin").
         target_stage_name: Name of the target stage (e.g., "sass").
         tool_name: Name of the tool used to generate the artifact (e.g., "nvdisasm").
-        adapter_affinity: Name of the adapter this derivation belongs to.
         derive_func: Callable that takes a source file path and returns derived content,
             or None if the tool is unavailable or derivation fails.
     """
@@ -62,7 +61,6 @@ class DerivedArtifactInfo:
     source_stage_name: str
     target_stage_name: str
     tool_name: str
-    adapter_affinity: str
     derive_func: Callable[[str], str | None]
 
 
@@ -130,14 +128,11 @@ class AnalyzerInfo:
         name: Analyzer name (e.g., "amd_buffer_ops")
         func: Analyzer function with signature (entry, procedure_checks) -> dict | None
         required_stages: Tuple of stage names required (e.g., ("ttgir", "amdgcn"))
-        adapter_affinity: Which backend this analyzer belongs to (e.g., "hip_triton").
-                       None means common/shared analyzer.
     """
 
     name: str
     func: Callable
     required_stages: tuple[str, ...]
-    adapter_affinity: str | None = None
 
 
 class AnalysisRegistry:
@@ -151,7 +146,6 @@ class AnalysisRegistry:
         analyzer_id: str,
         analyzer_func: Callable,
         required_stages: tuple[str, ...],
-        adapter_affinity: str | None = None,
     ) -> None:
         """Register an analyzer with its metadata."""
         if analyzer_id in self._analyzer_infos:
@@ -162,7 +156,6 @@ class AnalysisRegistry:
             name=analyzer_id,
             func=analyzer_func,
             required_stages=required_stages,
-            adapter_affinity=adapter_affinity,
         )
         self._analyzer_infos[analyzer_id] = info
 
@@ -224,13 +217,11 @@ class CompilationPipelineAdapter(ABC):
             "loop_schedules",
             _analyze_loop_schedules_generic,
             required_stages=("ttir", "ttgir"),
-            adapter_affinity=None,
         )
         self._analysis_registry.register(
             "procedure_checks",
             _analyze_procedures_generic,
             required_stages=("ttgir",),
-            adapter_affinity=None,
         )
 
     def get_ir_stages(self) -> list[IRStageDescriptor]:
@@ -260,8 +251,9 @@ class CompilationPipelineAdapter(ABC):
         all_artifacts = self._derived_artifact_registry.list_all()
 
         if enabled_derived_artifacts is not None:
+            enabled_normalized = {n.lower() for n in enabled_derived_artifacts}
             known = {info.target_stage_name.lower() for info in all_artifacts}
-            unknown = {n for n in enabled_derived_artifacts if n not in known}
+            unknown = enabled_normalized - known
             if unknown:
                 logger.warning(
                     f"TRITONPARSE_DERIVED_ARTIFACTS contains unknown target stage names: {unknown}. "
@@ -270,7 +262,7 @@ class CompilationPipelineAdapter(ABC):
             return [
                 info
                 for info in all_artifacts
-                if info.target_stage_name in enabled_derived_artifacts
+                if info.target_stage_name.lower() in enabled_normalized
             ]
 
         return all_artifacts
@@ -288,10 +280,13 @@ class CompilationPipelineAdapter(ABC):
                 source_stage_name=source_stage_name,
                 target_stage_name=target_stage_name,
                 tool_name=tool_name,
-                adapter_affinity=self.adapter_name,
                 derive_func=derive_func,
             )
         )
+
+    def list_parsers(self) -> list[str]:
+        """List all registered parser IDs (common + backend-specific)."""
+        return self._parser_registry.list_parsers()
 
     def get_analysis_passes(self) -> list[str]:
         """
@@ -301,6 +296,13 @@ class CompilationPipelineAdapter(ABC):
         (common + backend-specific).
         """
         return self._analysis_registry.list_analyzers()
+
+    def get_analyzer_required_stages(
+        self, analyzer_name: str
+    ) -> tuple[str, ...] | None:
+        """Return required stages for the given analyzer, or None if not registered."""
+        info = self._analysis_registry.get_analyzer_info(analyzer_name)
+        return info.required_stages if info else None
 
     def get_executable_analyzers(
         self,
@@ -322,9 +324,14 @@ class CompilationPipelineAdapter(ABC):
             List of executable analyzer names
         """
         # Validate user-provided names against known analyzers
-        if enabled_analyses is not None:
+        enabled_normalized = (
+            {n.lower() for n in enabled_analyses}
+            if enabled_analyses is not None
+            else None
+        )
+        if enabled_normalized is not None:
             known = {name.lower() for name in self._analysis_registry.list_analyzers()}
-            unknown = {n for n in enabled_analyses if n not in known}
+            unknown = enabled_normalized - known
             if unknown:
                 logger.warning(
                     f"TRITONPARSE_ANALYSIS contains unknown analyzer names: {unknown}. "
@@ -336,7 +343,10 @@ class CompilationPipelineAdapter(ABC):
 
         for analyzer_name in declared_analyzers:
             # Check 1: Is it enabled by user?
-            if enabled_analyses is not None and analyzer_name not in enabled_analyses:
+            if (
+                enabled_normalized is not None
+                and analyzer_name.lower() not in enabled_normalized
+            ):
                 continue
 
             # Check 2: Are required stages available?
@@ -468,7 +478,6 @@ class NvidiaTritonAdapter(CompilationPipelineAdapter):
                 source_stage_name="cubin",
                 target_stage_name="sass",
                 tool_name="nvdisasm",
-                adapter_affinity=self.adapter_name,
                 derive_func=derive_sass,
             )
         )
@@ -517,7 +526,6 @@ class AmdTritonAdapter(CompilationPipelineAdapter):
             "amd_buffer_ops",
             _analyze_amd_buffer_ops,
             required_stages=("ttgir", "amdgcn"),
-            adapter_affinity=self.adapter_name,
         )
 
         # Pre-initialize stage descriptors (immutable objects, can be reused)

--- a/tritonparse/parse/ir_analysis.py
+++ b/tritonparse/parse/ir_analysis.py
@@ -5,7 +5,6 @@ import re
 import shutil
 import subprocess
 import tempfile
-from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from typing import Any
 
@@ -18,91 +17,6 @@ logger = get_logger("IRAnalysis")
 
 # Default timeout (in seconds) for FileCheck subprocess calls
 FILECHECK_TIMEOUT_SECONDS = 30
-
-
-# =============================================================================
-# ANALYSIS REGISTRY
-# =============================================================================
-@dataclass
-class AnalyzerInfo:
-    """
-    Information about a registered analyzer.
-
-    Attributes:
-        name: Analyzer name (e.g., "amd_buffer_ops")
-        func: Analyzer function with signature (entry, procedure_checks) -> dict | None
-        required_stages: Tuple of stage names required (e.g., ("ttgir", "amdgcn"))
-        adapter_affinity: Which backend this analyzer belongs to (e.g., "hip_triton").
-                       None means common/shared analyzer.
-    """
-
-    name: str
-    func: Callable
-    required_stages: tuple[str, ...]
-    adapter_affinity: str | None = None
-
-
-class AnalysisRegistry:
-    """
-    Registry for managing IR analysis functions and their metadata.
-
-    This registry allows adapters to register and retrieve analysis functions
-    by analysis_id. It supports both common analyzers (shared across backends)
-    and backend-specific analyzers.
-    """
-
-    _analyzer_infos: dict[str, AnalyzerInfo] = {}
-
-    @classmethod
-    def register(
-        cls,
-        analyzer_id: str,
-        analyzer_func: Callable,
-        required_stages: tuple[str, ...],
-        adapter_affinity: str | None = None,
-    ) -> None:
-        """
-        Register an analyzer with its metadata.
-
-        Args:
-            analyzer_id: Analyzer identifier (e.g., "amd_buffer_ops")
-            analyzer_func: Analyzer function
-            required_stages: Required stage names (e.g., ("ttgir", "amdgcn"))
-            adapter_affinity: Which backend this analyzer belongs to (e.g., "hip_triton").
-                           None means common/shared analyzer.
-        """
-        if analyzer_id in cls._analyzer_infos:
-            logger.debug(
-                f"Analyzer '{analyzer_id}' is already registered. Overwriting."
-            )
-        info = AnalyzerInfo(
-            name=analyzer_id,
-            func=analyzer_func,
-            required_stages=required_stages,
-            adapter_affinity=adapter_affinity,
-        )
-        cls._analyzer_infos[analyzer_id] = info
-
-    @classmethod
-    def get_analyzer_info(cls, analyzer_id: str) -> AnalyzerInfo | None:
-        """Get analyzer info by name."""
-        return cls._analyzer_infos.get(analyzer_id)
-
-    @classmethod
-    def get_analyzer(cls, analyzer_id: str) -> Callable | None:
-        """Get the analyzer function by name."""
-        info = cls._analyzer_infos.get(analyzer_id)
-        return info.func if info else None
-
-    @classmethod
-    def list_analyzers(cls) -> list[str]:
-        """List all registered analyzer IDs."""
-        return list(cls._analyzer_infos.keys())
-
-    @classmethod
-    def list_analyzer_infos(cls) -> list[tuple[str, AnalyzerInfo]]:
-        """List all registered (analyzer_id, AnalyzerInfo) pairs."""
-        return list(cls._analyzer_infos.items())
 
 
 # =============================================================================
@@ -1375,26 +1289,3 @@ def _analyze_procedures_generic(
     if procedure_results:
         return {"procedure_checks": procedure_results}
     return None
-
-
-# =============================================================================
-# COMMON ANALYZER INITIALIZATION
-# =============================================================================
-def _initialize_common_analyzers() -> None:
-    """Register common analyzers that are shared across all backends."""
-    AnalysisRegistry.register(
-        "loop_schedules",
-        _analyze_loop_schedules_generic,
-        required_stages=("ttir", "ttgir"),
-        adapter_affinity=None,  # Common analyzer
-    )
-    AnalysisRegistry.register(
-        "procedure_checks",
-        _analyze_procedures_generic,
-        required_stages=("ttgir",),
-        adapter_affinity=None,  # Common analyzer
-    )
-
-
-# Initialize common analyzers on module load
-_initialize_common_analyzers()

--- a/tritonparse/parse/ir_parser.py
+++ b/tritonparse/parse/ir_parser.py
@@ -3,7 +3,7 @@
 import os
 import re
 from collections import defaultdict
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from tritonparse.tp_logger import get_logger
 
@@ -60,64 +60,6 @@ ALIAS_SIMPLE_PATTERN = re.compile(r"#loc(\d+)\s*=\s*loc\(\s*#loc(\d*)\s*\)")
 CALLSITE_PATTERN = re.compile(
     r"#loc(\d+)\s*=\s*loc\(\s*callsite\(\s*#loc(\d*)\s+at\s+#loc(\d*)\s*\)\s*\)"
 )
-
-
-# =============================================================================
-# PARSER REGISTRY
-# =============================================================================
-class ParserRegistry:
-    """
-    Registry for managing IR parser functions.
-
-    This registry allows adapters to register and retrieve parser functions
-    by parser_id. It supports both common parsers (shared across backends)
-    and backend-specific parsers.
-    """
-
-    _parsers: Dict[str, Callable] = {}
-
-    @classmethod
-    def register(cls, parser_id: str, parser_func: Callable) -> None:
-        """
-        Register a parser function with the given parser_id.
-
-        Args:
-            parser_id: The parser identifier (e.g., "generic_loc", "ptx_loc")
-            parser_func: The parser function
-
-        If parser_id is already registered, the existing parser is overwritten
-        and a warning is logged.
-        """
-        if parser_id in cls._parsers:
-            logger.warning(
-                f"Parser '{parser_id}' is already registered. "
-                f"Overwriting with new parser function."
-            )
-        cls._parsers[parser_id] = parser_func
-        logger.debug(f"Registered parser: {parser_id}")
-
-    @classmethod
-    def get_parser(cls, parser_id: str) -> Optional[Callable]:
-        """
-        Get a parser function by parser_id.
-
-        Args:
-            parser_id: The parser identifier
-
-        Returns:
-            The parser function, or None if not found
-        """
-        return cls._parsers.get(parser_id)
-
-    @classmethod
-    def list_parsers(cls) -> List[str]:
-        """
-        List all registered parser IDs.
-
-        Returns:
-            List of parser IDs
-        """
-        return list(cls._parsers.keys())
 
 
 def extract_loc_definitions(ir_content: str) -> Dict[str, Dict[str, Any]]:
@@ -712,25 +654,3 @@ def _parse_none(
         Empty dictionary
     """
     return {}
-
-
-# =============================================================================
-# REGISTER COMMON PARSERS
-# =============================================================================
-def _initialize_common_parsers() -> None:
-    """
-    Register common parsers that are shared across all backends.
-
-    Common parsers are those that work across all backends (e.g., TTIR/TTGIR/LLIR
-    which use generic #loc directives).
-
-    Backend-specific parsers (PTX, SASS, AMDGCN) are registered by their
-    respective adapters.
-    """
-    ParserRegistry.register("generic_loc", _parse_generic_loc)
-    ParserRegistry.register("none", _parse_none)
-    logger.debug("Common parsers registered successfully")
-
-
-# Initialize parsers at module import time
-_initialize_common_parsers()

--- a/tritonparse/shared_vars.py
+++ b/tritonparse/shared_vars.py
@@ -74,7 +74,7 @@ def get_enabled_analyses() -> set[str] | None:
         return set()
 
     # Validate against registered analyzers (lazy import to avoid circular deps)
-    from tritonparse.parse.ir_analysis import AnalysisRegistry
+    from tritonparse.backend import AnalysisRegistry
 
     known = {name.lower() for name in AnalysisRegistry.list_analyzers()}
     unknown = {n for n in raw_names if n not in known}

--- a/tritonparse/shared_vars.py
+++ b/tritonparse/shared_vars.py
@@ -73,18 +73,9 @@ def get_enabled_analyses() -> set[str] | None:
         )
         return set()
 
-    # Validate against registered analyzers (lazy import to avoid circular deps)
-    from tritonparse.backend import AnalysisRegistry
-
-    known = {name.lower() for name in AnalysisRegistry.list_analyzers()}
-    unknown = {n for n in raw_names if n not in known}
-    if unknown:
-        logger.warning(
-            f"TRITONPARSE_ANALYSIS contains unknown analyzer names: {unknown}. "
-            f"Available: {sorted(known)}"
-        )
-
-    return set(raw_names) & known if known else set(raw_names)
+    # Validation happens at adapter level (get_executable_analyzers)
+    # where the adapter's instance registry is available.
+    return set(raw_names)
 
 
 def set_runtime_sass_dump_override(enabled: bool | None) -> None:
@@ -154,15 +145,5 @@ def get_enabled_derived_artifacts() -> set[str] | None:
     if is_sass_dump_enabled():
         raw_names.append("sass")
 
-    # Validate against registered derived artifacts (lazy import to avoid circular deps)
-    from tritonparse.backend import DerivedArtifactRegistry
-
-    known = {name.lower() for name in DerivedArtifactRegistry.list_target_stage_names()}
-    unknown = {n for n in raw_names if n not in known}
-    if unknown and known:
-        logger.warning(
-            f"TRITONPARSE_DERIVED_ARTIFACTS contains unknown target stage names: {unknown}. "
-            f"Available: {sorted(known)}"
-        )
-
-    return set(raw_names) & known if known else set(raw_names)
+    # Validation happens at adapter level where the instance registry is available.
+    return set(raw_names)

--- a/tritonparse/structured_logging.py
+++ b/tritonparse/structured_logging.py
@@ -968,9 +968,7 @@ def _extract_file_content_adapter_driven(
 
     # Derived artifacts
     enabled = get_enabled_derived_artifacts()
-    for info in adapter.get_derived_artifacts():
-        if enabled is not None and info.target_stage_name not in enabled:
-            continue
+    for info in adapter.get_applicable_derived_artifacts(enabled):
         source_stage = adapter.get_stage_by_name(info.source_stage_name)
         if not source_stage:
             log.warning(


### PR DESCRIPTION
## Background

- **RFC**: https://github.com/meta-pytorch/tritonparse/issues/367

## Summary

This PR contains two core refactors that completely resolve the circular dependency between `backend.py`, `ir_analysis.py`, `ir_parser.py`, and `shared_vars.py`, and transitions all three Registries (Parser / Analysis / DerivedArtifact) from global class-level sharing to per-adapter instance isolation, along with a lazy adapter initialization mechanism.

---

## Task 1: Migrate Core Classes to `backend.py` to Eliminate Circular Dependencies

### Problem

Before this refactor, the three core registry classes were scattered across different modules, forming a fragile three-way circular dependency:

```mermaid
graph LR
    B["backend.py"] -- "lazy import AnalysisRegistry" --> A["ir_analysis.py"]
    B -- "lazy import ParserRegistry" --> P["ir_parser.py"]
    A -- "lazy import get_backend_registry()" --> B
    S["shared_vars.py"] -- "lazy import AnalysisRegistry" --> A
    S -- "lazy import DerivedArtifactRegistry" --> B

    style B fill:#ffe1e1,stroke:#f44336
    style A fill:#ffe1e1,stroke:#f44336
    style P fill:#ffe1e1,stroke:#f44336
    style S fill:#ffe1e1,stroke:#f44336
```

All four modules relied heavily on lazy imports (i.e., `from ... import` inside function bodies) to avoid circular imports at module load time — a fragile pattern that was easy to break.

### Solution

Migrate `ParserRegistry`, `AnalyzerInfo`, and `AnalysisRegistry` from `ir_parser.py` / `ir_analysis.py` into `backend.py`, aligning with the existing `DerivedArtifactRegistry`:

```mermaid
graph TD
    B["backend.py<br/>(Centralized registration hub)"] -- "lazy import impl functions" --> P["ir_parser.py<br/>(Pure parse functions)"]
    B -- "lazy import impl functions" --> A["ir_analysis.py<br/>(Pure analysis functions)"]
    S["shared_vars.py"] -- "import get_enabled_*()" --> B
    TP["trace_processor.py"] -- "import get_backend_registry()" --> B
    SL["structured_logging.py"] -- "import get_backend_registry()" --> B

    style B fill:#e1f5e1,stroke:#4caf50,stroke-width:2px
    style P fill:#f0f0f0,stroke:#999
    style A fill:#f0f0f0,stroke:#999
```

The dependency direction is now unified: `backend.py` serves as the centralized registration hub, while `ir_parser.py` and `ir_analysis.py` are responsible only for specific implementation functions and no longer hold registry definitions.

### Migration Details

| Class | Before | After |
|---|---|---|
| `ParserRegistry` | `ir_parser.py` | `backend.py` |
| `AnalyzerInfo` | `ir_analysis.py` | `backend.py` |
| `AnalysisRegistry` | `ir_analysis.py` | `backend.py` |
| `DerivedArtifactRegistry` | `backend.py` (unchanged) | `backend.py` |
| `_initialize_common_parsers()` | `ir_parser.py` (executed at module load) | `backend.py` |
| `_initialize_common_analyzers()` | `ir_analysis.py` (executed at module load) | `backend.py` |

---

## Task 2: Instance-Level Registry Isolation + Lazy Adapter Initialization

### Problem

Before this refactor, all three Registries used class-level storage (`_parsers: Dict = {}`), meaning every adapter instance shared the same underlying dict:

```mermaid
graph LR
    subgraph before ["Before: Global Sharing"]
        PR["ParserRegistry<br/>_parsers = {}"] --- N1["NvidiaAdapter"]
        PR --- A1["AmdAdapter"]
        AR["AnalysisRegistry<br/>_analyzer_infos = {}"] --- N1
        AR --- A1
    end

    style before fill:#ffe1e1,stroke:#f44336,stroke-width:2px
```

NVIDIA and AMD parser/analyzer registrations were coupled together, making independent management impossible.

### Change 1: Per-Adapter Registry Instances

All three Registries are converted to instance-level storage. Each adapter holds its own independent Registry instances:

```mermaid
graph LR
    subgraph after ["After: Instance Isolation"]
        N2["NvidiaAdapter"]
        N2 --- PR1["_parser_registry<br/>generic_loc, ptx_loc, sass_loc"]
        N2 --- AR1["_analysis_registry<br/>loop_schedules, procedure_checks"]
        N2 --- DR1["_derived_artifact_registry<br/>sass"]

        A2["AmdAdapter"]
        A2 --- PR2["_parser_registry<br/>generic_loc, amdgcn_loc"]
        A2 --- AR2["_analysis_registry<br/>loop_schedules, procedure_checks,<br/>amd_buffer_ops"]
        A2 --- DR2["_derived_artifact_registry<br/>(empty)"]
    end

    style after fill:#e1f5e1,stroke:#4caf50,stroke-width:2px
```

### Change 2: Lazy Adapter Initialization

`PipelineAdapterRegistry` now stores adapter classes and lazily instantiates them on first `resolve()`, caching the result for subsequent calls:

```mermaid
sequenceDiagram
    participant Code as Caller
    participant Registry as PipelineAdapterRegistry
    participant Adapter as NvidiaTritonAdapter

    Note over Registry: register() stores class only,<br/>no instantiation
    Code->>Registry: resolve(adapter_name="cuda_triton")
    alt First resolve
        Registry->>Adapter: Instantiate via __init__()
        Note over Adapter: 1. super().__init__() → register common parsers/analyzers<br/>2. Register backend-specific items
        Adapter-->>Registry: Cache instance
    end
    Registry-->>Code: Return adapter instance
```

### Change 3: Adapter Properties → Class Attributes

`adapter_name`, `runtime_backend`, and `pytorch_module` are converted from `@property` to class attributes, providing a consistent style and enabling the registry to access the adapter name without instantiation:

```python
# Before
class NvidiaTritonAdapter(CompilationPipelineAdapter):
    @property
    def adapter_name(self) -> str:
        return "cuda_triton"

# After
class NvidiaTritonAdapter(CompilationPipelineAdapter):
    adapter_name: str = "cuda_triton"
```

### Change 4: Hoist `get_ir_stages` into Base Class

Both subclasses had identical `get_ir_stages()` implementations (`return self._stages`). The method is now defined once in the base class — subclasses simply set `self._stages` in `__init__`.

### Change 5: Deferred Validation in Adapter Layer

The early validation logic in `get_enabled_analyses()` and `get_enabled_derived_artifacts()` (which required lazy imports of Registry classes) has been removed from `shared_vars.py`. Validation now happens at the adapter layer, where the instance registry is available:

| Validation | Before | After |
|---|---|---|
| Analyzer name validation | `shared_vars.py` (lazy import Registry) | `adapter.get_executable_analyzers()` |
| Derived artifact name validation | `shared_vars.py` (lazy import Registry) | `adapter.get_applicable_derived_artifacts()` |

Both methods follow a symmetric design, implementing validation + filtering in the adapter base class:

```python
# Analyzer validation
def get_executable_analyzers(self, file_content, enabled_analyses=None) -> list[str]

# Derived artifact validation
def get_applicable_derived_artifacts(self, enabled_derived_artifacts=None) -> list[DerivedArtifactInfo]
```

### Change 6: Dead Code Removal

Four methods with no callers have been removed:

- `PipelineAdapterRegistry.create_all()` — no external callers
- `CompilationPipelineAdapter.collect_derived_artifact_contents()` — no external callers
- `CompilationPipelineAdapter.get_stage_by_artifact()` — no external callers
- `CompilationPipelineAdapter.known_stage_extensions` — no external callers

---

## Files Changed

| File | Change |
|------|--------|
| `tritonparse/backend.py` | Registry classes migrated here + converted to instance-level + adapter class attributes + lazy initialization + dead code cleanup |
| `tritonparse/parse/ir_parser.py` | Removed `ParserRegistry` and `_initialize_common_parsers()` |
| `tritonparse/parse/ir_analysis.py` | Removed `AnalyzerInfo`, `AnalysisRegistry`, and `_initialize_common_analyzers()` |
| `tritonparse/shared_vars.py` | Removed early validation; `get_enabled_analyses()` / `get_enabled_derived_artifacts()` now parse env vars only |
| `tritonparse/structured_logging.py` | Use `adapter.get_applicable_derived_artifacts()` instead of manual filtering |
| `tests/cpu/test_multi_backend_stage.py` | Updated tests to reflect instance isolation semantics |

---

## Testing

- `make format-check`
<img width="909" height="231" alt="image" src="https://github.com/user-attachments/assets/33083a60-52e3-488d-88e1-835f5d46887b" />


- `make test-cuda`
<img width="1613" height="513" alt="image" src="https://github.com/user-attachments/assets/15e7fce1-f751-4444-b307-6aa1ade11081" />


- `make test`
<img width="1625" height="504" alt="image" src="https://github.com/user-attachments/assets/be655973-e745-4553-bc62-8f05d15505cf" />



---

## Conclusion

This PR delivers two architectural improvements:

1. **Circular dependency elimination**: All three core Registries and common initialization logic are consolidated into `backend.py`; `ir_parser.py` and `ir_analysis.py` are now pure implementation modules.
2. **Instance-level isolation + lazy initialization**: Each adapter holds independent Registry instances. `PipelineAdapterRegistry` defers adapter instantiation until first use.

Both changes are fully backward-compatible at the API level — no caller modifications are required. To add a new backend, simply subclass `CompilationPipelineAdapter`, set class attributes, and register backend-specific parsers/analyzers in `__init__` to get complete isolation automatically.
