### PR TITLE
Stabilize OSS Python lint checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,10 @@ jobs:
               run: |
                   make format-check || (echo "❌ Format check failed. Please run 'make format' to fix formatting issues, then commit the changes." && echo "📖 For detailed formatting guide, see: https://github.com/meta-pytorch/tritonparse/wiki/05.-Code-Formatting" && exit 1)
 
+            - name: Check Python lint
+              run: |
+                  make lint-check || (echo "❌ Lint check failed. Please run 'make lint' to fix lint issues, then commit the changes." && exit 1)
+
     # ===================================================================
     # GPU tests on PyTorch self-hosted runner: AWS g5.4xlarge / NVIDIA
     # A10G, ephemeral EC2 (1 job per VM, no cross-PR pollution).

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
 # Makefile for tritonparse project
 
-.PHONY: help format format-check test test-cuda clean install-dev website-install website-lint website-build website-build-single website-dev
+.PHONY: help format format-check lint lint-check test test-cuda clean install-dev website-install website-lint website-build website-build-single website-dev
 
 # Default target
 help:
 	@echo "Available targets:"
 	@echo "  format           - Format all Python files"
 	@echo "  format-check     - Check formatting without making changes"
+	@echo "  lint             - Fix Python lint issues"
+	@echo "  lint-check       - Check Python lint issues without making changes"
 	@echo "  test             - Run tests (CPU only)"
 	@echo "  test-cuda        - Run tests (including CUDA tests)"
 	@echo "  clean            - Clean up cache files"
@@ -22,11 +24,19 @@ help:
 # Formatting targets
 format:
 	@echo "Running format fix script..."
-	python -m tritonparse.tools.format_fix --verbose
+	python -m tritonparse.tools.format_fix --format-only --verbose
 
 format-check:
 	@echo "Checking formatting..."
-	python -m tritonparse.tools.format_fix --check-only --verbose
+	python -m tritonparse.tools.format_fix --format-only --check-only --verbose
+
+lint:
+	@echo "Fixing lint issues..."
+	python -m tritonparse.tools.format_fix --lint-only --verbose
+
+lint-check:
+	@echo "Checking lint issues..."
+	python -m tritonparse.tools.format_fix --lint-only --check-only --verbose
 
 # Testing targets
 test:

--- a/docs/05.-Code-Formatting.md
+++ b/docs/05.-Code-Formatting.md
@@ -6,28 +6,29 @@ This guide covers the comprehensive code formatting and linting setup for Triton
 
 | Tool | Purpose | Version | Configuration |
 |------|---------|---------|---------------|
-| **Black** | Code formatting | 24.4.2+ | `pyproject.toml` |
-| **usort** | Import sorting | 1.0.8+ | `pyproject.toml` |
-| **Ruff** | Linting & style checks | 0.1.0+ | Built-in rules |
+| **ufmt** | Unified formatting driver | 2.9.0 | `pyproject.toml` |
+| **ruff-api** | Code formatting | 0.2.0 | `pyproject.toml` |
+| **usort** | Import sorting | 1.1.0 | `pyproject.toml` |
+| **Ruff** | Linting and safe fixes | 0.16.0 | `pyproject.toml` |
 
 ### Tool Execution Order
 
 ```mermaid
 graph LR
-    A[Source Code] --> B[usort]
-    B --> C[ruff check]
-    C --> D[black]
-    D --> E[Formatted Code]
+    A[Source Code] --> B[ufmt]
+    B --> C[usort]
+    C --> D[ruff-api formatter]
+    D --> E[ruff check]
+    E --> F[Formatted and linted code]
 
-    B -.->|Import sorting| B1[Alphabetical imports]
-    C -.->|Linting| C1[Style violations]
+    C -.->|Import sorting| C1[Alphabetical imports]
     D -.->|Formatting| D1[Code structure]
+    E -.->|Linting| E1[Style violations]
 ```
 
 **Why this order?**
-1. **usort** - Sorts imports first (affects line numbers)
-2. **ruff** - Lints and auto-fixes issues
-3. **black** - Final formatting pass
+1. **ufmt** - Runs usort, then the ruff-api formatter
+2. **ruff** - Checks lint rules separately and applies safe fixes when requested
 
 ## 📦 Installation
 
@@ -41,11 +42,8 @@ make install-dev
 ### Manual Installation
 
 ```bash
-# Install tritonparse in development mode
-pip install -e ".[test]"
-
-# Install formatting tools
-pip install black usort ruff
+# Install tritonparse and its pinned development tools
+pip install -e ".[dev]"
 ```
 
 ## 🚀 Usage Commands
@@ -56,11 +54,14 @@ pip install black usort ruff
 # Fix all formatting issues
 make format
 
-# Check if code is properly formatted (CI-compatible)
-make lint-check
+# Fix safe lint issues
+make lint
 
 # Check formatting without fixing
 make format-check
+
+# Check all configured lint rules without fixing
+make lint-check
 ```
 
 ## ⚙️ Configuration
@@ -69,18 +70,25 @@ make format-check
 
 | Tool | Key Settings | Purpose |
 |------|--------------|----------|
-| **Black** | Line length: 88, Target: Python 3.10+ | PEP 8 compliant formatting |
+| **ruff-api** | Line length: 88 | PEP 8 compliant formatting |
 | **usort** | First-party detection: off | Alphabetical import sorting |
-| **Ruff** | Built-in rules, auto-fix enabled | Fast linting |
+| **Ruff** | Explicit `E4`, `E7`, `E9`, and `F` rules | Stable, fast linting |
 
 <details>
 <summary>📄 Full Configuration Files</summary>
 
 **pyproject.toml**:
 ```toml
-[tool.black]
+[tool.ufmt]
+formatter = "ruff-api"
+sorter = "usort"
+
+[tool.ruff]
 line-length = 88
-target-version = ["py310"]
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
 
 [tool.usort]
 first_party_detection = false
@@ -88,28 +96,19 @@ first_party_detection = false
 
 **Makefile**:
 ```makefile
-# Development dependencies
-install-dev:
-    pip install -U black usort ruff coverage
-
 # Formatting commands
 format:
-    python -m tritonparse.tools.format_fix --verbose
+    python -m tritonparse.tools.format_fix --format-only --verbose
 
 format-check:
-    python -m tritonparse.tools.format_fix --check-only --verbose
+    python -m tritonparse.tools.format_fix --format-only --check-only --verbose
 
 # Linting commands
+lint:
+    python -m tritonparse.tools.format_fix --lint-only --verbose
+
 lint-check:
-    ruff check --diff .
-    black --check --diff .
-
-# Testing commands
-test:
-    python -m unittest discover -s tests/cpu -t . -v
-
-test-cuda:
-    python -m unittest discover -s tests -t . -v
+    python -m tritonparse.tools.format_fix --lint-only --check-only --verbose
 ```
 </details>
 
@@ -123,7 +122,8 @@ test-cuda:
 # 2. Run formatting
 make format
 
-# 3. Verify everything is clean
+# 3. Verify formatting and lint are clean
+make format-check
 make lint-check
 
 # 4. Commit your changes
@@ -135,20 +135,21 @@ git commit -m "Your changes"
 
 **Format check fails?**
 ```bash
-make format          # Fix issues automatically
-make lint-check      # Verify fixes
+make format          # Fix formatting automatically
+make format-check    # Verify formatting
+make lint            # Fix safe lint issues automatically
+make lint-check      # Verify lint
 ```
 
 **Need to check specific changes?**
 ```bash
-ruff check --diff .
-black --check --diff .
+ufmt check path/to/file.py
+ruff check path/to/file.py
 ```
 
 **Fix individual files:**
 ```bash
-black path/to/file.py
-usort format path/to/file.py
+ufmt format path/to/file.py
 ruff check path/to/file.py --fix
 ```
 
@@ -158,7 +159,7 @@ rm -rf .ruff_cache __pycache__
 make format
 ```
 
-> 💡 **Tip**: Always run `make format` before committing. CI will check formatting automatically.
+> 💡 **Tip**: Run `make format`, `make lint`, `make format-check`, and `make lint-check` before committing.
 
 ## 🤖 CI Integration
 
@@ -175,11 +176,11 @@ The CI pipeline includes a `format-check` job that:
 format-check:
   runs-on: ubuntu-latest
   steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v4
+    - uses: actions/checkout@v6
+    - name: Set up Python 3.14
+      uses: actions/setup-python@v6
       with:
-        python-version: "3.11"
+        python-version: "3.14"
     - name: Install development dependencies
       run: make install-dev
     - name: Check code formatting
@@ -196,7 +197,7 @@ format-check:
 
 ## 🔍 Tool Details
 
-**Black** - Formats code structure, spacing, string quotes (double preferred), line breaks, indentation, and trailing commas. Uses 88-character line length (PEP 8 compliant).
+**ufmt and ruff-api** - Run import sorting and deterministic code formatting as one atomic operation. The ruff-api formatter uses an 88-character line length.
 
 **usort** - Sorts imports alphabetically within categories: standard library, third-party packages, and local modules. Groups imports with blank lines between categories.
 
@@ -213,7 +214,7 @@ from pathlib import Path
 def my_function(x,y,z):
     return x+y+z
 
-# After: usort → ruff → black
+# After: ufmt (usort → ruff-api formatter)
 import os
 from pathlib import Path
 
@@ -230,7 +231,7 @@ def my_function(x, y, z):
 | Issue | Error Message | Quick Fix |
 |-------|---------------|----------|
 | **Import Order** | `E402: Module level import not at top of file` | Move all imports to file top, before code |
-| **Black vs Ruff** | Conflicting format suggestions | Run `make format` (Black takes precedence) |
+| **Formatting vs linting** | Different checks report different issues | Run `make format`, then `make lint` |
 | **Import Sorting** | usort breaks functionality | Use `# usort: skip` comment for file/import |
 | **Line Length** | Line exceeds 88 characters | Use parentheses for multi-line breaks |
 
@@ -275,8 +276,8 @@ import special_module  # usort: skip
 
 - **Run `make format`** before every commit
 - **Use `make lint-check`** to verify CI compatibility
-- **Follow the tool chain order**: usort → ruff → black
-- **Keep line length at 88 characters** (Black default)
+- **Follow the tool chain order**: ufmt (usort → ruff-api), then Ruff lint
+- **Keep line length at 88 characters**
 - **Use descriptive commit messages** for formatting changes
 
 ### ❌ Don'ts
@@ -289,11 +290,11 @@ import special_module  # usort: skip
 
 ## 🔧 Editor Integration
 
-**VS Code**: Install Black and Ruff extensions. Enable `editor.formatOnSave` in settings.
+**VS Code**: Configure ufmt as the formatter and install the Ruff extension for linting. Enable `editor.formatOnSave` in settings.
 
-**PyCharm**: Install Black plugin, configure usort as external tool, enable Ruff inspection.
+**PyCharm**: Configure ufmt as an external formatter and enable Ruff inspection.
 
-**Vim/Neovim**: Use `psf/black` and `charliermarsh/ruff-lsp` plugins with auto-format on save.
+**Vim/Neovim**: Configure your formatter integration to run ufmt and use Ruff's language server for linting.
 
 > 💡 See your editor's plugin documentation for detailed setup instructions.
 
@@ -301,17 +302,17 @@ import special_module  # usort: skip
 
 This formatting setup follows **PyTorch ecosystem** patterns:
 
-- **Black** for primary formatting (industry standard)
+- **ruff-api** for primary formatting
 - **usort** for import management (Meta/Facebook standard)
 - **Ruff** for fast linting (modern Python tooling)
-- **88-character line length** (Black default)
+- **88-character line length**
 
 ## 🆘 Getting Help
 
 For formatting issues:
 
 1. **Check this guide** first
-2. **Run `make format`** and `make lint-check`
+2. **Run `make format`, `make lint`, `make format-check`, and `make lint-check`**
 3. **Review the [troubleshooting section](#-common-issues)**
 4. **Check CI logs** for specific errors
 5. **Ask in [GitHub Discussions](https://github.com/meta-pytorch/tritonparse/discussions)**
@@ -326,4 +327,4 @@ For formatting issues:
 
 ---
 
-**Note**: This formatting setup ensures consistent code quality across all contributions. When in doubt, run `make format` followed by `make lint-check` to resolve most issues automatically.
+**Note**: This formatting setup ensures consistent code quality across all contributions. When in doubt, run `make format`, `make lint`, `make format-check`, and `make lint-check`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dev = [
     "ufmt==2.9.0",
     "usort==1.1.0",
     "ruff-api==0.2.0",
-    "ruff>=0.4.0",
+    "ruff==0.16.0",
     "coverage>=7.0.0",
 ]
 
@@ -44,6 +44,9 @@ sorter = "usort"
 [tool.ruff]
 line-length = 88
 target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
 
 [tool.usort]
 first_party_detection = false

--- a/tests/cpu/test_format_fix.py
+++ b/tests/cpu/test_format_fix.py
@@ -1,0 +1,48 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tritonparse.tools import format_fix
+
+
+class FormatFixTest(unittest.TestCase):
+    @patch("tritonparse.tools.format_fix.subprocess.run")
+    def test_ruff_check_reports_all_lint_issues(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        self.assertTrue(format_fix.run_ruff_check(check_only=True))
+
+        mock_run.assert_called_once_with(
+            ["ruff", "check", "."],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    @patch("tritonparse.tools.format_fix.run_ruff_check")
+    @patch("tritonparse.tools.format_fix.run_ufmt", return_value=True)
+    def test_format_only_skips_linter(
+        self, mock_ufmt: MagicMock, mock_ruff: MagicMock
+    ) -> None:
+        with patch.object(sys, "argv", ["format_fix", "--format-only", "--check-only"]):
+            self.assertEqual(format_fix.main(), 0)
+
+        mock_ufmt.assert_called_once_with(True, False)
+        mock_ruff.assert_not_called()
+
+    @patch("tritonparse.tools.format_fix.run_ruff_check", return_value=True)
+    @patch("tritonparse.tools.format_fix.run_ufmt")
+    def test_lint_only_skips_formatter(
+        self, mock_ufmt: MagicMock, mock_ruff: MagicMock
+    ) -> None:
+        with patch.object(sys, "argv", ["format_fix", "--lint-only", "--check-only"]):
+            self.assertEqual(format_fix.main(), 0)
+
+        mock_ufmt.assert_not_called()
+        mock_ruff.assert_called_once_with(True, False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tritonparse/tools/format_fix.py
+++ b/tritonparse/tools/format_fix.py
@@ -13,6 +13,8 @@ Usage:
 
 Options:
     --check-only    Only check for issues, don't fix them
+    --format-only   Only run the formatter
+    --lint-only     Only run the linter
     --verbose       Verbose output
     --help          Show this help message
 """
@@ -65,9 +67,7 @@ def run_ruff_check(check_only: bool = False, verbose: bool = False) -> bool:
     """Run ruff for linting only."""
     cmd = ["ruff", "check", "."]
 
-    if check_only:
-        cmd.append("--diff")
-    else:
+    if not check_only:
         cmd.append("--fix")
 
     return run_command(cmd, verbose)
@@ -95,6 +95,17 @@ Examples:
         action="store_true",
         help="Only check for issues, don't fix them",
     )
+    mode_group = parser.add_mutually_exclusive_group()
+    mode_group.add_argument(
+        "--format-only",
+        action="store_true",
+        help="Only run the formatter",
+    )
+    mode_group.add_argument(
+        "--lint-only",
+        action="store_true",
+        help="Only run the linter",
+    )
     parser.add_argument("--verbose", action="store_true", help="Verbose output")
 
     args = parser.parse_args()
@@ -102,28 +113,29 @@ Examples:
     # Run formatters on the entire project
     success = True
 
-    # 1. Run ufmt for unified formatting (sorter + formatter)
-    # ufmt reads configuration from pyproject.toml [tool.ufmt] section
-    print("Running ufmt for formatting (sorter + formatter from pyproject.toml)...")
-    if not run_ufmt(args.check_only, args.verbose):
-        print("❌ ufmt failed")
-        success = False
-    else:
-        print("✅ ufmt completed")
+    if not args.lint_only:
+        # Run ufmt for unified formatting (sorter + formatter).
+        # ufmt reads configuration from pyproject.toml [tool.ufmt] section.
+        print("Running ufmt for formatting (sorter + formatter from pyproject.toml)...")
+        if not run_ufmt(args.check_only, args.verbose):
+            print("❌ ufmt failed")
+            success = False
+        else:
+            print("✅ ufmt completed")
 
-    # 2. Run ruff for linting only
-    print("Running ruff for linting...")
-    if not run_ruff_check(args.check_only, args.verbose):
-        print("❌ ruff linting failed")
-        success = False
-    else:
-        print("✅ ruff linting completed")
+    if not args.format_only:
+        print("Running ruff for linting...")
+        if not run_ruff_check(args.check_only, args.verbose):
+            print("❌ ruff linting failed")
+            success = False
+        else:
+            print("✅ ruff linting completed")
 
     if success:
-        print("\n🎉 All formatting tools completed successfully!")
+        print("\n🎉 All selected code quality tools completed successfully!")
         return 0
     else:
-        print("\n❌ Some formatting tools failed. Please check the output above.")
+        print("\n❌ Some code quality tools failed. Please check the output above.")
         return 1
 
 


### PR DESCRIPTION
Summary:
Pin the standalone Ruff CLI and explicitly preserve the pre-0.16 default rule set so upstream default-rule changes cannot silently redefine the OSS lint policy.

Separate formatting and linting targets, and make check-only lint run a complete Ruff check instead of --diff, which implies fix-only and can miss non-fixable diagnostics. Add regression tests for command construction and tool selection, and update the formatting guide.

Differential Revision: D114009567


