### PR TITLE
backend.py Internal Consistency Cleanup — Registry Simplification, API Renaming, Docstring & Type Hint Unification

### DIFF
--- a/tests/cpu/test_multi_backend_stage.py
+++ b/tests/cpu/test_multi_backend_stage.py
@@ -124,21 +124,21 @@ class TestMultiBackendStage(unittest.TestCase):
 
         # Common parsers present in both
         for adapter in (nvidia, amd):
-            parsers = adapter.list_parsers()
-            self.assertIn("generic_loc", parsers)
-            self.assertIn("none", parsers)
+            self.assertIsNotNone(adapter.get_parser("generic_loc"))
+            self.assertIsNotNone(adapter.get_parser("none"))
 
         # NVIDIA-specific parsers only in NVIDIA adapter
-        nvidia_parsers = nvidia.list_parsers()
-        self.assertIn("ptx_loc", nvidia_parsers)
-        self.assertIn("sass_loc", nvidia_parsers)
-        self.assertNotIn("amdgcn_loc", nvidia_parsers)
+        self.assertIsNotNone(nvidia.get_parser("ptx_loc"))
+        self.assertIsNotNone(nvidia.get_parser("sass_loc"))
+        with self.assertRaises(ValueError):
+            nvidia.get_parser("amdgcn_loc")
 
         # AMD-specific parser only in AMD adapter
-        amd_parsers = amd.list_parsers()
-        self.assertIn("amdgcn_loc", amd_parsers)
-        self.assertNotIn("ptx_loc", amd_parsers)
-        self.assertNotIn("sass_loc", amd_parsers)
+        self.assertIsNotNone(amd.get_parser("amdgcn_loc"))
+        with self.assertRaises(ValueError):
+            amd.get_parser("ptx_loc")
+        with self.assertRaises(ValueError):
+            amd.get_parser("sass_loc")
 
     def test_adapter_get_parser_method(self):
         """Test adapter.get_parser() with isolated per-adapter registries."""
@@ -369,21 +369,21 @@ class TestAnalysisAdapterDriven(unittest.TestCase):
 
         # Common analyzers present in both
         for adapter in (nvidia, amd):
-            analyzers = adapter.get_analysis_passes()
+            analyzers = adapter.list_analyzer_keys()
             self.assertIn("loop_schedules", analyzers)
             self.assertIn("procedure_checks", analyzers)
 
         # Only AMD adapter has amd_buffer_ops
-        self.assertIn("amd_buffer_ops", amd.get_analysis_passes())
-        self.assertNotIn("amd_buffer_ops", nvidia.get_analysis_passes())
+        self.assertIn("amd_buffer_ops", amd.list_analyzer_keys())
+        self.assertNotIn("amd_buffer_ops", nvidia.list_analyzer_keys())
 
     def test_analysis_adapter_passes_differ_by_backend(self):
         """NVIDIA only has common passes; AMD additionally has amd_buffer_ops."""
         nvidia_passes = set(
-            self.registry.resolve(adapter_name="cuda_triton").get_analysis_passes()
+            self.registry.resolve(adapter_name="cuda_triton").list_analyzer_keys()
         )
         amd_passes = set(
-            self.registry.resolve(adapter_name="hip_triton").get_analysis_passes()
+            self.registry.resolve(adapter_name="hip_triton").list_analyzer_keys()
         )
 
         self.assertIn("loop_schedules", nvidia_passes)
@@ -391,21 +391,6 @@ class TestAnalysisAdapterDriven(unittest.TestCase):
 
         self.assertIn("loop_schedules", amd_passes)
         self.assertIn("amd_buffer_ops", amd_passes)
-
-    def test_analysis_adapter_required_stages_consistency(self):
-        """Each analysis pass's required_stages should exist in the adapter."""
-        amd_adapter = self.registry.resolve(adapter_name="hip_triton")
-        for pass_name in amd_adapter.get_analysis_passes():
-            required_stages = amd_adapter.get_analyzer_required_stages(pass_name)
-            self.assertIsNotNone(
-                required_stages, f"Analyzer '{pass_name}' should be registered"
-            )
-            assert required_stages is not None  # for type checker
-            for stage_name in required_stages:
-                self.assertIsNotNone(
-                    amd_adapter.get_stage_by_name(stage_name),
-                    f"Required stage '{stage_name}' should exist in AMD adapter",
-                )
 
     def test_analysis_adapter_run_analysis_pass(self):
         """run_analysis_pass: empty artifacts → None; invalid analyzer → ValueError."""
@@ -502,8 +487,11 @@ class TestAnalysisAdapterDriven(unittest.TestCase):
             return sentinel_result
 
         # Save original loop_schedules on NVIDIA
-        original_analyzer = nvidia.get_analyzer("loop_schedules")
-        original_stages = nvidia.get_analyzer_required_stages("loop_schedules")
+        original_info = nvidia._analysis_registry.get_analyzer_info("loop_schedules")
+        self.assertIsNotNone(original_info)
+        assert original_info is not None
+        original_analyzer = original_info.func
+        original_stages = original_info.required_stages
 
         try:
             # Overwrite loop_schedules on NVIDIA with custom analyzer
@@ -528,7 +516,10 @@ class TestAnalysisAdapterDriven(unittest.TestCase):
             )
 
             # AMD's loop_schedules is unaffected (isolation)
-            amd_stages = amd.get_analyzer_required_stages("loop_schedules")
+            amd_info = amd._analysis_registry.get_analyzer_info("loop_schedules")
+            self.assertIsNotNone(amd_info)
+            assert amd_info is not None
+            amd_stages = amd_info.required_stages
             self.assertEqual(amd_stages, original_stages)
         finally:
             nvidia.register_backend_analyzer(
@@ -546,7 +537,7 @@ class TestAnalysisAdapterDriven(unittest.TestCase):
         # Save original sass derived artifact on NVIDIA
         original_artifacts = [
             info
-            for info in nvidia.get_applicable_derived_artifacts()
+            for info in nvidia.list_applicable_derived_artifacts()
             if info.target_stage_name == "sass"
         ]
         original_sass = original_artifacts[0] if original_artifacts else None
@@ -561,12 +552,12 @@ class TestAnalysisAdapterDriven(unittest.TestCase):
             )
 
             # Custom artifact visible on NVIDIA
-            nvidia_artifacts = nvidia.get_applicable_derived_artifacts()
+            nvidia_artifacts = nvidia.list_applicable_derived_artifacts()
             target_names = [info.target_stage_name for info in nvidia_artifacts]
             self.assertIn("sass", target_names)
 
             # AMD is unaffected (isolation) — AMD has no sass
-            amd_artifacts = amd.get_applicable_derived_artifacts()
+            amd_artifacts = amd.list_applicable_derived_artifacts()
             amd_target_names = [info.target_stage_name for info in amd_artifacts]
             self.assertNotIn("sass", amd_target_names)
         finally:
@@ -582,13 +573,17 @@ class TestAnalysisAdapterDriven(unittest.TestCase):
 class TestDeviceStringHelpers(unittest.TestCase):
     """Tests for device-string normalization helpers."""
 
-    def test_adapter_returns_canonical_cuda_device(self):
-        adapter = NvidiaTritonAdapter()
-        self.assertEqual(adapter.get_canonical_device_string(), "cuda:0")
+    def test_public_helper_normalizes_cuda(self):
+        from tritonparse.backend import normalize_accelerator_device_string
 
-    def test_adapter_returns_canonical_hip_device(self):
-        adapter = AmdTritonAdapter()
-        self.assertEqual(adapter.get_canonical_device_string(), "cuda:0")
+        self.assertEqual(normalize_accelerator_device_string("cuda"), "cuda:0")
+        self.assertEqual(normalize_accelerator_device_string("cuda:2"), "cuda:0")
+
+    def test_public_helper_normalizes_hip(self):
+        from tritonparse.backend import normalize_accelerator_device_string
+
+        self.assertEqual(normalize_accelerator_device_string("hip"), "hip:0")
+        self.assertEqual(normalize_accelerator_device_string("hip:3"), "hip:0")
 
     def test_public_helper_keeps_cpu(self):
         from tritonparse.backend import normalize_accelerator_device_string

--- a/tritonparse/backend.py
+++ b/tritonparse/backend.py
@@ -73,13 +73,24 @@ class DerivedArtifactRegistry:
     def __init__(self) -> None:
         self._registry: dict[str, DerivedArtifactInfo] = {}
 
-    def register(self, info: DerivedArtifactInfo) -> None:
-        key = info.target_stage_name
-        if key in self._registry:
-            logger.debug(
-                f"Overwriting existing derived artifact registration for '{key}'"
+    def register(
+        self,
+        target_stage_name: str,
+        source_stage_name: str,
+        tool_name: str,
+        derive_func: Callable[[str], str | None],
+    ) -> None:
+        if target_stage_name in self._registry:
+            logger.warning(
+                f"Overwriting existing derived artifact registration for '{target_stage_name}'."
             )
-        self._registry[key] = info
+        self._registry[target_stage_name] = DerivedArtifactInfo(
+            source_stage_name=source_stage_name,
+            target_stage_name=target_stage_name,
+            tool_name=tool_name,
+            derive_func=derive_func,
+        )
+        logger.debug(f"Registered derived artifact: {target_stage_name}")
 
     def get_by_target(self, target_stage_name: str) -> DerivedArtifactInfo | None:
         return self._registry.get(target_stage_name)
@@ -156,7 +167,7 @@ class AnalysisRegistry:
     ) -> None:
         """Register an analyzer with its metadata."""
         if analyzer_id in self._analyzer_infos:
-            logger.debug(
+            logger.warning(
                 f"Analyzer '{analyzer_id}' is already registered. Overwriting."
             )
         info = AnalyzerInfo(
@@ -170,18 +181,13 @@ class AnalysisRegistry:
         """Get analyzer info by name."""
         return self._analyzer_infos.get(analyzer_id)
 
-    def get_analyzer(self, analyzer_id: str) -> Callable | None:
-        """Get the analyzer function by name."""
-        info = self._analyzer_infos.get(analyzer_id)
-        return info.func if info else None
-
     def list_analyzers(self) -> list[str]:
         """List all registered analyzer IDs."""
         return list(self._analyzer_infos.keys())
 
-    def list_analyzer_infos(self) -> list[tuple[str, AnalyzerInfo]]:
-        """List all registered (analyzer_id, AnalyzerInfo) pairs."""
-        return list(self._analyzer_infos.items())
+    def list_analyzer_infos(self) -> list[AnalyzerInfo]:
+        """List all registered analyzer info objects."""
+        return list(self._analyzer_infos.values())
 
 
 # =============================================================================
@@ -283,12 +289,10 @@ class CompilationPipelineAdapter(ABC):
     ) -> None:
         """Register a backend-specific derived artifact to the adapter's registry."""
         self._derived_artifact_registry.register(
-            DerivedArtifactInfo(
-                source_stage_name=source_stage_name,
-                target_stage_name=target_stage_name,
-                tool_name=tool_name,
-                derive_func=derive_func,
-            )
+            target_stage_name=target_stage_name,
+            source_stage_name=source_stage_name,
+            tool_name=tool_name,
+            derive_func=derive_func,
         )
 
     def list_parsers(self) -> list[str]:
@@ -309,10 +313,10 @@ class CompilationPipelineAdapter(ABC):
         return self._analysis_registry.get_analyzer(analyzer_id)
 
     def get_analyzer_required_stages(
-        self, analyzer_name: str
+        self, analyzer_id: str
     ) -> tuple[str, ...] | None:
         """Return required stages for the given analyzer, or None if not registered."""
-        info = self._analysis_registry.get_analyzer_info(analyzer_name)
+        info = self._analysis_registry.get_analyzer_info(analyzer_id)
         return info.required_stages if info else None
 
     def get_executable_analyzers(
@@ -341,7 +345,10 @@ class CompilationPipelineAdapter(ABC):
             else None
         )
         if enabled_normalized is not None:
-            known = {name.lower() for name in self._analysis_registry.list_analyzers()}
+            known = {
+                info.name.lower()
+                for info in self._analysis_registry.list_analyzer_infos()
+            }
             unknown = enabled_normalized - known
             if unknown:
                 logger.warning(
@@ -349,22 +356,17 @@ class CompilationPipelineAdapter(ABC):
                     f"Available for {self.adapter_name}: {sorted(known)}"
                 )
 
-        declared_analyzers = self.get_analysis_passes()
         executable = []
 
-        for analyzer_name in declared_analyzers:
+        for info in self._analysis_registry.list_analyzer_infos():
             # Check 1: Is it enabled by user?
             if (
                 enabled_normalized is not None
-                and analyzer_name.lower() not in enabled_normalized
+                and info.name.lower() not in enabled_normalized
             ):
                 continue
 
             # Check 2: Are required stages available?
-            info = self._analysis_registry.get_analyzer_info(analyzer_name)
-            if not info:
-                continue
-
             stages_available = True
             for stage_name in info.required_stages:
                 stage = self.get_stage_by_name(stage_name)
@@ -378,13 +380,13 @@ class CompilationPipelineAdapter(ABC):
                     break
 
             if stages_available:
-                executable.append(analyzer_name)
+                executable.append(info.name)
 
         return executable
 
     def run_analysis_pass(
         self,
-        pass_name: str,
+        analyzer_id: str,
         entry: dict,
         ctx: AnalyzerContext | None = None,
     ) -> dict[str, Any] | None:
@@ -392,7 +394,7 @@ class CompilationPipelineAdapter(ABC):
         Execute the specified analysis pass.
 
         Args:
-            pass_name: Analysis name (e.g., "amd_buffer_ops", "loop_schedules")
+            analyzer_id: Analysis name (e.g., "amd_buffer_ops", "loop_schedules")
             entry: Trace entry (contains payload)
             ctx: Per-call analyzer context; defaults to empty AnalyzerContext()
 
@@ -400,18 +402,18 @@ class CompilationPipelineAdapter(ABC):
             Analysis result dictionary, or None if analysis cannot be performed
 
         Raises:
-            ValueError: If the pass_name is not found in the registry
+            ValueError: If the analyzer_id is not found in the registry
         """
         if ctx is None:
             ctx = AnalyzerContext()
-        analyzer = self._analysis_registry.get_analyzer(pass_name)
-        if analyzer is None:
+        info = self._analysis_registry.get_analyzer_info(analyzer_id)
+        if info is None:
             available = self._analysis_registry.list_analyzers()
             raise ValueError(
-                f"Analyzer '{pass_name}' not found. Available analyzers: {available}"
+                f"Analyzer '{analyzer_id}' not found. Available analyzers: {available}"
             )
 
-        return analyzer(entry, ctx)
+        return info.func(entry, ctx)
 
     def register_backend_analyzer(
         self,

--- a/tritonparse/backend.py
+++ b/tritonparse/backend.py
@@ -92,14 +92,16 @@ class DerivedArtifactRegistry:
         )
         logger.debug(f"Registered derived artifact: {target_stage_name}")
 
-    def get_by_target(self, target_stage_name: str) -> DerivedArtifactInfo | None:
+    def get_derived_artifact_info(
+        self, target_stage_name: str
+    ) -> DerivedArtifactInfo | None:
         return self._registry.get(target_stage_name)
 
-    def list_all(self) -> list[DerivedArtifactInfo]:
-        return list(self._registry.values())
-
-    def list_target_stage_names(self) -> list[str]:
+    def list_derived_artifact_keys(self) -> list[str]:
         return list(self._registry.keys())
+
+    def list_derived_artifact_infos(self) -> list[DerivedArtifactInfo]:
+        return list(self._registry.values())
 
 
 class ParserRegistry:
@@ -126,7 +128,7 @@ class ParserRegistry:
         """Get a parser function by parser_id."""
         return self._parsers.get(parser_id)
 
-    def list_parsers(self) -> list[str]:
+    def list_parser_keys(self) -> list[str]:
         """List all registered parser IDs."""
         return list(self._parsers.keys())
 
@@ -181,7 +183,7 @@ class AnalysisRegistry:
         """Get analyzer info by name."""
         return self._analyzer_infos.get(analyzer_id)
 
-    def list_analyzers(self) -> list[str]:
+    def list_analyzer_keys(self) -> list[str]:
         """List all registered analyzer IDs."""
         return list(self._analyzer_infos.keys())
 
@@ -217,8 +219,8 @@ class CompilationPipelineAdapter(ABC):
         # Register common parsers (shared across all backends)
         from tritonparse.parse.ir_parser import _parse_generic_loc, _parse_none
 
-        self._parser_registry.register("generic_loc", _parse_generic_loc)
-        self._parser_registry.register("none", _parse_none)
+        self.register_backend_parser("generic_loc", _parse_generic_loc)
+        self.register_backend_parser("none", _parse_none)
 
         # Register common analyzers (shared across all backends)
         from tritonparse.parse.ir_analysis import (
@@ -226,27 +228,27 @@ class CompilationPipelineAdapter(ABC):
             _analyze_procedures_generic,
         )
 
-        self._analysis_registry.register(
+        self.register_backend_analyzer(
             "loop_schedules",
             _analyze_loop_schedules_generic,
             required_stages=("ttir", "ttgir"),
         )
-        self._analysis_registry.register(
+        self.register_backend_analyzer(
             "procedure_checks",
             _analyze_procedures_generic,
             required_stages=("ttgir",),
         )
 
-    def get_ir_stages(self) -> list[IRStageDescriptor]:
-        return self._stages
+    def list_ir_stages(self) -> list[IRStageDescriptor]:
+        return list(self._stages)
 
     def get_stage_by_name(self, stage_name: str) -> IRStageDescriptor | None:
-        for stage in self.get_ir_stages():
+        for stage in self.list_ir_stages():
             if stage.name == stage_name:
                 return stage
         return None
 
-    def get_applicable_derived_artifacts(
+    def list_applicable_derived_artifacts(
         self,
         enabled_derived_artifacts: set[str] | None = None,
     ) -> list[DerivedArtifactInfo]:
@@ -261,7 +263,7 @@ class CompilationPipelineAdapter(ABC):
         Returns:
             List of applicable DerivedArtifactInfo
         """
-        all_artifacts = self._derived_artifact_registry.list_all()
+        all_artifacts = self._derived_artifact_registry.list_derived_artifact_infos()
 
         if enabled_derived_artifacts is not None:
             enabled_normalized = {n.lower() for n in enabled_derived_artifacts}
@@ -282,8 +284,8 @@ class CompilationPipelineAdapter(ABC):
 
     def register_backend_derived_artifact(
         self,
-        source_stage_name: str,
         target_stage_name: str,
+        source_stage_name: str,
         tool_name: str,
         derive_func: Callable[[str], str | None],
     ) -> None:
@@ -295,31 +297,20 @@ class CompilationPipelineAdapter(ABC):
             derive_func=derive_func,
         )
 
-    def list_parsers(self) -> list[str]:
+    def list_parser_keys(self) -> list[str]:
         """List all registered parser IDs (common + backend-specific)."""
-        return self._parser_registry.list_parsers()
+        return self._parser_registry.list_parser_keys()
 
-    def get_analysis_passes(self) -> list[str]:
+    def list_analyzer_keys(self) -> list[str]:
         """
         Return list of analysis pass names for this adapter.
 
         All analyzers in the adapter's instance registry are included
         (common + backend-specific).
         """
-        return self._analysis_registry.list_analyzers()
+        return self._analysis_registry.list_analyzer_keys()
 
-    def get_analyzer(self, analyzer_id: str) -> Callable | None:
-        """Get analyzer function by analyzer_id from the adapter's registry."""
-        return self._analysis_registry.get_analyzer(analyzer_id)
-
-    def get_analyzer_required_stages(
-        self, analyzer_id: str
-    ) -> tuple[str, ...] | None:
-        """Return required stages for the given analyzer, or None if not registered."""
-        info = self._analysis_registry.get_analyzer_info(analyzer_id)
-        return info.required_stages if info else None
-
-    def get_executable_analyzers(
+    def list_executable_analyzers(
         self,
         file_content: dict[str, str],
         enabled_analyses: set[str] | None = None,
@@ -408,7 +399,7 @@ class CompilationPipelineAdapter(ABC):
             ctx = AnalyzerContext()
         info = self._analysis_registry.get_analyzer_info(analyzer_id)
         if info is None:
-            available = self._analysis_registry.list_analyzers()
+            available = self._analysis_registry.list_analyzer_keys()
             raise ValueError(
                 f"Analyzer '{analyzer_id}' not found. Available analyzers: {available}"
             )
@@ -432,10 +423,6 @@ class CompilationPipelineAdapter(ABC):
         """
         self._analysis_registry.register(analyzer_id, analyzer_func, required_stages)
 
-    def get_canonical_device_string(self) -> str:
-        """Return the adapter's canonical accelerator device string."""
-        return normalize_accelerator_device_string(self.pytorch_module)
-
     def get_parser(self, parser_id: str):
         """
         Get parser function by parser_id from the adapter's parser registry.
@@ -451,7 +438,7 @@ class CompilationPipelineAdapter(ABC):
         """
         parser = self._parser_registry.get_parser(parser_id)
         if parser is None:
-            available_parsers = self._parser_registry.list_parsers()
+            available_parsers = self._parser_registry.list_parser_keys()
             raise ValueError(
                 f"Parser '{parser_id}' not found. "
                 f"Available parsers: {available_parsers}"
@@ -468,6 +455,10 @@ class CompilationPipelineAdapter(ABC):
         """
         self._parser_registry.register(parser_id, parser_func)
 
+    def list_derived_artifact_keys(self) -> list[str]:
+        """List all registered derived artifact target stage names."""
+        return self._derived_artifact_registry.list_derived_artifact_keys()
+
 
 class NvidiaTritonAdapter(CompilationPipelineAdapter):
     adapter_name: str = "cuda_triton"
@@ -480,19 +471,17 @@ class NvidiaTritonAdapter(CompilationPipelineAdapter):
         # Register NVIDIA-specific parsers
         from tritonparse.parse.ir_parser import _parse_ptx_loc, _parse_sass_loc
 
-        self._parser_registry.register("ptx_loc", _parse_ptx_loc)
-        self._parser_registry.register("sass_loc", _parse_sass_loc)
+        self.register_backend_parser("ptx_loc", _parse_ptx_loc)
+        self.register_backend_parser("sass_loc", _parse_sass_loc)
 
         # Register NVIDIA-specific derived artifacts
         from tritonparse.tools.disasm import extract as derive_sass
 
-        self._derived_artifact_registry.register(
-            DerivedArtifactInfo(
-                source_stage_name="cubin",
-                target_stage_name="sass",
-                tool_name="nvdisasm",
-                derive_func=derive_sass,
-            )
+        self.register_backend_derived_artifact(
+            target_stage_name="sass",
+            source_stage_name="cubin",
+            tool_name="nvdisasm",
+            derive_func=derive_sass,
         )
 
         # Pre-initialize stage descriptors (immutable objects, can be reused)
@@ -530,12 +519,12 @@ class AmdTritonAdapter(CompilationPipelineAdapter):
         # Register AMD-specific parsers
         from tritonparse.parse.ir_parser import _parse_amdgcn_loc
 
-        self._parser_registry.register("amdgcn_loc", _parse_amdgcn_loc)
+        self.register_backend_parser("amdgcn_loc", _parse_amdgcn_loc)
 
         # Register AMD-specific analyzers
         from tritonparse.parse.ir_analysis import _analyze_amd_buffer_ops
 
-        self._analysis_registry.register(
+        self.register_backend_analyzer(
             "amd_buffer_ops",
             _analyze_amd_buffer_ops,
             required_stages=("ttgir", "amdgcn"),

--- a/tritonparse/backend.py
+++ b/tritonparse/backend.py
@@ -25,7 +25,7 @@ def normalize_accelerator_device_string(device: str) -> str:
 class IRStageDescriptor:
     """Describes an IR stage in the compilation pipeline.
 
-    Fields:
+    Attributes:
         name: Internal stage identifier (e.g., "ttir", "ptx").
         extension: File extension for artifacts (e.g., ".ttir", ".ptx").
         display_name: Human-readable name for UI display.
@@ -50,16 +50,16 @@ class IRStageDescriptor:
 class DerivedArtifactInfo:
     """Describes an artifact derived by running tools on another stage's output.
 
-    Fields:
-        source_stage_name: Name of the source stage (e.g., "cubin").
+    Attributes:
         target_stage_name: Name of the target stage (e.g., "sass").
+        source_stage_name: Name of the source stage (e.g., "cubin").
         tool_name: Name of the tool used to generate the artifact (e.g., "nvdisasm").
         derive_func: Callable that takes a source file path and returns derived content,
             or None if the tool is unavailable or derivation fails.
     """
 
-    source_stage_name: str
     target_stage_name: str
+    source_stage_name: str
     tool_name: str
     derive_func: Callable[[str], str | None]
 
@@ -85,8 +85,8 @@ class DerivedArtifactRegistry:
                 f"Overwriting existing derived artifact registration for '{target_stage_name}'."
             )
         self._registry[target_stage_name] = DerivedArtifactInfo(
-            source_stage_name=source_stage_name,
             target_stage_name=target_stage_name,
+            source_stage_name=source_stage_name,
             tool_name=tool_name,
             derive_func=derive_func,
         )
@@ -125,11 +125,9 @@ class ParserRegistry:
         logger.debug(f"Registered parser: {parser_id}")
 
     def get_parser(self, parser_id: str) -> Callable | None:
-        """Get a parser function by parser_id."""
         return self._parsers.get(parser_id)
 
     def list_parser_keys(self) -> list[str]:
-        """List all registered parser IDs."""
         return list(self._parsers.keys())
 
 
@@ -167,7 +165,6 @@ class AnalysisRegistry:
         analyzer_func: Callable,
         required_stages: tuple[str, ...],
     ) -> None:
-        """Register an analyzer with its metadata."""
         if analyzer_id in self._analyzer_infos:
             logger.warning(
                 f"Analyzer '{analyzer_id}' is already registered. Overwriting."
@@ -180,15 +177,12 @@ class AnalysisRegistry:
         self._analyzer_infos[analyzer_id] = info
 
     def get_analyzer_info(self, analyzer_id: str) -> AnalyzerInfo | None:
-        """Get analyzer info by name."""
         return self._analyzer_infos.get(analyzer_id)
 
     def list_analyzer_keys(self) -> list[str]:
-        """List all registered analyzer IDs."""
         return list(self._analyzer_infos.keys())
 
     def list_analyzer_infos(self) -> list[AnalyzerInfo]:
-        """List all registered analyzer info objects."""
         return list(self._analyzer_infos.values())
 
 
@@ -239,6 +233,8 @@ class CompilationPipelineAdapter(ABC):
             required_stages=("ttgir",),
         )
 
+    # -- Stage methods --------------------------------------------------------
+
     def list_ir_stages(self) -> list[IRStageDescriptor]:
         return list(self._stages)
 
@@ -248,67 +244,68 @@ class CompilationPipelineAdapter(ABC):
                 return stage
         return None
 
-    def list_applicable_derived_artifacts(
-        self,
-        enabled_derived_artifacts: set[str] | None = None,
-    ) -> list[DerivedArtifactInfo]:
-        """
-        Get derived artifacts applicable to this adapter, filtered by user-enabled list.
+    # -- Parser methods -------------------------------------------------------
 
-        Validates user-provided names and warns about unknowns.
+    def get_parser(self, parser_id: str) -> Callable:
+        """
+        Get parser function by parser_id from the adapter's parser registry.
 
         Args:
-            enabled_derived_artifacts: User-enabled target stage names (None = all)
+            parser_id: The parser identifier (e.g., "generic_loc", "ptx_loc")
 
         Returns:
-            List of applicable DerivedArtifactInfo
+            The parser function for the given parser_id
+
+        Raises:
+            ValueError: If the parser_id is not found in the registry
         """
-        all_artifacts = self._derived_artifact_registry.list_derived_artifact_infos()
+        parser = self._parser_registry.get_parser(parser_id)
+        if parser is None:
+            available_parsers = self._parser_registry.list_parser_keys()
+            raise ValueError(
+                f"Parser '{parser_id}' not found. "
+                f"Available parsers: {available_parsers}"
+            )
+        return parser
 
-        if enabled_derived_artifacts is not None:
-            enabled_normalized = {n.lower() for n in enabled_derived_artifacts}
-            known = {info.target_stage_name.lower() for info in all_artifacts}
-            unknown = enabled_normalized - known
-            if unknown:
-                logger.warning(
-                    f"TRITONPARSE_DERIVED_ARTIFACTS contains unknown target stage names: {unknown}. "
-                    f"Available for {self.adapter_name}: {sorted(known)}"
-                )
-            return [
-                info
-                for info in all_artifacts
-                if info.target_stage_name.lower() in enabled_normalized
-            ]
-
-        return all_artifacts
-
-    def register_backend_derived_artifact(
-        self,
-        target_stage_name: str,
-        source_stage_name: str,
-        tool_name: str,
-        derive_func: Callable[[str], str | None],
-    ) -> None:
-        """Register a backend-specific derived artifact to the adapter's registry."""
-        self._derived_artifact_registry.register(
-            target_stage_name=target_stage_name,
-            source_stage_name=source_stage_name,
-            tool_name=tool_name,
-            derive_func=derive_func,
-        )
+    def register_backend_parser(self, parser_id: str, parser_func: Callable) -> None:
+        self._parser_registry.register(parser_id, parser_func)
 
     def list_parser_keys(self) -> list[str]:
-        """List all registered parser IDs (common + backend-specific)."""
         return self._parser_registry.list_parser_keys()
 
-    def list_analyzer_keys(self) -> list[str]:
-        """
-        Return list of analysis pass names for this adapter.
+    # -- Analyzer methods -----------------------------------------------------
 
-        All analyzers in the adapter's instance registry are included
-        (common + backend-specific).
+    def run_analysis_pass(
+        self,
+        analyzer_id: str,
+        entry: dict,
+        ctx: AnalyzerContext | None = None,
+    ) -> dict[str, Any] | None:
         """
-        return self._analysis_registry.list_analyzer_keys()
+        Execute the specified analysis pass.
+
+        Args:
+            analyzer_id: Analysis name (e.g., "amd_buffer_ops", "loop_schedules")
+            entry: Trace entry (contains payload)
+            ctx: Per-call analyzer context; defaults to empty AnalyzerContext()
+
+        Returns:
+            Analysis result dictionary, or None if analysis cannot be performed
+
+        Raises:
+            ValueError: If the analyzer_id is not found in the registry
+        """
+        if ctx is None:
+            ctx = AnalyzerContext()
+        info = self._analysis_registry.get_analyzer_info(analyzer_id)
+        if info is None:
+            available = self._analysis_registry.list_analyzer_keys()
+            raise ValueError(
+                f"Analyzer '{analyzer_id}' not found. Available analyzers: {available}"
+            )
+
+        return info.func(entry, ctx)
 
     def list_executable_analyzers(
         self,
@@ -375,92 +372,71 @@ class CompilationPipelineAdapter(ABC):
 
         return executable
 
-    def run_analysis_pass(
-        self,
-        analyzer_id: str,
-        entry: dict,
-        ctx: AnalyzerContext | None = None,
-    ) -> dict[str, Any] | None:
-        """
-        Execute the specified analysis pass.
-
-        Args:
-            analyzer_id: Analysis name (e.g., "amd_buffer_ops", "loop_schedules")
-            entry: Trace entry (contains payload)
-            ctx: Per-call analyzer context; defaults to empty AnalyzerContext()
-
-        Returns:
-            Analysis result dictionary, or None if analysis cannot be performed
-
-        Raises:
-            ValueError: If the analyzer_id is not found in the registry
-        """
-        if ctx is None:
-            ctx = AnalyzerContext()
-        info = self._analysis_registry.get_analyzer_info(analyzer_id)
-        if info is None:
-            available = self._analysis_registry.list_analyzer_keys()
-            raise ValueError(
-                f"Analyzer '{analyzer_id}' not found. Available analyzers: {available}"
-            )
-
-        return info.func(entry, ctx)
-
     def register_backend_analyzer(
         self,
         analyzer_id: str,
-        analyzer_func,
+        analyzer_func: Callable,
         required_stages: tuple[str, ...],
     ) -> None:
-        """
-        Register a backend-specific analyzer to the adapter's registry.
-
-        Args:
-            analyzer_id: The analyzer identifier (e.g., "amd_buffer_ops")
-            analyzer_func: The analyzer function with signature
-                          (entry, ctx) -> dict | None
-            required_stages: Required stage names (e.g., ("ttgir", "amdgcn"))
-        """
         self._analysis_registry.register(analyzer_id, analyzer_func, required_stages)
 
-    def get_parser(self, parser_id: str):
+    def list_analyzer_keys(self) -> list[str]:
+        return self._analysis_registry.list_analyzer_keys()
+
+    # -- Derived artifact methods ---------------------------------------------
+
+    def list_applicable_derived_artifacts(
+        self,
+        enabled_derived_artifacts: set[str] | None = None,
+    ) -> list[DerivedArtifactInfo]:
         """
-        Get parser function by parser_id from the adapter's parser registry.
+        Get derived artifacts applicable to this adapter, filtered by user-enabled list.
+
+        Validates user-provided names and warns about unknowns.
 
         Args:
-            parser_id: The parser identifier (e.g., "generic_loc", "ptx_loc")
+            enabled_derived_artifacts: User-enabled target stage names (None = all)
 
         Returns:
-            The parser function for the given parser_id
-
-        Raises:
-            ValueError: If the parser_id is not found in the registry
+            List of applicable DerivedArtifactInfo
         """
-        parser = self._parser_registry.get_parser(parser_id)
-        if parser is None:
-            available_parsers = self._parser_registry.list_parser_keys()
-            raise ValueError(
-                f"Parser '{parser_id}' not found. "
-                f"Available parsers: {available_parsers}"
-            )
-        return parser
+        all_artifacts = self._derived_artifact_registry.list_derived_artifact_infos()
 
-    def register_backend_parser(self, parser_id: str, parser_func) -> None:
-        """
-        Register a backend-specific parser to the adapter's parser registry.
+        if enabled_derived_artifacts is not None:
+            enabled_normalized = {n.lower() for n in enabled_derived_artifacts}
+            known = {info.target_stage_name.lower() for info in all_artifacts}
+            unknown = enabled_normalized - known
+            if unknown:
+                logger.warning(
+                    f"TRITONPARSE_DERIVED_ARTIFACTS contains unknown target stage names: {unknown}. "
+                    f"Available for {self.adapter_name}: {sorted(known)}"
+                )
+            return [
+                info
+                for info in all_artifacts
+                if info.target_stage_name.lower() in enabled_normalized
+            ]
 
-        Args:
-            parser_id: The parser identifier (e.g., "ascend_ir")
-            parser_func: The parser function
-        """
-        self._parser_registry.register(parser_id, parser_func)
+        return all_artifacts
+
+    def register_backend_derived_artifact(
+        self,
+        target_stage_name: str,
+        source_stage_name: str,
+        tool_name: str,
+        derive_func: Callable[[str], str | None],
+    ) -> None:
+        self._derived_artifact_registry.register(
+            target_stage_name, source_stage_name, tool_name, derive_func
+        )
 
     def list_derived_artifact_keys(self) -> list[str]:
-        """List all registered derived artifact target stage names."""
         return self._derived_artifact_registry.list_derived_artifact_keys()
 
 
 class NvidiaTritonAdapter(CompilationPipelineAdapter):
+    """Compilation pipeline adapter for NVIDIA CUDA backends."""
+
     adapter_name: str = "cuda_triton"
     runtime_backend: str = "cuda"
     pytorch_module: str = "cuda"
@@ -509,6 +485,8 @@ class NvidiaTritonAdapter(CompilationPipelineAdapter):
 
 
 class AmdTritonAdapter(CompilationPipelineAdapter):
+    """Compilation pipeline adapter for AMD HIP backends."""
+
     adapter_name: str = "hip_triton"
     runtime_backend: str = "hip"
     pytorch_module: str = "cuda"
@@ -578,6 +556,17 @@ class PipelineAdapterRegistry:
         *,
         adapter_name: str,
     ) -> CompilationPipelineAdapter:
+        """Resolve an adapter by name, lazily instantiating if needed.
+
+        Args:
+            adapter_name: Adapter name (e.g., "cuda_triton", "hip_triton").
+
+        Returns:
+            The resolved CompilationPipelineAdapter instance.
+
+        Raises:
+            ValueError: If no adapter is registered with the given name.
+        """
         self._ensure_initialized(adapter_name)
         adapter = self._adapter_instances.get(adapter_name.lower())
         if adapter is None:
@@ -592,6 +581,17 @@ class PipelineAdapterRegistry:
         self,
         backend_name: str,
     ) -> CompilationPipelineAdapter:
+        """Resolve an adapter from a backend name (e.g., "cuda" → "cuda_triton").
+
+        Args:
+            backend_name: Backend name (e.g., "cuda", "hip").
+
+        Returns:
+            The resolved CompilationPipelineAdapter instance.
+
+        Raises:
+            ValueError: If no adapter matches the inferred name.
+        """
         inferred_adapter_name = f"{backend_name}_triton"
         return self.resolve(adapter_name=inferred_adapter_name)
 
@@ -599,6 +599,17 @@ class PipelineAdapterRegistry:
         self,
         metadata: dict[str, Any],
     ) -> CompilationPipelineAdapter:
+        """Resolve an adapter from trace metadata containing backend_name.
+
+        Args:
+            metadata: Trace metadata dictionary with a "backend_name" key.
+
+        Returns:
+            The resolved CompilationPipelineAdapter instance.
+
+        Raises:
+            ValueError: If backend_name is missing or no matching adapter exists.
+        """
         backend_name = metadata.get("backend_name")
         if isinstance(backend_name, str):
             return self.resolve_from_backend_name(backend_name)

--- a/tritonparse/parse/ir_analysis.py
+++ b/tritonparse/parse/ir_analysis.py
@@ -1029,7 +1029,7 @@ def _generate_ir_analysis_adapter_driven(
     adapter = get_backend_registry().resolve_from_trace(metadata)
 
     # Get executable analyzers (adapter handles all the logic)
-    executable_analyzers = adapter.get_executable_analyzers(
+    executable_analyzers = adapter.list_executable_analyzers(
         file_content, enabled_analyses
     )
 

--- a/tritonparse/parse/trace_processor.py
+++ b/tritonparse/parse/trace_processor.py
@@ -295,7 +295,7 @@ def _resolve_source_mappable_stage_keys(
         from tritonparse.backend import get_backend_registry
 
         adapter = get_backend_registry().resolve_from_trace(metadata)
-        for stage in adapter.get_ir_stages():
+        for stage in adapter.list_ir_stages():
             if not stage.supports_source_mapping:
                 continue
             artifact_name = next(
@@ -525,7 +525,7 @@ def parse_single_trace_content(trace_content: str) -> str:
                     "supports_source_mapping": stage.supports_source_mapping,
                     "syntax_id": stage.syntax_id,
                 }
-                for stage in adapter.get_ir_stages()
+                for stage in adapter.list_ir_stages()
             ]
         except ValueError:
             logger.warning("Could not resolve adapter for ir_stages; skipping")

--- a/tritonparse/shared_vars.py
+++ b/tritonparse/shared_vars.py
@@ -73,7 +73,7 @@ def get_enabled_analyses() -> set[str] | None:
         )
         return set()
 
-    # Validation happens at adapter level (get_executable_analyzers)
+    # Validation happens at adapter level (list_executable_analyzers)
     # where the adapter's instance registry is available.
     return set(raw_names)
 

--- a/tritonparse/structured_logging.py
+++ b/tritonparse/structured_logging.py
@@ -954,7 +954,7 @@ def _extract_file_content_adapter_driven(
 
     # Text-file detection via adapter stages
     text_extensions = {
-        stage.extension for stage in adapter.get_ir_stages() if stage.is_text
+        stage.extension for stage in adapter.list_ir_stages() if stage.is_text
     }
 
     for ir_filename, file_path in metadata_group.items():
@@ -977,7 +977,7 @@ def _extract_file_content_adapter_driven(
 
     # Derived artifacts
     enabled = get_enabled_derived_artifacts()
-    for info in adapter.get_applicable_derived_artifacts(enabled):
+    for info in adapter.list_applicable_derived_artifacts(enabled):
         source_stage = adapter.get_stage_by_name(info.source_stage_name)
         if not source_stage:
             log.warning(


### PR DESCRIPTION
## Summary

This PR cleans up internal consistency in the backend adapter layer across three focused commits:

1. simplify registry implementations and analyzer internals
2. clarify adapter listing APIs and update call sites
3. unify docstrings, type hints, and method ordering

The intent is refactoring and API cleanup rather than changing parsing or analysis behavior.

---

## Changes

### 1. Simplify registries and analyzer internals

- align DerivedArtifactRegistry registration with the other registry types
- simplify analyzer execution around AnalyzerInfo as the canonical internal representation
- normalize analyzer-related naming around analyzer_id
- make overwrite logging behavior consistent across registries

Scope:
backend.py only

### 2. Clarify adapter listing APIs and update call sites

- rename collection-returning adapter methods to consistent list_ names
- add explicit key-listing helpers for parsers, analyzers, and derived artifacts
- update adapter subclasses to register through the public backend registration methods
- update all affected callers and tests to the new API names
- remove redundant test-only / superseded public helpers

Scope:
backend.py, structured_logging.py, parse/ir_analysis.py, parse/trace_processor.py, shared_vars.py, tests/cpu/test_multi_backend_stage.py

### 3. Unify docstrings, type hints, and method ordering

- normalize backend dataclass docstring style
- complete missing adapter-layer callable annotations
- remove low-value proxy docstrings and add documentation where public behavior benefits from it
- regroup CompilationPipelineAdapter methods by responsibility

Scope:
backend.py only

---

## Testing

- `make format-check`
<img width="925" height="286" alt="image" src="https://github.com/user-attachments/assets/670852b6-d932-4d08-bb19-d7d1ce1fefd0" />


- `make test-cuda`
<img width="1260" height="517" alt="image" src="https://github.com/user-attachments/assets/44ac8ff9-2a66-4c10-b425-e787aa4a480e" />


- `make test`
<img width="1275" height="510" alt="image" src="https://github.com/user-attachments/assets/7f430838-197b-4c63-a3dc-551711945b44" />

